### PR TITLE
Implement accessibility options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ The next stages follow the broad implementation plan in the project spec.
   - [x] Surface adaptive suggestions from the dialog engine
   - [x] Add caregiver override actions in the CorrectionPanel
 - **Phase 3 – Refine and Polish**
-  - [ ] Improve UI layout and feedback animations
-  - [ ] Implement accessibility options like larger fonts and high contrast
+  - [x] Improve UI layout and feedback animations
+  - [x] Implement accessibility options like larger fonts and high contrast
   - [ ] Support optional DGS video playback for symbols
 - **Phase 4 – Advanced Features & Deployment**
   - [ ] Connect to an LLM for dynamic suggestions with privacy controls

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -8,17 +8,29 @@ import CorrectionScreen from './src/screens/CorrectionScreen';
 import TrainingScreen from './src/screens/TrainingScreen';
 import { loadProfile } from './src/storage';
 import { setActiveVocabularySet } from './src/model';
+import {
+  AccessibilityContext,
+  AccessibilitySettings,
+} from './src/components/AccessibilityContext';
 
 const Stack = createStackNavigator();
 
 export default function App() {
   const [initialRoute, setInitialRoute] = useState<string | null>(null);
+  const [accessibility, setAccessibility] = useState<AccessibilitySettings>({
+    largeText: false,
+    highContrast: false,
+  });
 
   useEffect(() => {
     async function init() {
       const profile = await loadProfile();
       if (profile) {
         setActiveVocabularySet(profile.vocabularySetId);
+        setAccessibility({
+          largeText: !!profile.largeText,
+          highContrast: !!profile.highContrast,
+        });
         setInitialRoute('Recognition');
       } else {
         setInitialRoute('Onboarding');
@@ -32,16 +44,18 @@ export default function App() {
   }
 
   return (
-    <NavigationContainer>
-      <Stack.Navigator
-        initialRouteName={initialRoute as any}
-        screenOptions={{ headerShown: false }}
-      >
-        <Stack.Screen name="Onboarding" component={OnboardingScreen} />
-        <Stack.Screen name="Recognition" component={RecognitionScreen} />
-        <Stack.Screen name="Correction" component={CorrectionScreen} />
-        <Stack.Screen name="Training" component={TrainingScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <AccessibilityContext.Provider value={accessibility}>
+      <NavigationContainer>
+        <Stack.Navigator
+          initialRouteName={initialRoute as any}
+          screenOptions={{ headerShown: false }}
+        >
+          <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+          <Stack.Screen name="Recognition" component={RecognitionScreen} />
+          <Stack.Screen name="Correction" component={CorrectionScreen} />
+          <Stack.Screen name="Training" component={TrainingScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </AccessibilityContext.Provider>
   );
 }

--- a/app/src/components/AccessibilityContext.tsx
+++ b/app/src/components/AccessibilityContext.tsx
@@ -1,0 +1,15 @@
+import React, { createContext, useContext } from 'react';
+
+export interface AccessibilitySettings {
+  largeText: boolean;
+  highContrast: boolean;
+}
+
+export const AccessibilityContext = createContext<AccessibilitySettings>({
+  largeText: false,
+  highContrast: false,
+});
+
+export function useAccessibility(): AccessibilitySettings {
+  return useContext(AccessibilityContext);
+}

--- a/app/src/components/CorrectionPanel.tsx
+++ b/app/src/components/CorrectionPanel.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { Modal, View, Button, StyleSheet } from 'react-native';
+import React, { useRef, useEffect } from 'react';
+import { Modal, View, Button, StyleSheet, Animated, Easing } from 'react-native';
 import { gestureModel } from '../model';
+import { useAccessibility } from './AccessibilityContext';
 
 interface Props {
   visible: boolean;
@@ -15,7 +16,37 @@ export default function CorrectionPanel({
   onClose,
   onAddNew,
 }: Props) {
+  const { highContrast } = useAccessibility();
   const options = gestureModel.gestures.slice(0, 4);
+  const slideAnim = useRef(new Animated.Value(300)).current;
+
+  useEffect(() => {
+    if (visible) {
+      Animated.timing(slideAnim, {
+        toValue: 0,
+        duration: 250,
+        easing: Easing.out(Easing.ease),
+        useNativeDriver: true,
+      }).start();
+    } else {
+      slideAnim.setValue(300);
+    }
+  }, [visible]);
+  const styles = StyleSheet.create({
+    overlay: {
+      flex: 1,
+      justifyContent: 'flex-end',
+      backgroundColor: 'rgba(0,0,0,0.5)',
+    },
+    panel: {
+      backgroundColor: highContrast ? '#222' : '#fff',
+      padding: 20,
+      borderTopLeftRadius: 16,
+      borderTopRightRadius: 16,
+    },
+    row: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 20 },
+  });
+
   return (
     <Modal
       visible={visible}
@@ -24,7 +55,7 @@ export default function CorrectionPanel({
       onRequestClose={onClose}
     >
       <View style={styles.overlay}>
-        <View style={styles.panel}>
+        <Animated.View style={[styles.panel, { transform: [{ translateY: slideAnim }] }]}>
           <View style={styles.row}>
             {options.slice(0, 2).map((g) => (
               <Button key={g.id} title={g.label} onPress={() => onSelect(g.id)} />
@@ -38,14 +69,8 @@ export default function CorrectionPanel({
           <View style={styles.row}>
             <Button title="None of these" onPress={onAddNew} />
           </View>
-        </View>
+        </Animated.View>
       </View>
     </Modal>
   );
 }
-
-const styles = StyleSheet.create({
-  overlay: { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.5)' },
-  panel: { backgroundColor: '#fff', padding: 20, borderTopLeftRadius: 16, borderTopRightRadius: 16 },
-  row: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 20 },
-});

--- a/app/src/screens/CorrectionScreen.tsx
+++ b/app/src/screens/CorrectionScreen.tsx
@@ -1,12 +1,34 @@
 import React from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import { logCorrection } from '../storage';
+import { useAccessibility } from '../components/AccessibilityContext';
 
 export default function CorrectionScreen({ navigation }: any) {
+  const { largeText, highContrast } = useAccessibility();
   const handleSelect = async (choice: string) => {
     await logCorrection(choice);
     navigation.goBack();
   };
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: highContrast ? '#000' : '#fff',
+    },
+    title: {
+      fontSize: largeText ? 24 : 20,
+      marginBottom: 20,
+      color: highContrast ? '#fff' : '#000',
+    },
+    buttonRow: {
+      width: '80%',
+      flexWrap: 'wrap',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+  });
 
   return (
     <View style={styles.container}>
@@ -20,9 +42,3 @@ export default function CorrectionScreen({ navigation }: any) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  title: { fontSize: 20, marginBottom: 20 },
-  buttonRow: { width: '80%', flexWrap: 'wrap', flexDirection: 'row', justifyContent: 'space-between' },
-});

--- a/app/src/screens/OnboardingScreen.tsx
+++ b/app/src/screens/OnboardingScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, Switch, Button, StyleSheet } from 'react-native';
+import { View, Text, Switch, Button, StyleSheet, SafeAreaView } from 'react-native';
 import { saveProfile, Profile } from '../storage';
 import {
   availableVocabularySets,
@@ -10,6 +10,8 @@ export default function OnboardingScreen({ navigation }: any) {
   const [consentDataUpload, setConsentDataUpload] = useState(false);
   const [consentHelpMeGetSmarter, setConsentHelpMeGetSmarter] = useState(false);
   const [vocabSet, setVocabSet] = useState('basic');
+  const [largeText, setLargeText] = useState(false);
+  const [highContrast, setHighContrast] = useState(false);
 
   const handleContinue = async () => {
     const profile: Profile = {
@@ -17,14 +19,38 @@ export default function OnboardingScreen({ navigation }: any) {
       consentDataUpload,
       consentHelpMeGetSmarter,
       vocabularySetId: vocabSet,
+      largeText,
+      highContrast,
     };
     await saveProfile(profile);
     setActiveVocabularySet(vocabSet);
     navigation.replace('Recognition');
   };
 
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+      backgroundColor: highContrast ? '#000' : '#fdfdfd',
+    },
+    heart: { fontSize: largeText ? 80 : 64, textAlign: 'center', marginBottom: 20, color: highContrast ? '#fff' : '#000' },
+    title: { fontSize: largeText ? 32 : 24, textAlign: 'center', marginBottom: 20, color: highContrast ? '#fff' : '#000' },
+    toggleRow: {
+      width: '100%',
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 20,
+    },
+    label: { fontSize: largeText ? 22 : 18, color: highContrast ? '#fff' : '#000' },
+    switch: { transform: [{ scaleX: 1.5 }, { scaleY: 1.5 }] },
+    setRow: { flexDirection: 'row', justifyContent: 'space-around', width: '100%', marginBottom: 20 },
+  });
+
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <Text style={styles.heart}>❤️</Text>
       <Text style={styles.title}>Welcome to Amy's Echo</Text>
       <View style={styles.toggleRow}>
@@ -43,6 +69,22 @@ export default function OnboardingScreen({ navigation }: any) {
           style={styles.switch}
         />
       </View>
+      <View style={styles.toggleRow}>
+        <Text style={styles.label}>Large text</Text>
+        <Switch
+          value={largeText}
+          onValueChange={setLargeText}
+          style={styles.switch}
+        />
+      </View>
+      <View style={styles.toggleRow}>
+        <Text style={styles.label}>High contrast</Text>
+        <Switch
+          value={highContrast}
+          onValueChange={setHighContrast}
+          style={styles.switch}
+        />
+      </View>
       <View style={styles.setRow}>
         {availableVocabularySets.map((s) => (
           <Button
@@ -54,22 +96,7 @@ export default function OnboardingScreen({ navigation }: any) {
         ))}
       </View>
       <Button title="Continue" onPress={handleContinue} />
-    </View>
+    </SafeAreaView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
-  heart: { fontSize: 64, textAlign: 'center', marginBottom: 20 },
-  title: { fontSize: 24, textAlign: 'center', marginBottom: 20 },
-  toggleRow: {
-    width: '100%',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 20,
-  },
-  label: { fontSize: 18 },
-  switch: { transform: [{ scaleX: 1.5 }, { scaleY: 1.5 }] },
-  setRow: { flexDirection: 'row', justifyContent: 'space-around', width: '100%', marginBottom: 20 },
-});

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import { saveTrainingSample } from '../storage';
 import { gestureModel } from '../model';
+import { useAccessibility } from '../components/AccessibilityContext';
 
 function captureDummyLandmarks() {
   return Array.from({ length: 21 }, () => [
@@ -12,6 +13,7 @@ function captureDummyLandmarks() {
 }
 
 export default function TrainingScreen({ navigation }: any) {
+  const { largeText, highContrast } = useAccessibility();
   const [gestureId, setGestureId] = useState<string | null>(null);
   const [count, setCount] = useState(0);
 
@@ -25,6 +27,20 @@ export default function TrainingScreen({ navigation }: any) {
   const handleFinish = () => {
     navigation.goBack();
   };
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: highContrast ? '#000' : '#fff',
+    },
+    title: {
+      fontSize: largeText ? 24 : 20,
+      marginBottom: 20,
+      color: highContrast ? '#fff' : '#000',
+    },
+  });
 
   return (
     <View style={styles.container}>
@@ -44,8 +60,3 @@ export default function TrainingScreen({ navigation }: any) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  title: { fontSize: 20, marginBottom: 20 },
-});

--- a/app/src/storage.ts
+++ b/app/src/storage.ts
@@ -5,6 +5,8 @@ export interface Profile {
   consentDataUpload: boolean;
   consentHelpMeGetSmarter: boolean;
   vocabularySetId: string;
+  largeText?: boolean;
+  highContrast?: boolean;
 }
 
 const PROFILE_KEY = 'profile';
@@ -32,6 +34,8 @@ export async function loadProfile(): Promise<Profile | null> {
     consentDataUpload: !!parsed.consentDataUpload,
     consentHelpMeGetSmarter: !!parsed.consentHelpMeGetSmarter,
     vocabularySetId: parsed.vocabularySetId || 'basic',
+    largeText: !!parsed.largeText,
+    highContrast: !!parsed.highContrast,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface Profile {
   consentDataUpload: boolean;
   consentHelpMeGetSmarter: boolean;
   vocabularySetId: string;
+  largeText?: boolean;
+  highContrast?: boolean;
 }
 
 export interface LearningAnalytics {


### PR DESCRIPTION
## Summary
- enable high contrast and large text preferences
- store accessibility settings in profile
- provide context for screens and panel
- mark accessibility roadmap item complete

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876ae65306c8322ae7ec20af24815a9