### PR TITLE
Add caregiver analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The next stages follow the broad implementation plan in the project spec.
 - **Phase 4 – Advanced Features & Deployment**
   - [x] Connect to an LLM for dynamic suggestions with privacy controls
   - [x] Explore offline model retraining from collected data
-  - [ ] Build the caregiver analytics dashboard
+  - [x] Build the caregiver analytics dashboard
   - [ ] Prepare production builds for app store release
 
 ## ▶️ Running the mobile app
@@ -119,6 +119,17 @@ node dist/tools/retrainOfflineModel.js <path/to/db.json> dist/offlineModel.json
 ```
 
 The recognizer will load `dist/offlineModel.json` by default when classifying offline.
+
+### Updating analytics
+
+Run the analytics updater to refresh caregiver stats stored in the database:
+
+```bash
+npm run build
+node dist/tools/updateAnalytics.js <path/to/db.json>
+```
+
+Open the app and tap **Analytics** on the recognition screen to view the dashboard.
 
 ---
 

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -6,6 +6,7 @@ import OnboardingScreen from './src/screens/OnboardingScreen';
 import RecognitionScreen from './src/screens/RecognitionScreen';
 import CorrectionScreen from './src/screens/CorrectionScreen';
 import TrainingScreen from './src/screens/TrainingScreen';
+import DashboardScreen from './src/screens/DashboardScreen';
 import { loadProfile } from './src/storage';
 import { setActiveVocabularySet } from './src/model';
 import {
@@ -54,6 +55,7 @@ export default function App() {
           <Stack.Screen name="Recognition" component={RecognitionScreen} />
           <Stack.Screen name="Correction" component={CorrectionScreen} />
           <Stack.Screen name="Training" component={TrainingScreen} />
+          <Stack.Screen name="Dashboard" component={DashboardScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </AccessibilityContext.Provider>

--- a/app/src/screens/DashboardScreen.tsx
+++ b/app/src/screens/DashboardScreen.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { loadAnalytics, LearningAnalytics } from '../services/analytics';
+import { useAccessibility } from '../components/AccessibilityContext';
+
+export default function DashboardScreen({ navigation }: any) {
+  const { largeText, highContrast } = useAccessibility();
+  const [data, setData] = useState<LearningAnalytics | null>(null);
+
+  useEffect(() => {
+    loadAnalytics().then(setData);
+  }, []);
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: highContrast ? '#000' : '#fff',
+    },
+    label: {
+      fontSize: largeText ? 24 : 20,
+      marginBottom: 10,
+      color: highContrast ? '#fff' : '#000',
+    },
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Analytics Dashboard</Text>
+      {data ? (
+        <>
+          <Text style={styles.label}>
+            Success Rate (7d): {(data.successRate7d * 100).toFixed(0)}%
+          </Text>
+          <Text style={styles.label}>
+            Trend: {(data.improvementTrend * 100).toFixed(0)}%
+          </Text>
+        </>
+      ) : (
+        <Text style={styles.label}>No data</Text>
+      )}
+      <Button title="Back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+}

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -100,6 +100,7 @@ export default function RecognitionScreen({ navigation }: any) {
         onClose={() => setShowCorrection(false)}
         onAddNew={handleAddNew}
       />
+      <Button title="Analytics" onPress={() => navigation.navigate('Dashboard')} />
     </SafeAreaView>
   );
 }

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -1,0 +1,31 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface LearningAnalytics {
+  successRate7d: number;
+  improvementTrend: number;
+}
+
+const LOG_KEY = 'interactionLogs';
+
+export async function loadAnalytics(): Promise<LearningAnalytics> {
+  const raw = await AsyncStorage.getItem(LOG_KEY);
+  const logs = raw ? JSON.parse(raw) : [];
+  const now = Date.now();
+  const oneWeek = 7 * 24 * 60 * 60 * 1000;
+  const weekAgo = now - oneWeek;
+  const prevWeekAgo = weekAgo - oneWeek;
+
+  const recent = logs.filter((l: any) => l.timestamp >= weekAgo);
+  const prev = logs.filter((l: any) => l.timestamp >= prevWeekAgo && l.timestamp < weekAgo);
+
+  const rate = (ls: any[]) =>
+    ls.length === 0 ? 0 : ls.filter((l) => l.wasSuccessful).length / ls.length;
+
+  const success = rate(recent);
+  const improvement = success - rate(prev);
+
+  return {
+    successRate7d: Number(success.toFixed(2)),
+    improvementTrend: Number(improvement.toFixed(2)),
+  };
+}

--- a/app/src/services/index.ts
+++ b/app/src/services/index.ts
@@ -2,3 +2,4 @@ export * from './mlService';
 export * from './audioService';
 export * from './dialogService';
 export * from './videoService';
+export * from './analytics';

--- a/app/src/storage.ts
+++ b/app/src/storage.ts
@@ -62,6 +62,7 @@ export async function logCorrection(correctId: string): Promise<void> {
     gestureDefinitionId: correctId,
     wasSuccessful: true,
     confidenceScore: 0,
+    timestamp: Date.now(),
     processedBy: 'local',
   });
   await AsyncStorage.setItem(LOG_KEY, JSON.stringify(logs));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gesture to voice translator for Amy",
   "main": "index.js",
   "scripts": {
-    "test": "npm run build && node dist/test/db.test.js && node dist/test/recognizer.test.js && node dist/test/services.test.js && node dist/test/model.test.js && node dist/test/retrain.test.js",
+    "test": "npm run build && node dist/test/db.test.js && node dist/test/recognizer.test.js && node dist/test/services.test.js && node dist/test/model.test.js && node dist/test/retrain.test.js && node dist/test/analytics.test.js",
     "build": "tsc"
   },
   "keywords": [],

--- a/src/db.ts
+++ b/src/db.ts
@@ -221,6 +221,7 @@ export const logCorrection = (
     gestureDefinitionId: predictedGestureId,
     wasSuccessful: false,
     confidenceScore: 0,
+    timestamp: Date.now(),
     caregiverOverrideId: correctedGestureId,
     processedBy: 'local',
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from './services/mlService';
 export * from './services/audioService';
 export * from './services/dialogService';
 export * from './services/videoService';
+export * from './services/analyticsService';

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,0 +1,39 @@
+import { Database } from '../db';
+import { LearningAnalytics } from '../types';
+
+export function computeLearningAnalytics(db: Database): LearningAnalytics {
+  const now = Date.now();
+  const oneWeek = 7 * 24 * 60 * 60 * 1000;
+  const weekAgo = now - oneWeek;
+  const prevWeekAgo = weekAgo - oneWeek;
+
+  const recent = db.interactionLogs.filter((l) => l.timestamp >= weekAgo);
+  const prev = db.interactionLogs.filter(
+    (l) => l.timestamp >= prevWeekAgo && l.timestamp < weekAgo,
+  );
+
+  const rate = (logs: typeof recent) =>
+    logs.length === 0
+      ? 0
+      : logs.filter((l) => l.wasSuccessful).length / logs.length;
+
+  const successRate7d = rate(recent);
+  const improvementTrend = successRate7d - rate(prev);
+
+  return {
+    id: 'default',
+    successRate7d: Number(successRate7d.toFixed(2)),
+    improvementTrend: Number(improvementTrend.toFixed(2)),
+  };
+}
+
+export function refreshLearningAnalytics(db: Database): void {
+  const analytics = computeLearningAnalytics(db);
+  const existing = db.learningAnalytics.find((a) => a.id === 'default');
+  if (existing) {
+    existing.successRate7d = analytics.successRate7d;
+    existing.improvementTrend = analytics.improvementTrend;
+  } else {
+    db.learningAnalytics.push(analytics);
+  }
+}

--- a/src/tools/updateAnalytics.ts
+++ b/src/tools/updateAnalytics.ts
@@ -1,0 +1,14 @@
+import { loadDatabase, saveDatabase } from '../db';
+import { refreshLearningAnalytics } from '../services/analyticsService';
+
+(async () => {
+  const [dbPath] = process.argv.slice(2);
+  if (!dbPath) {
+    console.error('Usage: node updateAnalytics.js <db.json>');
+    process.exit(1);
+  }
+  const db = await loadDatabase(dbPath);
+  refreshLearningAnalytics(db);
+  await saveDatabase(db, dbPath);
+  console.log('analytics updated');
+})();

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface InteractionLog {
   gestureDefinitionId: string;
   wasSuccessful: boolean;
   confidenceScore: number;
+  timestamp: number;
   caregiverOverrideId?: string;
   processedBy: ProcessedBy;
 }

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -1,0 +1,31 @@
+import { createDatabase } from '../src/db';
+import { refreshLearningAnalytics } from '../src/services/analyticsService';
+import { InteractionLog } from '../src/types';
+
+(async () => {
+  const db = createDatabase();
+  const now = Date.now();
+  const recent: InteractionLog = {
+    id: '1',
+    gestureDefinitionId: 'g',
+    wasSuccessful: true,
+    confidenceScore: 1,
+    timestamp: now,
+    processedBy: 'local',
+  };
+  const old: InteractionLog = {
+    id: '2',
+    gestureDefinitionId: 'g',
+    wasSuccessful: false,
+    confidenceScore: 0,
+    timestamp: now - 8 * 24 * 60 * 60 * 1000,
+    processedBy: 'local',
+  };
+  db.interactionLogs.push(recent, old);
+  refreshLearningAnalytics(db);
+  const analytics = db.learningAnalytics[0];
+  if (!analytics || analytics.successRate7d !== 1 || analytics.improvementTrend <= 0) {
+    throw new Error('analytics computation failed');
+  }
+  console.log('analytics computed');
+})();


### PR DESCRIPTION
## Summary
- implement analytics computation and refresh utilities
- add Analytics service and dashboard screen in React Native app
- log timestamps for interactions
- provide CLI to update analytics
- document how to update and view analytics
- mark roadmap item complete

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687732961dbc8322974636a5796d754d