### PR TITLE
Implement seeding and LLM suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gesture to voice translator for Amy",
   "main": "index.js",
   "scripts": {
-    "test": "npm run build && node dist/test/db.test.js && node dist/test/recognizer.test.js && node dist/test/services.test.js && node dist/test/model.test.js && node dist/test/retrain.test.js && node dist/test/analytics.test.js",
+    "test": "npm run build && node dist/test/db.test.js && node dist/test/recognizer.test.js && node dist/test/services.test.js && node dist/test/model.test.js && node dist/test/retrain.test.js && node dist/test/analytics.test.js && node dist/test/dialogEngine.test.js && node dist/test/seed.test.js",
     "build": "tsc",
     "build:android": "npx eas build --platform android --profile production --project-dir app",
     "build:ios": "npx eas build --platform ios --profile production --project-dir app"

--- a/src/db.ts
+++ b/src/db.ts
@@ -227,3 +227,48 @@ export const logCorrection = (
   };
   addInteractionLog(db, log);
 };
+
+export async function setupDatabase(filePath: string): Promise<Database> {
+  let db = await loadDatabase(filePath);
+  let changed = false;
+
+  if (db.profiles.length === 0) {
+    const profile: Profile = {
+      id: 'default',
+      consentDataUpload: false,
+      consentHelpMeGetSmarter: false,
+      vocabularySetId: 'basic',
+    };
+    db.profiles.push(profile);
+    changed = true;
+  }
+
+  if (db.symbols.length === 0) {
+    const defaults: SymbolRecord[] = [
+      {
+        id: 'hello',
+        name: 'Hello',
+        emoji: '👋',
+        color: '#ffcc00',
+        audioUri: 'hello.mp3',
+        healthScore: 1,
+      },
+      {
+        id: 'drink',
+        name: 'Drink',
+        emoji: '🥤',
+        color: '#0099ff',
+        audioUri: 'drink.mp3',
+        healthScore: 1,
+      },
+    ];
+    db.symbols.push(...defaults);
+    changed = true;
+  }
+
+  if (changed) {
+    await saveDatabase(db, filePath);
+  }
+
+  return db;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './services/audioService';
 export * from './services/dialogService';
 export * from './services/videoService';
 export * from './services/analyticsService';
+export * from './services/dialogEngine';

--- a/src/services/dialogEngine.ts
+++ b/src/services/dialogEngine.ts
@@ -1,0 +1,42 @@
+import fetch from 'node-fetch';
+
+export interface LLMRequest {
+  input: string;
+  context: string[];
+  language: string;
+  age: number;
+}
+
+export interface LLMSuggestions {
+  nextWords: string[];
+  caregiverPhrases: string[];
+}
+
+export async function getLLMSuggestions(req: LLMRequest): Promise<LLMSuggestions> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return { nextWords: [], caregiverPhrases: [] };
+  }
+  const prompt = `A ${req.age}-year-old child who speaks ${req.language} just selected the word "${req.input}". The current context is [${req.context.join(', ')}]. Provide likely next words and helpful phrases for a caregiver. Return a JSON object with two keys: "nextWords": string[] and "caregiverPhrases": string[].`;
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4-turbo',
+        messages: [{ role: 'user', content: prompt }],
+        response_format: { type: 'json_object' },
+      }),
+    });
+    if (!response.ok) throw new Error(`API call failed with status: ${response.status}`);
+    const data = (await response.json()) as any;
+    const content = JSON.parse(data.choices[0].message.content as string);
+    return content as LLMSuggestions;
+  } catch (error) {
+    console.error('LLM suggestion error:', error);
+    return { nextWords: [], caregiverPhrases: [] };
+  }
+}

--- a/test/dialogEngine.test.ts
+++ b/test/dialogEngine.test.ts
@@ -1,0 +1,14 @@
+import { getLLMSuggestions } from '../src/services/dialogEngine';
+
+(async () => {
+  const res = await getLLMSuggestions({
+    input: 'hello',
+    context: ['hi'],
+    language: 'English',
+    age: 4,
+  });
+  if (res.nextWords.length !== 0 || res.caregiverPhrases.length !== 0) {
+    throw new Error('Expected empty suggestions without API key');
+  }
+  console.log('dialog engine default ok');
+})();

--- a/test/seed.test.ts
+++ b/test/seed.test.ts
@@ -1,0 +1,18 @@
+import { setupDatabase, loadDatabase } from '../src/db';
+import { tmpdir } from 'os';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+(async () => {
+  const file = path.join(tmpdir(), 'seed-test.json');
+  await fs.rm(file, { force: true });
+  const db = await setupDatabase(file);
+  if (db.profiles.length === 0 || db.symbols.length === 0) {
+    throw new Error('seeding failed');
+  }
+  const loaded = await loadDatabase(file);
+  if (loaded.profiles.length === 0 || loaded.symbols.length === 0) {
+    throw new Error('persist seeded data failed');
+  }
+  console.log('seed ok');
+})();


### PR DESCRIPTION
## Summary
- add a `setupDatabase` helper to seed profiles and symbols
- support LLM suggestions through new `dialogEngine` service
- add tests for seeding and dialogEngine
- export dialogEngine and update test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c2bad7b483228417ad4380adcda0