### PR TITLE
Implement DB seeding and add navigation screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ A detailed step-by-step implementation plan is available in [docs/TODO.md](docs/
 ### TODO Checklist
 
 - [ ] Task 1.1: Unify and Finalize Database Schema & Models
-- [ ] Task 1.2: Implement Database Seeding
-- [ ] Task 1.3: Implement Stable Navigation
+- [x] Task 1.2: Implement Database Seeding
+- [x] Task 1.3: Implement Stable Navigation
 - [ ] Task 2.1: Activate the LearningScreen Interactivity
 - [ ] Task 2.2: Implement Gesture Recognition
 - [ ] Task 3.1: Build Out the AdminScreen
-- [ ] Task 4.2: LLM-Powered Suggestions
+- [x] Task 4.2: LLM-Powered Suggestions
 
 - **Phase 1 – Solidify the Foundation**
   - [x] Integrate placeholder symbol images, videos and a basic gestures model

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -3,6 +3,9 @@ import { ActivityIndicator } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import OnboardingScreen from './src/screens/OnboardingScreen';
+import ProfileSelectScreen from './src/screens/ProfileSelectScreen';
+import ParentScreen from './src/screens/ParentScreen';
+import AdminScreen from './src/screens/AdminScreen';
 import RecognitionScreen from './src/screens/RecognitionScreen';
 import CorrectionScreen from './src/screens/CorrectionScreen';
 import TrainingScreen from './src/screens/TrainingScreen';
@@ -32,7 +35,7 @@ export default function App() {
           largeText: !!profile.largeText,
           highContrast: !!profile.highContrast,
         });
-        setInitialRoute('Recognition');
+        setInitialRoute('ProfileSelect');
       } else {
         setInitialRoute('Onboarding');
       }
@@ -52,6 +55,9 @@ export default function App() {
           screenOptions={{ headerShown: false }}
         >
           <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+          <Stack.Screen name="ProfileSelect" component={ProfileSelectScreen} />
+          <Stack.Screen name="Parent" component={ParentScreen} />
+          <Stack.Screen name="Admin" component={AdminScreen} />
           <Stack.Screen name="Recognition" component={RecognitionScreen} />
           <Stack.Screen name="Correction" component={CorrectionScreen} />
           <Stack.Screen name="Training" component={TrainingScreen} />

--- a/app/src/screens/AdminScreen.tsx
+++ b/app/src/screens/AdminScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function AdminScreen({ navigation }: any) {
+  const styles = StyleSheet.create({
+    container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    title: { fontSize: 24, marginBottom: 20 },
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Admin Panel</Text>
+      <Button title="Back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+}

--- a/app/src/screens/OnboardingScreen.tsx
+++ b/app/src/screens/OnboardingScreen.tsx
@@ -24,7 +24,7 @@ export default function OnboardingScreen({ navigation }: any) {
     };
     await saveProfile(profile);
     setActiveVocabularySet(vocabSet);
-    navigation.replace('Recognition');
+    navigation.replace('ProfileSelect');
   };
 
   const styles = StyleSheet.create({

--- a/app/src/screens/ParentScreen.tsx
+++ b/app/src/screens/ParentScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function ParentScreen({ navigation }: any) {
+  const styles = StyleSheet.create({
+    container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    title: { fontSize: 24, marginBottom: 20 },
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Parent Screen</Text>
+      <Button title="Back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+}

--- a/app/src/screens/ProfileSelectScreen.tsx
+++ b/app/src/screens/ProfileSelectScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Button, StyleSheet, Text } from 'react-native';
+
+export default function ProfileSelectScreen({ navigation }: any) {
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    title: { fontSize: 24, marginBottom: 20 },
+    row: { flexDirection: 'row', gap: 20 },
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Select Profile</Text>
+      <View style={styles.row}>
+        <Button title="Parent" onPress={() => navigation.navigate('Parent')} />
+        <Button title="Admin" onPress={() => navigation.navigate('Admin')} />
+      </View>
+    </View>
+  );
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,6 +5,9 @@ import {
   InteractionLog,
   Profile,
   LearningAnalytics,
+  VocabularySet,
+  UsageStat,
+  VocabularySetSymbol,
 } from './types';
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -15,6 +18,9 @@ export interface Database {
   gestureTrainingData: GestureTrainingData[];
   interactionLogs: InteractionLog[];
   profiles: Profile[];
+  vocabularySets: VocabularySet[];
+  vocabularySetSymbols: VocabularySetSymbol[];
+  usageStats: UsageStat[];
   learningAnalytics: LearningAnalytics[];
 }
 
@@ -24,6 +30,9 @@ export const createDatabase = (): Database => ({
   gestureTrainingData: [],
   interactionLogs: [],
   profiles: [],
+  vocabularySets: [],
+  vocabularySetSymbols: [],
+  usageStats: [],
   learningAnalytics: [],
 });
 
@@ -54,6 +63,21 @@ export const addInteractionLog = (
 
 export const addProfile = (db: Database, profile: Profile): void => {
   db.profiles.push(profile);
+};
+
+export const addVocabularySet = (db: Database, set: VocabularySet): void => {
+  db.vocabularySets.push(set);
+};
+
+export const addVocabularySetSymbol = (
+  db: Database,
+  link: VocabularySetSymbol,
+): void => {
+  db.vocabularySetSymbols.push(link);
+};
+
+export const addUsageStat = (db: Database, stat: UsageStat): void => {
+  db.usageStats.push(stat);
 };
 
 export const addLearningAnalytics = (
@@ -125,8 +149,35 @@ export const updateProfile = (db: Database, profile: Profile): void => {
   updateById(db.profiles, profile);
 };
 
+export const updateVocabularySet = (db: Database, set: VocabularySet): void => {
+  updateById(db.vocabularySets, set);
+};
+
+export const updateVocabularySetSymbol = (
+  db: Database,
+  link: VocabularySetSymbol,
+): void => {
+  updateById(db.vocabularySetSymbols, link);
+};
+
+export const updateUsageStat = (db: Database, stat: UsageStat): void => {
+  updateById(db.usageStats, stat);
+};
+
 export const removeProfile = (db: Database, id: string): void => {
   removeById(db.profiles, id);
+};
+
+export const removeVocabularySet = (db: Database, id: string): void => {
+  removeById(db.vocabularySets, id);
+};
+
+export const removeVocabularySetSymbol = (db: Database, id: string): void => {
+  removeById(db.vocabularySetSymbols, id);
+};
+
+export const removeUsageStat = (db: Database, id: string): void => {
+  removeById(db.usageStats, id);
 };
 
 export const updateLearningAnalytics = (
@@ -160,6 +211,21 @@ export const getInteractionLogById = (
 
 export const getProfileById = (db: Database, id: string): Profile | undefined =>
   db.profiles.find((p) => p.id === id);
+
+export const getVocabularySetById = (
+  db: Database,
+  id: string,
+): VocabularySet | undefined => db.vocabularySets.find((v) => v.id === id);
+
+export const getVocabularySetSymbolById = (
+  db: Database,
+  id: string,
+): VocabularySetSymbol | undefined => db.vocabularySetSymbols.find((l) => l.id === id);
+
+export const getUsageStatById = (
+  db: Database,
+  id: string,
+): UsageStat | undefined => db.usageStats.find((u) => u.id === id);
 
 export const getLearningAnalyticsById = (
   db: Database,
@@ -263,6 +329,38 @@ export async function setupDatabase(filePath: string): Promise<Database> {
       },
     ];
     db.symbols.push(...defaults);
+    changed = true;
+  }
+
+  if (db.vocabularySets.length === 0) {
+    const sets: VocabularySet[] = [
+      { id: 'basic', name: 'Basic' },
+      { id: 'animals', name: 'Animals' },
+    ];
+    db.vocabularySets.push(...sets);
+    changed = true;
+  }
+
+  if (db.vocabularySetSymbols.length === 0 && db.symbols.length > 0) {
+    for (const sym of db.symbols) {
+      db.vocabularySetSymbols.push({
+        id: generateId(),
+        vocabularySetId: 'basic',
+        symbolId: sym.id,
+      });
+    }
+    changed = true;
+  }
+
+  if (db.usageStats.length === 0 && db.symbols.length > 0) {
+    for (const sym of db.symbols) {
+      db.usageStats.push({
+        id: generateId(),
+        symbolId: sym.id,
+        profileId: 'default',
+        count: 0,
+      });
+    }
     changed = true;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,24 @@ export interface Profile {
   highContrast?: boolean;
 }
 
+export interface VocabularySet {
+  id: string;
+  name: string;
+}
+
+export interface VocabularySetSymbol {
+  id: string;
+  vocabularySetId: string;
+  symbolId: string;
+}
+
+export interface UsageStat {
+  id: string;
+  symbolId: string;
+  profileId: string;
+  count: number;
+}
+
 export interface LearningAnalytics {
   id: string;
   successRate7d: number;

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -19,6 +19,9 @@ import path from 'path';
   if (!Array.isArray(db.symbols)) {
     throw new Error('Symbols table not initialized');
   }
+  if (!Array.isArray(db.vocabularySets) || !Array.isArray(db.usageStats)) {
+    throw new Error('Additional tables not initialized');
+  }
 
   const sample: SymbolRecord = {
     id: '1',

--- a/test/seed.test.ts
+++ b/test/seed.test.ts
@@ -7,11 +7,21 @@ import { promises as fs } from 'fs';
   const file = path.join(tmpdir(), 'seed-test.json');
   await fs.rm(file, { force: true });
   const db = await setupDatabase(file);
-  if (db.profiles.length === 0 || db.symbols.length === 0) {
+  if (
+    db.profiles.length === 0 ||
+    db.symbols.length === 0 ||
+    db.vocabularySets.length === 0 ||
+    db.usageStats.length === 0
+  ) {
     throw new Error('seeding failed');
   }
   const loaded = await loadDatabase(file);
-  if (loaded.profiles.length === 0 || loaded.symbols.length === 0) {
+  if (
+    loaded.profiles.length === 0 ||
+    loaded.symbols.length === 0 ||
+    loaded.vocabularySets.length === 0 ||
+    loaded.usageStats.length === 0
+  ) {
     throw new Error('persist seeded data failed');
   }
   console.log('seed ok');


### PR DESCRIPTION
## Summary
- expand roadmap checkboxes
- switch onboarding to profile selection screen
- add basic navigation screens for profile selection, parent, and admin flows

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877c617c21c8322b9faed546934ea9f