### PR TITLE
Add learning screen and secure API key storage

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -6,6 +6,7 @@ import OnboardingScreen from './src/screens/OnboardingScreen';
 import ProfileSelectScreen from './src/screens/ProfileSelectScreen';
 import ParentScreen from './src/screens/ParentScreen';
 import AdminScreen from './src/screens/AdminScreen';
+import LearningScreen from './src/screens/LearningScreen';
 import RecognitionScreen from './src/screens/RecognitionScreen';
 import CorrectionScreen from './src/screens/CorrectionScreen';
 import TrainingScreen from './src/screens/TrainingScreen';
@@ -61,6 +62,7 @@ export default function App() {
           <Stack.Screen name="Recognition" component={RecognitionScreen} />
           <Stack.Screen name="Correction" component={CorrectionScreen} />
           <Stack.Screen name="Training" component={TrainingScreen} />
+          <Stack.Screen name="Learning" component={LearningScreen} />
           <Stack.Screen name="Dashboard" component={DashboardScreen} />
         </Stack.Navigator>
       </NavigationContainer>

--- a/app/src/components/SymbolVideoPlayer.tsx
+++ b/app/src/components/SymbolVideoPlayer.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Video } from 'expo-av';
+import { GestureModelEntry } from '../model';
+
+export interface SymbolVideoPlayerProps {
+  entry: GestureModelEntry;
+  paused: boolean;
+  useDgs?: boolean;
+  onEnd?: () => void;
+}
+
+export default function SymbolVideoPlayer({ entry, paused, useDgs, onEnd }: SymbolVideoPlayerProps) {
+  const source = useDgs
+    ? require(`../assets/videos/dgs/${entry.id}.mp4`)
+    : require(`../assets/videos/${entry.id}.mp4`);
+
+  return (
+    <Video
+      source={source}
+      shouldPlay={!paused}
+      onPlaybackStatusUpdate={(status) => {
+        if (!paused && status.isLoaded && status.didJustFinish) {
+          onEnd && onEnd();
+        }
+      }}
+      useNativeControls
+      resizeMode="contain"
+      style={{ width: 300, height: 200 }}
+    />
+  );
+}
+

--- a/app/src/screens/AdminScreen.tsx
+++ b/app/src/screens/AdminScreen.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
 } from 'react-native';
 import { gestureModel, GestureModelEntry } from '../model';
+import { loadOpenAIApiKey, saveOpenAIApiKey } from '../storage';
 
 export default function AdminScreen({ navigation }: any) {
   const [symbols, setSymbols] = useState<GestureModelEntry[]>([
@@ -18,6 +19,13 @@ export default function AdminScreen({ navigation }: any) {
   const [label, setLabel] = useState('');
   const [id, setId] = useState('');
   const [modalVisible, setModalVisible] = useState(false);
+  const [apiKey, setApiKey] = useState('');
+
+  React.useEffect(() => {
+    loadOpenAIApiKey().then((k) => {
+      if (k) setApiKey(k);
+    });
+  }, []);
 
   const openAdd = () => {
     setEditing(null);
@@ -45,12 +53,17 @@ export default function AdminScreen({ navigation }: any) {
     setModalVisible(false);
   };
 
+  const handleSaveApiKey = async () => {
+    await saveOpenAIApiKey(apiKey);
+  };
+
   const styles = StyleSheet.create({
     container: { flex: 1, padding: 20 },
     title: { fontSize: 24, marginBottom: 20, textAlign: 'center' },
     row: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 10 },
     modal: { flex: 1, justifyContent: 'center', padding: 20 },
     input: { borderWidth: 1, padding: 8, marginBottom: 12 },
+    apiInput: { borderWidth: 1, padding: 8, marginVertical: 12 },
   });
 
   return (
@@ -66,6 +79,13 @@ export default function AdminScreen({ navigation }: any) {
           </View>
         )}
       />
+      <TextInput
+        style={styles.apiInput}
+        placeholder="OpenAI API Key"
+        value={apiKey}
+        onChangeText={setApiKey}
+      />
+      <Button title="Save API Key" onPress={handleSaveApiKey} />
       <Button title="Add Symbol" onPress={openAdd} />
       <Button title="Back" onPress={() => navigation.goBack()} />
 

--- a/app/src/screens/LearningScreen.tsx
+++ b/app/src/screens/LearningScreen.tsx
@@ -1,0 +1,81 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, Button, FlatList, StyleSheet, Switch } from 'react-native';
+import { GestureModelEntry, gestureModel } from '../model';
+import { playSymbolAudio } from '../services/audioService';
+import { incrementUsage } from '../services/usageTracker';
+import { loadProfile, Profile } from '../storage';
+import SymbolVideoPlayer from '../components/SymbolVideoPlayer';
+import { getLLMSuggestions, LLMSuggestions } from '../services/dialogService';
+
+export default function LearningScreen() {
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [playing, setPlaying] = useState<GestureModelEntry | null>(null);
+  const [videoPaused, setVideoPaused] = useState(true);
+  const [useDgs, setUseDgs] = useState(false);
+  const [suggestions, setSuggestions] = useState<LLMSuggestions | null>(null);
+
+  useEffect(() => {
+    loadProfile().then(setProfile);
+  }, []);
+
+  const handlePress = async (entry: GestureModelEntry) => {
+    await playSymbolAudio(entry);
+    if (profile) {
+      await incrementUsage(entry, profile.id);
+    }
+    setPlaying(entry);
+    setVideoPaused(false);
+    const adv = await getLLMSuggestions(entry.label);
+    setSuggestions(adv);
+  };
+
+  const styles = StyleSheet.create({
+    container: { flex: 1, padding: 20, alignItems: 'center' },
+    row: { flexDirection: 'row', gap: 10, flexWrap: 'wrap' },
+    suggestion: { marginTop: 10, textAlign: 'center' },
+  });
+
+  return (
+    <View style={styles.container}>
+      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 10 }}>
+        <Text>Use DGS Video</Text>
+        <Switch value={useDgs} onValueChange={setUseDgs} />
+      </View>
+      <FlatList
+        data={gestureModel.gestures}
+        numColumns={2}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={{ margin: 10 }}>
+            <Button title={item.label} onPress={() => handlePress(item)} />
+          </View>
+        )}
+      />
+      {playing && (
+        <SymbolVideoPlayer
+          entry={playing}
+          paused={videoPaused}
+          useDgs={useDgs}
+          onEnd={() => setVideoPaused(true)}
+        />
+      )}
+      {suggestions && suggestions.nextWords.length > 0 && (
+        <View>
+          <Text style={styles.suggestion}>Next words:</Text>
+          {suggestions.nextWords.map((s, i) => (
+            <Text key={i} style={styles.suggestion}>{s}</Text>
+          ))}
+        </View>
+      )}
+      {suggestions && suggestions.caregiverPhrases.length > 0 && (
+        <View>
+          <Text style={styles.suggestion}>Caregiver:</Text>
+          {suggestions.caregiverPhrases.map((s, i) => (
+            <Text key={i} style={styles.suggestion}>{s}</Text>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+

--- a/app/src/screens/ParentScreen.tsx
+++ b/app/src/screens/ParentScreen.tsx
@@ -10,6 +10,8 @@ export default function ParentScreen({ navigation }: any) {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Parent Screen</Text>
+      <Button title="Learning" onPress={() => navigation.navigate('Learning')} />
+      <Button title="Recognition" onPress={() => navigation.navigate('Recognition')} />
       <Button title="Back" onPress={() => navigation.goBack()} />
     </View>
   );

--- a/app/src/services/dialogService.ts
+++ b/app/src/services/dialogService.ts
@@ -3,8 +3,10 @@ export interface LLMSuggestions {
   caregiverPhrases: string[];
 }
 
+import { loadOpenAIApiKey } from '../storage';
+
 export async function getLLMSuggestions(label: string): Promise<LLMSuggestions> {
-  const apiKey = process.env.OPENAI_API_KEY;
+  const apiKey = await loadOpenAIApiKey();
   if (!apiKey) {
     switch (label) {
       case 'hello':

--- a/app/src/storage.ts
+++ b/app/src/storage.ts
@@ -83,3 +83,12 @@ export async function saveTrainingSample(
   });
   await AsyncStorage.setItem(TRAINING_KEY, JSON.stringify(data));
 }
+
+const API_KEY = 'openaiApiKey';
+export async function saveOpenAIApiKey(key: string): Promise<void> {
+  await AsyncStorage.setItem(API_KEY, key);
+}
+
+export async function loadOpenAIApiKey(): Promise<string | null> {
+  return AsyncStorage.getItem(API_KEY);
+}


### PR DESCRIPTION
## Summary
- add SymbolVideoPlayer component
- create LearningScreen with video playback and suggestions
- allow storing OpenAI API key via AsyncStorage in AdminScreen
- load API key from storage in dialogService
- hook LearningScreen into navigation and ParentScreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877e4b1efd483228158df82a01134c3