### PR TITLE
Implement DGS video paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ A detailed step-by-step implementation plan is available in [docs/TODO.md](docs/
 
 The React Native code lives in `app/`. Install dependencies with `npm install` inside that folder, then run `npm run ios` or `npm run android` to start a simulator. This skeleton includes onboarding, recognition, correction and training screens. Camera and ML integration now have an initial hybrid recognizer stub.
 
-DGS demonstration videos can be placed under `app/assets/videos/dgs/`. A toggle on the recognition screen lets you switch between the standard symbol video and the DGS version when available.
+DGS demonstration videos can be placed under `app/assets/videos/dgs/`. Each gesture entry may specify a `videoUri` and optional `dgsVideoUri` pointing to these files. A toggle on the recognition screen lets you switch between the standard symbol video and the DGS version when available.
 
 ### Building the custom dev client
 

--- a/app/assets/model/animalGestures.json
+++ b/app/assets/model/animalGestures.json
@@ -2,11 +2,15 @@
   "gestures": [
     {
       "id": "cat",
-      "label": "cat"
+      "label": "cat",
+      "videoUri": "videos/cat.mp4",
+      "dgsVideoUri": "videos/dgs/cat.mp4"
     },
     {
       "id": "dog",
-      "label": "dog"
+      "label": "dog",
+      "videoUri": "videos/dog.mp4",
+      "dgsVideoUri": "videos/dgs/dog.mp4"
     }
   ]
 }

--- a/app/assets/model/basicGestures.json
+++ b/app/assets/model/basicGestures.json
@@ -1,1 +1,10 @@
-{"gestures": [{"id": "sample", "label": "hello"}]}
+{
+  "gestures": [
+    {
+      "id": "sample",
+      "label": "hello",
+      "videoUri": "videos/sample.mp4",
+      "dgsVideoUri": "videos/dgs/sample.mp4"
+    }
+  ]
+}

--- a/app/src/components/SymbolVideoPlayer.tsx
+++ b/app/src/components/SymbolVideoPlayer.tsx
@@ -10,9 +10,12 @@ export interface SymbolVideoPlayerProps {
 }
 
 export default function SymbolVideoPlayer({ entry, paused, useDgs, onEnd }: SymbolVideoPlayerProps) {
-  const source = useDgs
-    ? require(`../assets/videos/dgs/${entry.id}.mp4`)
-    : require(`../assets/videos/${entry.id}.mp4`);
+  const path = useDgs ? entry.dgsVideoUri : entry.videoUri;
+  const source = path
+    ? { uri: path }
+    : useDgs
+      ? require(`../assets/videos/dgs/${entry.id}.mp4`)
+      : require(`../assets/videos/${entry.id}.mp4`);
 
   return (
     <Video

--- a/app/src/model.ts
+++ b/app/src/model.ts
@@ -4,6 +4,10 @@ import animals from '../assets/model/animalGestures.json';
 export type GestureModelEntry = {
   id: string;
   label: string;
+  /** Path to the standard demonstration video relative to the assets folder */
+  videoUri?: string;
+  /** Optional path to a DGS video */
+  dgsVideoUri?: string;
 };
 
 export type GestureModel = {

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -47,9 +47,13 @@ export default function RecognitionScreen({ navigation }: any) {
     setStatus(`I think: ${result.label}`);
     startFeedbackAnimation();
     setLastLabel(result.label);
-    await playSymbolAudio({ id: result.label, label: result.label });
+    const entry = gestureModel.gestures.find((g) => g.id === result.label) || {
+      id: result.label,
+      label: result.label,
+    };
+    await playSymbolAudio(entry);
     if (profile) {
-      await incrementUsage({ id: result.label, label: result.label }, profile.id);
+      await incrementUsage(entry, profile.id);
     }
     const adv = await getLLMSuggestions(result.label);
     setSuggestions(adv);
@@ -69,7 +73,12 @@ export default function RecognitionScreen({ navigation }: any) {
 
   const handlePlayVideo = async () => {
     if (!lastLabel) return;
-    await playSymbolVideo({ id: lastLabel, label: lastLabel }, useDgs);
+    const entry =
+      gestureModel.gestures.find((g) => g.id === lastLabel) || {
+        id: lastLabel,
+        label: lastLabel,
+      };
+    await playSymbolVideo(entry, useDgs);
   };
 
   const styles = StyleSheet.create({

--- a/app/src/services/videoService.ts
+++ b/app/src/services/videoService.ts
@@ -11,10 +11,13 @@ export async function playSymbolVideo(
 ): Promise<void> {
   try {
     const video = new Video();
-    const path = useDgs
-      ? `../assets/videos/dgs/${entry.id}.mp4`
-      : `../assets/videos/${entry.id}.mp4`;
-    await video.loadAsync(require(path));
+    const customPath = useDgs ? entry.dgsVideoUri : entry.videoUri;
+    const source = customPath
+      ? { uri: customPath }
+      : useDgs
+        ? require(`../assets/videos/dgs/${entry.id}.mp4`)
+        : require(`../assets/videos/${entry.id}.mp4`);
+    await video.loadAsync(source);
     await video.presentFullscreenPlayer();
     await video.playAsync();
     await video.unloadAsync();


### PR DESCRIPTION
## Summary
- add `videoUri` and `dgsVideoUri` fields for gesture entries
- use those paths when showing or playing symbol videos
- extend sample gesture data with the new fields
- adjust recognition screen to look up entries before playback
- document the new optional fields for videos
- refactor video loaders to use URI sources

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877ee09681483228d4186f778d88ac4