### PR TITLE
Implement unified schema and navigation foundation

### DIFF
--- a/app/db/index.ts
+++ b/app/db/index.ts
@@ -1,0 +1,110 @@
+import { Database } from '@nozbe/watermelondb';
+import SQLiteAdapter from '@nozbe/watermelondb/adapters/sqlite';
+import { mySchema } from './schema';
+import {
+  Profile,
+  Symbol,
+  VocabularySet,
+  UsageStat,
+  VocabularySetSymbol,
+  GestureDefinition,
+  GestureTrainingData,
+  InteractionLog,
+  LearningAnalytic,
+} from './models';
+
+const adapter = new SQLiteAdapter({
+  schema: mySchema,
+  jsi: true,
+});
+
+export const database = new Database({
+  adapter,
+  modelClasses: [
+    Profile,
+    Symbol,
+    VocabularySet,
+    UsageStat,
+    VocabularySetSymbol,
+    GestureDefinition,
+    GestureTrainingData,
+    InteractionLog,
+    LearningAnalytic,
+  ],
+});
+
+export const setupDatabase = async () => {
+  const profileCollection = database.get<Profile>('profiles');
+  const profiles = await profileCollection.query().fetch();
+  if (profiles.length > 0) {
+    console.log('Database already populated.');
+    return profiles[0].id;
+  }
+  let amyProfileId = '';
+  await database.write(async () => {
+    console.log('Setting up database with initial data...');
+    const now = Date.now();
+    const symbolCollection = database.get<Symbol>('symbols');
+
+    const trinkenSymbol = await symbolCollection.create(s => {
+      s.name = 'Trinken';
+      s.category = 'basic';
+      s.iconName = 'trinken.png';
+      s.videoAssetPath = 'trinken.mp4';
+      s.contextTagsRaw = JSON.stringify(['Durst', 'Becher', 'mehr']);
+      s.emoji = '🥛';
+      s.priority = 1;
+      s.isActive = true;
+      s.healthScore = 100;
+      s.color = '#AEDFF7';
+      s.createdAt = new Date(now);
+    });
+
+    const essenSymbol = await symbolCollection.create(s => {
+      s.name = 'Essen';
+      s.category = 'basic';
+      s.iconName = 'essen.png';
+      s.videoAssetPath = 'essen.mp4';
+      s.contextTagsRaw = JSON.stringify(['Hunger', 'Teller', 'mehr']);
+      s.emoji = '🍪';
+      s.priority = 1;
+      s.isActive = true;
+      s.healthScore = 100;
+      s.color = '#F7C5A8';
+      s.createdAt = new Date(now);
+    });
+
+    const spielenSymbol = await symbolCollection.create(s => {
+      s.name = 'Spielen';
+      s.category = 'extra';
+      s.iconName = 'spielen.png';
+      s.videoAssetPath = 'spielen.mp4';
+      s.contextTagsRaw = JSON.stringify(['Spaß', 'Freunde', 'Ball']);
+      s.emoji = '⚽';
+      s.priority = 2;
+      s.isActive = true;
+      s.healthScore = 100;
+      s.color = '#A8F7A8';
+      s.createdAt = new Date(now);
+    });
+
+    const setCollection = database.get<VocabularySet>('vocabulary_sets');
+    const alltagSet = await setCollection.create(v => { v.name = 'Alltag'; });
+    const kitaSet = await setCollection.create(v => { v.name = 'Kita'; });
+    const vssCollection = database.get<VocabularySetSymbol>('vocabulary_set_symbols');
+    await vssCollection.create(vs => { (vs as any).vocabularySet.id = alltagSet.id; (vs as any).symbol.id = trinkenSymbol.id; });
+    await vssCollection.create(vs => { (vs as any).vocabularySet.id = alltagSet.id; (vs as any).symbol.id = essenSymbol.id; });
+    await vssCollection.create(vs => { (vs as any).vocabularySet.id = kitaSet.id; (vs as any).symbol.id = spielenSymbol.id; });
+
+    const amyProfile = await profileCollection.create(p => {
+      p.name = 'Amy';
+      (p as any).activeVocabularySet.id = alltagSet.id;
+      p.consentHelpMeGetSmarter = true;
+      p.consentHelpMeLearnOverTime = true;
+      p.createdAt = new Date(now);
+      p.updatedAt = new Date(now);
+    });
+    amyProfileId = amyProfile.id;
+  });
+  return amyProfileId;
+};

--- a/app/db/models.ts
+++ b/app/db/models.ts
@@ -1,0 +1,128 @@
+import { Model } from '@nozbe/watermelondb';
+import { field, relation, text, date, children } from '@nozbe/watermelondb/decorators';
+
+export class Profile extends Model {
+  static table = 'profiles';
+  static associations = {
+    vocabulary_sets: { type: 'belongs_to', key: 'active_vocabulary_set_id' },
+  } as const;
+
+  @text('name') name!: string;
+  @field('consent_help_me_get_smarter') consentHelpMeGetSmarter!: boolean;
+  @field('consent_help_me_learn_over_time') consentHelpMeLearnOverTime!: boolean;
+  @date('created_at') createdAt!: Date;
+  @date('updated_at') updatedAt!: Date;
+  @relation('vocabulary_sets', 'active_vocabulary_set_id') activeVocabularySet: any;
+}
+
+export class Symbol extends Model {
+  static table = 'symbols';
+
+  @text('name') name!: string;
+  @text('icon_name') iconName!: string;
+  @text('video_asset_path') videoAssetPath?: string;
+  @text('category') category!: string;
+  @field('priority') priority!: number;
+  @field('is_active') isActive!: boolean;
+  @date('created_at') createdAt!: Date;
+  @text('emoji') emoji!: string;
+  @text('color') color!: string;
+  @field('health_score') healthScore!: number;
+  @field('context_tags') contextTagsRaw?: string;
+
+  get label(): string {
+    return this.name;
+  }
+
+  get imageAssetPath(): string {
+    return this.iconName;
+  }
+
+  get contextTags(): string[] {
+    if (!this.contextTagsRaw) return [];
+    try {
+      return JSON.parse(this.contextTagsRaw);
+    } catch {
+      return [];
+    }
+  }
+}
+
+export class VocabularySet extends Model {
+  static table = 'vocabulary_sets';
+  static associations = {
+    vocabulary_set_symbols: { type: 'has_many', foreignKey: 'vocabulary_set_id' },
+  } as const;
+
+  @field('name') name!: string;
+}
+
+export class UsageStat extends Model {
+  static table = 'usage_stats';
+  @relation('profiles', 'profile_id') profile!: any;
+  @relation('symbols', 'symbol_id') symbol: any;
+  @field('usage_count') usageCount!: number;
+}
+
+export class VocabularySetSymbol extends Model {
+  static table = 'vocabulary_set_symbols';
+  @relation('vocabulary_sets', 'vocabulary_set_id') vocabularySet!: any;
+  @relation('symbols', 'symbol_id') symbol!: any;
+}
+
+export class GestureDefinition extends Model {
+  static table = 'gesture_definitions';
+  static associations = {
+    symbols: { type: 'belongs_to', key: 'symbol_id' },
+    gesture_training_data: { type: 'has_many', foreignKey: 'gesture_definition_id' },
+  } as const;
+
+  @text('name') name!: string;
+  @text('status') status!: string;
+  @field('health_score') healthScore!: number;
+  @field('min_confidence_threshold') minConfidenceThreshold!: number;
+  @field('training_sessions_count') trainingSessionsCount!: number;
+  @date('last_successful_recognition') lastSuccessfulRecognition!: Date | null;
+  @date('created_at') createdAt!: Date;
+  @date('updated_at') updatedAt!: Date;
+  @relation('symbols', 'symbol_id') symbol!: any;
+  @children('gesture_training_data') trainingData!: any;
+}
+
+export class GestureTrainingData extends Model {
+  static table = 'gesture_training_data';
+  static associations = {
+    gesture_definitions: { type: 'belongs_to', key: 'gesture_definition_id' },
+  } as const;
+  @text('landmark_data') landmarkData!: string;
+  @text('source') source!: string;
+  @field('quality_score') qualityScore!: number;
+  @text('frame_metadata') frameMetadata!: string;
+  @date('created_at') createdAt!: Date;
+  @relation('gesture_definitions', 'gesture_definition_id') gestureDefinition!: any;
+}
+
+export class InteractionLog extends Model {
+  static table = 'interaction_logs';
+
+  @text('session_id') sessionId!: string;
+  @text('gesture_definition_id') gestureDefinitionId!: string;
+  @field('was_successful') wasSuccessful!: boolean;
+  @field('confidence_score') confidenceScore!: number;
+  @text('input_type') inputType!: string;
+  @field('processing_time_ms') processingTimeMs!: number;
+  @text('caregiver_override_id') caregiverOverrideId?: string;
+  @text('environmental_context') environmentalContext!: string;
+  @date('created_at') createdAt!: Date;
+}
+
+export class LearningAnalytic extends Model {
+  static table = 'learning_analytics';
+
+  @text('gesture_definition_id') gestureDefinitionId!: string;
+  @field('success_rate_24h') successRate24h!: number;
+  @field('success_rate_7d') successRate7d!: number;
+  @field('avg_confidence_score') avgConfidenceScore!: number;
+  @text('improvement_trend') improvementTrend!: string;
+  @date('last_calculated') lastCalculated!: Date;
+}

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -1,0 +1,103 @@
+import { appSchema, tableSchema } from '@nozbe/watermelondb';
+
+export const mySchema = appSchema({
+  version: 3,
+  tables: [
+    tableSchema({
+      name: 'profiles',
+      columns: [
+        { name: 'name', type: 'string' },
+        { name: 'consent_help_me_get_smarter', type: 'boolean' },
+        { name: 'consent_help_me_learn_over_time', type: 'boolean' },
+        { name: 'created_at', type: 'number' },
+        { name: 'updated_at', type: 'number' },
+        { name: 'active_vocabulary_set_id', type: 'string', isOptional: true, isIndexed: true },
+      ],
+    }),
+    tableSchema({
+      name: 'symbols',
+      columns: [
+        { name: 'name', type: 'string', isIndexed: true },
+        { name: 'icon_name', type: 'string' },
+        { name: 'video_asset_path', type: 'string', isOptional: true },
+        { name: 'category', type: 'string', isIndexed: true },
+        { name: 'priority', type: 'number' },
+        { name: 'is_active', type: 'boolean' },
+        { name: 'created_at', type: 'number' },
+        { name: 'emoji', type: 'string' },
+        { name: 'color', type: 'string' },
+        { name: 'health_score', type: 'number' },
+        { name: 'context_tags', type: 'string', isOptional: true },
+      ],
+    }),
+    tableSchema({
+      name: 'vocabulary_sets',
+      columns: [{ name: 'name', type: 'string' }],
+    }),
+    tableSchema({
+      name: 'vocabulary_set_symbols',
+      columns: [
+        { name: 'vocabulary_set_id', type: 'string', isIndexed: true },
+        { name: 'symbol_id', type: 'string', isIndexed: true },
+      ],
+    }),
+    tableSchema({
+      name: 'usage_stats',
+      columns: [
+        { name: 'profile_id', type: 'string', isIndexed: true },
+        { name: 'symbol_id', type: 'string', isIndexed: true },
+        { name: 'usage_count', type: 'number' },
+      ],
+    }),
+    tableSchema({
+      name: 'gesture_definitions',
+      columns: [
+        { name: 'name', type: 'string' },
+        { name: 'status', type: 'string', isIndexed: true },
+        { name: 'health_score', type: 'number' },
+        { name: 'symbol_id', type: 'string', isIndexed: true },
+        { name: 'min_confidence_threshold', type: 'number' },
+        { name: 'training_sessions_count', type: 'number' },
+        { name: 'last_successful_recognition', type: 'number', isOptional: true },
+        { name: 'created_at', type: 'number' },
+        { name: 'updated_at', type: 'number' },
+      ],
+    }),
+    tableSchema({
+      name: 'gesture_training_data',
+      columns: [
+        { name: 'gesture_definition_id', type: 'string', isIndexed: true },
+        { name: 'landmark_data', type: 'string' },
+        { name: 'source', type: 'string', isIndexed: true },
+        { name: 'quality_score', type: 'number' },
+        { name: 'frame_metadata', type: 'string' },
+        { name: 'created_at', type: 'number', isIndexed: true },
+      ],
+    }),
+    tableSchema({
+      name: 'interaction_logs',
+      columns: [
+        { name: 'session_id', type: 'string', isIndexed: true },
+        { name: 'gesture_definition_id', type: 'string', isIndexed: true },
+        { name: 'was_successful', type: 'boolean', isIndexed: true },
+        { name: 'confidence_score', type: 'number' },
+        { name: 'input_type', type: 'string' },
+        { name: 'processing_time_ms', type: 'number' },
+        { name: 'caregiver_override_id', type: 'string', isOptional: true },
+        { name: 'environmental_context', type: 'string' },
+        { name: 'created_at', type: 'number', isIndexed: true },
+      ],
+    }),
+    tableSchema({
+      name: 'learning_analytics',
+      columns: [
+        { name: 'gesture_definition_id', type: 'string', isIndexed: true },
+        { name: 'success_rate_24h', type: 'number' },
+        { name: 'success_rate_7d', type: 'number' },
+        { name: 'avg_confidence_score', type: 'number' },
+        { name: 'improvement_trend', type: 'string' },
+        { name: 'last_calculated', type: 'number' },
+      ],
+    }),
+  ],
+});

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,11 @@
     "@react-navigation/stack": "^6.3.18",
     "@react-native-async-storage/async-storage": "^1.22.0",
     "expo-av": "~13.2.1",
-    "expo-speech": "~11.4.0"
+    "expo-speech": "~11.4.0",
+    "@nozbe/watermelondb": "^0.24.0",
+    "react-native-vision-camera": "^2.15.4",
+    "react-native-reanimated": "^3.0.0",
+    "react-native-fast-tflite": "^0.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/app/src/components/SymbolButton.tsx
+++ b/app/src/components/SymbolButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Pressable, Text, View, StyleSheet } from 'react-native';
+import { Symbol } from '../../db/models';
+
+interface Props {
+  symbol: Symbol;
+  onPress: (s: Symbol) => void;
+}
+
+export const SymbolButton = ({ symbol, onPress }: Props) => (
+  <Pressable style={styles.button} onPress={() => onPress(symbol)}>
+    <Text style={styles.text}>{symbol.emoji} {symbol.name}</Text>
+  </Pressable>
+);
+
+const styles = StyleSheet.create({
+  button: { padding: 10, margin: 5, backgroundColor: '#eee', borderRadius: 8, minWidth: 120, alignItems: 'center' },
+  text: { fontSize: 16 },
+});

--- a/app/src/components/gestureMap.ts
+++ b/app/src/components/gestureMap.ts
@@ -1,0 +1,9 @@
+const gestureToSymbol: Record<string, string> = {
+  trinken: 'Trinken',
+  essen: 'Essen',
+  spielen: 'Spielen',
+};
+
+export function getSymbolLabelForGesture(gesture: string): string | undefined {
+  return gestureToSymbol[gesture];
+}

--- a/app/src/context/ServicesContext.tsx
+++ b/app/src/context/ServicesContext.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { mlService } from '../services/mlService';
+import { audioService } from '../services/audioService';
+import { adaptiveLearningService } from '../services/adaptiveLearningService';
+
+export const ServicesContext = React.createContext({
+  mlService,
+  audioService,
+  adaptiveLearningService,
+});

--- a/app/src/screens/LearningScreen.tsx
+++ b/app/src/screens/LearningScreen.tsx
@@ -1,81 +1,157 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, Button, FlatList, StyleSheet, Switch } from 'react-native';
-import { GestureModelEntry, gestureModel } from '../model';
+import { View, Text, ActivityIndicator, FlatList, Pressable, AppState, StyleSheet, Switch } from 'react-native';
+import withObservables from '@nozbe/with-observables';
+import { switchMap } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
+import { useIsFocused } from '@react-navigation/native';
+import { Camera, useCameraDevice, useFrameProcessor } from 'react-native-vision-camera';
+import { useTensorflowModel } from 'react-native-fast-tflite';
+import { runOnJS } from 'react-native-reanimated';
+import { database } from '../../db';
 import { playSymbolAudio } from '../services/audioService';
-import { incrementUsage } from '../services/usageTracker';
-import { loadProfile, Profile } from '../storage';
+import { usageTracker } from '../services/usageTracker';
+import { SymbolButton } from '../components/SymbolButton';
 import SymbolVideoPlayer from '../components/SymbolVideoPlayer';
-import { getLLMSuggestions, LLMSuggestions } from '../services/dialogService';
+import { dialogEngine } from '../services/dialogEngine';
+import { getSymbolLabelForGesture } from '../components/gestureMap';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Profile, Symbol } from '../../db/models';
 
-export default function LearningScreen() {
-  const [profile, setProfile] = useState<Profile | null>(null);
-  const [playing, setPlaying] = useState<GestureModelEntry | null>(null);
-  const [videoPaused, setVideoPaused] = useState(true);
-  const [useDgs, setUseDgs] = useState(false);
-  const [suggestions, setSuggestions] = useState<LLMSuggestions | null>(null);
+type RootStackParamList = { Learning: { profileId: string }, Admin: { profileId: string } };
+type Props = NativeStackScreenProps<RootStackParamList, 'Learning'>;
 
-  useEffect(() => {
-    loadProfile().then(setProfile);
-  }, []);
+type GesturePrediction = { label: string; confidence: number };
 
-  const handlePress = async (entry: GestureModelEntry) => {
-    await playSymbolAudio(entry);
-    if (profile) {
-      await incrementUsage(entry, profile.id);
-    }
-    setPlaying(entry);
+const enhance = withObservables<Props, { profile: Profile, vocabulary: Symbol[] }>(['route'], ({ route }) => ({
+  profile: database.get<Profile>('profiles').findAndObserve(route.params.profileId),
+  vocabulary: database.get<Profile>('profiles').findAndObserve(route.params.profileId).pipe(
+    switchMap(p => p.activeVocabularySet.observe()),
+    switchMap(activeSet => activeSet ? database.get<Symbol>('symbols').query(
+        { on: 'vocabulary_set_symbols', where: { vocabulary_set_id: activeSet.id } }
+    ).observe() : new BehaviorSubject<Symbol[]>([]))
+  ),
+}));
+
+const LearningScreen = ({ profile, vocabulary, navigation }: { profile: Profile, vocabulary: Symbol[], navigation: Props['navigation'] }) => {
+  const [isCameraActive, setIsCameraActive] = useState(false);
+  const [lastGesture, setLastGesture] = useState<string | null>(null);
+  const [selectedSymbol, setSelectedSymbol] = useState<Symbol | null>(null);
+  const [videoPaused, setVideoPaused] = useState(false);
+  const [suggestions, setSuggestions] = useState<Symbol[]>([]);
+
+  const { model } = useTensorflowModel(require('../../assets/models/gestures.tflite'));
+  const device = useCameraDevice('front');
+  const isFocused = useIsFocused();
+  const appState = AppState.currentState;
+  const canRunCamera = device != null && isCameraActive && isFocused && appState === 'active';
+
+  const handlePress = async (symbol: Symbol) => {
+    setSelectedSymbol(symbol);
     setVideoPaused(false);
-    const adv = await getLLMSuggestions(entry.label);
-    setSuggestions(adv);
+    await playSymbolAudio({ id: symbol.id, label: symbol.name });
+    await usageTracker.incrementUsage(symbol, profile.id);
+    const adaptiveSuggestions = await dialogEngine.getAdaptiveSuggestions(vocabulary, profile.id);
+    setSuggestions(adaptiveSuggestions);
   };
 
-  const styles = StyleSheet.create({
-    container: { flex: 1, padding: 20, alignItems: 'center' },
-    row: { flexDirection: 'row', gap: 10, flexWrap: 'wrap' },
-    suggestion: { marginTop: 10, textAlign: 'center' },
-  });
+  const handleGesture = (prediction: GesturePrediction) => {
+    if (lastGesture !== null) return;
+    const recognizedSymbolLabel = getSymbolLabelForGesture(prediction.label);
+    if (recognizedSymbolLabel) {
+      const foundSymbol = vocabulary.find(s => s.name === recognizedSymbolLabel);
+      if (foundSymbol) {
+        runOnJS(handlePress)(foundSymbol);
+        runOnJS(setLastGesture)(prediction.label);
+        setTimeout(() => runOnJS(setLastGesture)(null), 2000);
+      }
+    }
+  };
+
+  const frameProcessor = useFrameProcessor(frame => {
+    'worklet';
+    if (!model.value) return;
+    try {
+      const data = model.value.runSync(frame) as any[];
+      if (data?.length > 0) {
+        const best = data.reduce((p, c) => (p.confidence > c.confidence) ? p : c);
+        if (best?.confidence > 0.8) {
+          handleGesture(best);
+        }
+      }
+    } catch (e) {
+      console.error('Frame processor error', e);
+    }
+  }, [model, vocabulary, lastGesture]);
+
+  if (!profile || !vocabulary) {
+    return <View style={styles.container}><ActivityIndicator size="large" /></View>;
+  }
 
   return (
     <View style={styles.container}>
-      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 10 }}>
-        <Text>Use DGS Video</Text>
-        <Switch value={useDgs} onValueChange={setUseDgs} />
+      {canRunCamera && <Camera style={StyleSheet.absoluteFill} device={device} isActive={true} frameProcessor={frameProcessor} frameProcessorFps={5}/>} 
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>{profile.name}'s Vokabular</Text>
+        <Pressable onPress={() => navigation.navigate('Admin', { profileId: profile.id })}>
+          <Text style={styles.adminButton}>⚙️</Text>
+        </Pressable>
       </View>
-      <FlatList
-        data={gestureModel.gestures}
-        numColumns={2}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={{ margin: 10 }}>
-            <Button title={item.label} onPress={() => handlePress(item)} />
-          </View>
-        )}
+      <FlatList 
+        data={vocabulary} 
+        renderItem={({ item }) => <SymbolButton symbol={item} onPress={handlePress} />} 
+        keyExtractor={item => item.id} 
+        numColumns={2} 
+        contentContainerStyle={styles.list} 
       />
-      {playing && (
-        <SymbolVideoPlayer
-          entry={playing}
-          paused={videoPaused}
-          useDgs={useDgs}
-          onEnd={() => setVideoPaused(true)}
+      {selectedSymbol && (
+        <View style={styles.selectedSymbolContainer}>
+          <Text style={styles.selectedSymbolLabel}>{selectedSymbol.name}</Text>
+          <SymbolVideoPlayer
+            entry={{ id: selectedSymbol.id, label: selectedSymbol.name, videoUri: selectedSymbol.videoAssetPath }}
+            paused={videoPaused}
+            onEnd={() => setVideoPaused(true)}
+          />
+          <Pressable style={styles.repeatButton} onPress={() => handlePress(selectedSymbol)}>
+            <Text style={styles.buttonText}>🔁 Wiederholen</Text>
+          </Pressable>
+          {suggestions.length > 0 && (
+            <View style={styles.suggestionsContainer}>
+                <Text style={styles.suggestionsTitle}>Vielleicht auch?</Text>
+                <View style={styles.suggestionsList}>
+                    {suggestions.map(s => <SymbolButton key={s.id} symbol={s} onPress={handlePress} />)}
+                </View>
+            </View>
+          )}
+        </View>
+      )}
+
+      <View style={styles.cameraToggle}>
+        <Text>Gesten erkennen</Text>
+        <Switch
+            trackColor={{ false: '#767577', true: '#81b0ff' }}
+            thumbColor={isCameraActive ? '#f5dd4b' : '#f4f3f4'}
+            onValueChange={() => setIsCameraActive(prev => !prev)}
+            value={isCameraActive}
         />
-      )}
-      {suggestions && suggestions.nextWords.length > 0 && (
-        <View>
-          <Text style={styles.suggestion}>Next words:</Text>
-          {suggestions.nextWords.map((s, i) => (
-            <Text key={i} style={styles.suggestion}>{s}</Text>
-          ))}
-        </View>
-      )}
-      {suggestions && suggestions.caregiverPhrases.length > 0 && (
-        <View>
-          <Text style={styles.suggestion}>Caregiver:</Text>
-          {suggestions.caregiverPhrases.map((s, i) => (
-            <Text key={i} style={styles.suggestion}>{s}</Text>
-          ))}
-        </View>
-      )}
+      </View>
     </View>
   );
-}
+};
 
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F8FAFC' },
+  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 15, borderBottomWidth: 1, borderColor: '#eee' },
+  headerTitle: { fontSize: 20, fontWeight: 'bold' },
+  adminButton: { fontSize: 24 },
+  list: { alignItems: 'center', paddingTop: 10, paddingBottom: 200 },
+  cameraToggle: { position: 'absolute', bottom: 30, alignSelf: 'center', padding: 15, backgroundColor: 'rgba(255, 255, 255, 0.9)', borderRadius: 20, elevation: 5, flexDirection: 'row', alignItems: 'center', gap: 10 },
+  selectedSymbolContainer: { position: 'absolute', bottom: 100, left: 10, right: 10, alignItems: 'center', padding: 10, backgroundColor: 'white', borderRadius: 15, elevation: 10, shadowColor: '#000', shadowOffset: { width: 0, height: -2 }, shadowOpacity: 0.1, shadowRadius: 4 },
+  selectedSymbolLabel: { fontSize: 24, fontWeight: 'bold', marginBottom: 10 },
+  repeatButton: { marginTop: 10, paddingVertical: 10, paddingHorizontal: 20, backgroundColor: '#e0e0e0', borderRadius: 10 },
+  buttonText: { fontWeight: 'bold' },
+  suggestionsContainer: { marginTop: 15, width: '100%' },
+  suggestionsTitle: { fontWeight: 'bold', fontSize: 16, textAlign: 'center', marginBottom: 5 },
+  suggestionsList: { flexDirection: 'row', justifyContent: 'center', flexWrap: 'wrap' }
+});
+
+export default enhance(LearningScreen);

--- a/app/src/services/adaptiveLearningService.ts
+++ b/app/src/services/adaptiveLearningService.ts
@@ -1,0 +1,5 @@
+export const adaptiveLearningService = {
+  async getSuggestions() {
+    return [] as any[];
+  },
+};

--- a/app/src/services/audioService.ts
+++ b/app/src/services/audioService.ts
@@ -16,3 +16,14 @@ export async function playSymbolAudio(entry: GestureModelEntry): Promise<void> {
     Speech.speak(entry.label);
   }
 }
+
+export const ttsService = {
+  speak(text: string) {
+    Speech.speak(text);
+  },
+};
+
+export const audioService = {
+  playSymbolAudio,
+  ttsService,
+};


### PR DESCRIPTION
## Summary
- introduce WatermelonDB schema and models
- seed initial data and connect database
- rework app navigation with stable stack
- update learning screen logic
- add utility components and services

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877f50413b083229d08d436670ed65a