### PR TITLE
Document API key file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.openai-key

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The React Native code lives in `app/`. Install dependencies with `npm install` i
 
 DGS demonstration videos can be placed under `app/assets/videos/dgs/`. Each gesture entry may specify a `videoUri` and optional `dgsVideoUri` pointing to these files. A toggle on the recognition screen lets you switch between the standard symbol video and the DGS version when available.
 
-The LLM-powered suggestions require an OpenAI API key. You can set this via the `OPENAI_API_KEY` environment variable or save it securely using the Admin screen. Never commit keys to the repository.
+The LLM-powered suggestions require an OpenAI API key. You can set this via the `OPENAI_API_KEY` environment variable, place the key in a local `.openai-key` file, or save it securely using the Admin screen. Never commit keys to the repository.
 
 ### Building the custom dev client
 

--- a/src/services/dialogEngine.ts
+++ b/src/services/dialogEngine.ts
@@ -12,9 +12,17 @@ export interface LLMSuggestions {
   caregiverPhrases: string[];
 }
 
+function getApiKey(): string | undefined {
+  if (process.env.OPENAI_API_KEY) return process.env.OPENAI_API_KEY;
+  try {
+    return require('fs').readFileSync('.openai-key', 'utf8').trim();
+  } catch {
+    return undefined;
+  }
+}
+
 export async function getLLMSuggestions(req: LLMRequest): Promise<LLMSuggestions> {
-  // TODO: Replace with secure storage (e.g., from a settings screen)
-  const apiKey = process.env.OPENAI_API_KEY;
+  const apiKey = getApiKey();
   if (!apiKey) {
     return { nextWords: [], caregiverPhrases: [] };
   }


### PR DESCRIPTION
## Summary
- note that `dialogEngine` can load a key from `.openai-key`
- ignore this file in Git

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687888ca0c948322b12254d35ab4b886