### PR TITLE
Improve suggestion types and UI state handling

### DIFF
--- a/app/src/services/adaptiveLearningService.ts
+++ b/app/src/services/adaptiveLearningService.ts
@@ -1,5 +1,16 @@
 export const adaptiveLearningService = {
-  async getSuggestions() {
-    return [] as any[];
+  /**
+   * Fetch adaptive suggestions based on the user's vocabulary and usage history.
+   *
+   * LLM Hint: The real implementation will query the local database and apply
+   * lightweight heuristics (e.g., most recent selections) to propose related
+   * symbols. For now this is a stub that returns an empty array.
+   */
+  async getSuggestions(
+    _vocabulary: any[],
+    _profileId: string,
+  ): Promise<any[]> {
+    return [];
   },
 };
+

--- a/src/services/dialogEngine.ts
+++ b/src/services/dialogEngine.ts
@@ -1,5 +1,12 @@
 import fetch from 'node-fetch';
 
+// LLM Hint: Define a clear type for the expected JSON response from the LLM.
+// This helps with type safety and makes it clear what structure the prompt should request.
+export type LLMSuggestionResponse = {
+  nextWords: string[];
+  caregiverPhrases: string[];
+};
+
 export interface LLMRequest {
   input: string;
   context: string[];
@@ -7,6 +14,7 @@ export interface LLMRequest {
   age: number;
 }
 
+// Retain existing interface name for backward compatibility within the codebase.
 export interface LLMSuggestions {
   nextWords: string[];
   caregiverPhrases: string[];
@@ -15,19 +23,26 @@ export interface LLMSuggestions {
 function getApiKey(): string | undefined {
   if (process.env.OPENAI_API_KEY) return process.env.OPENAI_API_KEY;
   try {
+    // LLM Hint: The .openai-key file is documented in README.md. Replace with
+    // secure storage when integrating into the mobile app.
     return require('fs').readFileSync('.openai-key', 'utf8').trim();
   } catch {
     return undefined;
   }
 }
 
-export async function getLLMSuggestions(req: LLMRequest): Promise<LLMSuggestions> {
+export async function getLLMSuggestions(req: LLMRequest): Promise<LLMSuggestionResponse> {
   const apiKey = getApiKey();
   if (!apiKey) {
     return { nextWords: [], caregiverPhrases: [] };
   }
-  const prompt = `A ${req.age}-year-old child who speaks ${req.language} just selected the word "${req.input}". The current context is [${req.context.join(', ')}]. Provide likely next words and helpful phrases for a caregiver. Return a JSON object with two keys: "nextWords": string[] and "caregiverPhrases": string[].`;
+  // LLM Hint: The prompt is the most critical part. It should clearly state the
+  // role, the context, the desired output format (JSON), and the exact keys for
+  // the JSON object. The formatting here mirrors the guidelines in docs/TODO.md.
+  const prompt = `A ${req.age}-year-old child who speaks ${req.language} just selected the word "${req.input}". The current context is [${req.context.join(', ')}]. Provide likely next words and helpful phrases for a caregiver. Return a JSON object with two keys: "nextWords" and "caregiverPhrases".`;
+  console.log('LLM Prompt:', prompt);
   try {
+    // TODO: Replace this with a real OpenAI API call as outlined in docs/TODO.md
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -43,7 +58,7 @@ export async function getLLMSuggestions(req: LLMRequest): Promise<LLMSuggestions
     if (!response.ok) throw new Error(`API call failed with status: ${response.status}`);
     const data = (await response.json()) as any;
     const content = JSON.parse(data.choices[0].message.content as string);
-    return content as LLMSuggestions;
+    return content as LLMSuggestionResponse;
   } catch (error) {
     console.error('LLM suggestion error:', error);
     return { nextWords: [], caregiverPhrases: [] };


### PR DESCRIPTION
## Summary
- define `LLMSuggestionResponse` type and add LLM comments in dialog engine
- add adaptive suggestion state machine in `LearningScreen`
- fetch adaptive and LLM suggestions concurrently
- display suggestions using a unified status enum
- render LLM suggestions in `LearningScreen`
- stub out adaptive suggestion service API

## Testing
- `npm install`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68788f4c8a10832288a6c624446bc530