### PR TITLE
Implement ML service and update README tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ The project has a stable foundation after a major refactor. The database, naviga
 
 **For detailed implementation instructions, see [`docs/TODO.md`](docs/TODO.md).**
 
-### Priority 1: Activate Core Functionality
+-### Priority 1: Activate Core Functionality
 - [ ] **Implement Gesture Recognition**: The `mlService.ts` is currently a stub. Implement the `loadModels` and `classifyGesture` methods to enable live camera interaction.
 - [ ] **Implement Rich Audio Feedback**: The `audioService.ts` is a stub. Implement the `playSystemSound` method to provide non-verbal cues for success and error states.
 
-### Priority 2: Enhance with Intelligence & Accessibility
+-### Priority 2: Enhance with Intelligence & Accessibility
 - [ ] **Integrate Live LLM Dialog Engine**: Replace the placeholder in `dialogEngine.ts` with a live API call to provide dynamic suggestions.
 - [ ] **Add DGS Video Playback**: Add support for German Sign Language videos, including schema changes and a UI toggle on the `LearningScreen`.
 

--- a/src/services/dialogEngine.ts
+++ b/src/services/dialogEngine.ts
@@ -42,7 +42,6 @@ export async function getLLMSuggestions(req: LLMRequest): Promise<LLMSuggestionR
   const prompt = `A ${req.age}-year-old child who speaks ${req.language} just selected the word "${req.input}". The current context is [${req.context.join(', ')}]. Provide likely next words and helpful phrases for a caregiver. Return a JSON object with two keys: "nextWords" and "caregiverPhrases".`;
   console.log('LLM Prompt:', prompt);
   try {
-    // TODO: Replace this with a real OpenAI API call as outlined in docs/TODO.md
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {

--- a/src/services/mlService.ts
+++ b/src/services/mlService.ts
@@ -1,7 +1,61 @@
-import { classifyGesture, ClassificationResult } from '../recognizer';
+import { classifyGesture as recognizerClassifyGesture, ClassificationResult } from '../recognizer';
+
+type TfliteType = {
+  loadModel(opts: { path: string; numThreads: number }): Promise<void>;
+  runOnModel(input: any): Promise<any[]>;
+};
+
+let TfliteCtor: { new (): TfliteType } | null = null;
+try {
+  // The native module is only available in the React Native environment.
+  TfliteCtor = require('react-native-fast-tflite').Tflite;
+} catch {
+  TfliteCtor = null;
+}
+
+class MachineLearningService {
+  private isReady = false;
+  private gestureModel: TfliteType | null = null;
+
+  constructor() {
+    if (TfliteCtor) {
+      this.gestureModel = new TfliteCtor();
+    }
+  }
+
+  async loadModels(): Promise<void> {
+    if (!this.gestureModel) return;
+    try {
+      await this.gestureModel.loadModel({
+        path: process.env.TFLITE_GESTURE_MODEL || 'gestures.tflite',
+        numThreads: 4,
+      });
+      this.isReady = true;
+      console.log('ML model loaded successfully.');
+    } catch (error) {
+      console.error('Failed to load ML model:', error);
+      this.isReady = false;
+    }
+  }
+
+  isServiceReady = (): boolean => this.isReady;
+
+  async classifyGesture(frame: any): Promise<any[] | null> {
+    if (!this.isReady || !this.gestureModel) return null;
+    try {
+      const output = await this.gestureModel.runOnModel(frame);
+      return output;
+    } catch (error) {
+      console.error('Local classification failed:', error);
+      return null;
+    }
+  }
+}
+
+export const mlService = new MachineLearningService();
 
 export async function processLandmarks(landmarks: unknown): Promise<ClassificationResult> {
   // Directly leverage the recognizer which already implements
   // the online/offline classification fallback logic.
-  return classifyGesture(landmarks);
+  return recognizerClassifyGesture(landmarks);
 }


### PR DESCRIPTION
## Summary
- add TFLite type stubs and configurable model path in `mlService`
- revert README roadmap tasks to incomplete

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878f78e532083229fcd28ba1b2a7f33