### PR TITLE
Expand analytics and audio service tests

### DIFF
--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -1,5 +1,8 @@
 import { createDatabase } from '../src/db';
-import { refreshLearningAnalytics } from '../src/services/analyticsService';
+import {
+  refreshLearningAnalytics,
+  computeLearningAnalytics,
+} from '../src/services/analyticsService';
 import { InteractionLog } from '../src/types';
 
 (async () => {
@@ -28,4 +31,81 @@ import { InteractionLog } from '../src/types';
     throw new Error('analytics computation failed');
   }
   console.log('analytics computed');
+})();
+
+(async () => {
+  const db = createDatabase();
+  const analytics = computeLearningAnalytics(db);
+  if (analytics.successRate7d !== 0 || analytics.improvementTrend !== 0) {
+    throw new Error('analytics default values incorrect');
+  }
+  console.log('analytics empty ok');
+})();
+
+(async () => {
+  const db = createDatabase();
+  const now = Date.now();
+
+  // logs from the last 7 days: 5 successes and 5 failures
+  for (let i = 0; i < 5; i++) {
+    db.interactionLogs.push({
+      id: `cur-success-${i}`,
+      gestureDefinitionId: 'g',
+      wasSuccessful: true,
+      confidenceScore: 1,
+      timestamp: now - i * 1000,
+      processedBy: 'local',
+    });
+    db.interactionLogs.push({
+      id: `cur-fail-${i}`,
+      gestureDefinitionId: 'g',
+      wasSuccessful: false,
+      confidenceScore: 0,
+      timestamp: now - i * 1000,
+      processedBy: 'local',
+    });
+  }
+
+  // logs from the previous week: 4 successes and 6 failures
+  const eightDays = 8 * 24 * 60 * 60 * 1000;
+  for (let i = 0; i < 10; i++) {
+    db.interactionLogs.push({
+      id: `old-${i}`,
+      gestureDefinitionId: 'g',
+      wasSuccessful: i < 4,
+      confidenceScore: i < 4 ? 1 : 0,
+      timestamp: now - eightDays - i * 1000,
+      processedBy: 'local',
+    });
+  }
+
+  refreshLearningAnalytics(db);
+  if (
+    db.learningAnalytics.length !== 1 ||
+    db.learningAnalytics[0].successRate7d !== 0.5 ||
+    db.learningAnalytics[0].improvementTrend !== 0.1
+  ) {
+    throw new Error('initial analytics incorrect');
+  }
+
+  // add an additional failed interaction and refresh again
+  db.interactionLogs.push({
+    id: 'cur-extra',
+    gestureDefinitionId: 'g',
+    wasSuccessful: false,
+    confidenceScore: 0,
+    timestamp: now + 1,
+    processedBy: 'local',
+  });
+  refreshLearningAnalytics(db);
+
+  const updated = db.learningAnalytics[0];
+  if (
+    db.learningAnalytics.length !== 1 ||
+    updated.successRate7d !== 0.45 ||
+    updated.improvementTrend !== 0.05
+  ) {
+    throw new Error('analytics update failed');
+  }
+  console.log('analytics update ok');
 })();

--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -1,5 +1,5 @@
 import { processLandmarks } from '../src/services/mlService';
-import { playAudio } from '../src/services/audioService';
+import { playAudio, playSystemSound } from '../src/services/audioService';
 import { playVideo } from '../src/services/videoService';
 import { fetchSuggestions } from '../src/services/dialogService';
 import { tmpdir } from 'os';
@@ -19,6 +19,20 @@ import path from 'path';
   const vid = path.join(tmpdir(), 'dummy.mp4');
   await fs.writeFile(vid, '');
   await playVideo(vid);
+
+  // should not throw even if the sound file is missing
+  await playSystemSound('success');
+  await playSystemSound('error');
+
+  let failed = false;
+  try {
+    await playAudio('/no/such/file.mp3');
+  } catch {
+    failed = true;
+  }
+  if (!failed) {
+    throw new Error('missing audio should error');
+  }
 
   const sugg = await fetchSuggestions('hello');
   if (sugg.length !== 0) {


### PR DESCRIPTION
## Summary
- extend analytics tests to cover record updates and metric trends
- test audio service failure path for missing files

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687938824164832286460b9da2fa3b2e