### PR TITLE
Implement personalized model download and adaptive suggestions

### DIFF
--- a/app/src/screens/AdminScreen.tsx
+++ b/app/src/screens/AdminScreen.tsx
@@ -9,7 +9,12 @@ import {
   TextInput,
 } from 'react-native';
 import { Alert } from 'react-native';
-import { loadOpenAIApiKey, saveOpenAIApiKey } from '../storage';
+import {
+  loadOpenAIApiKey,
+  saveOpenAIApiKey,
+  saveCustomModelUri,
+} from '../storage';
+import * as FileSystem from 'expo-file-system';
 import { database } from '../../db';
 import { Symbol as DBSymbol } from '../../db/models';
 
@@ -78,6 +83,22 @@ export default function AdminScreen({ navigation }: any) {
     await saveOpenAIApiKey(apiKey);
   };
 
+  const handleDownloadModel = async () => {
+    try {
+      const uri = FileSystem.documentDirectory + 'custom_model.tflite';
+      const res = await FileSystem.downloadAsync(
+        'http://localhost:5000/latest-model',
+        uri,
+        { headers: { Authorization: 'Bearer secret' } },
+      );
+      await saveCustomModelUri(res.uri);
+      Alert.alert('Model downloaded');
+    } catch (e) {
+      console.error(e);
+      Alert.alert('Download failed');
+    }
+  };
+
   const handleDelete = (sym: DBSymbol) => {
     Alert.alert('Symbol löschen', `"${sym.name}" wirklich entfernen?`, [
       { text: 'Abbrechen', style: 'cancel' },
@@ -122,6 +143,7 @@ export default function AdminScreen({ navigation }: any) {
         onChangeText={setApiKey}
       />
       <Button title="Save API Key" onPress={handleSaveApiKey} />
+      <Button title="Download Latest Model" onPress={handleDownloadModel} />
       <Button title="Add Symbol" onPress={openAdd} />
       <Button title="Training" onPress={() => navigation.navigate('Training')} />
       <Button title="Back" onPress={() => navigation.goBack()} />

--- a/app/src/screens/LearningScreen.tsx
+++ b/app/src/screens/LearningScreen.tsx
@@ -6,6 +6,7 @@ import { BehaviorSubject } from 'rxjs';
 import { useIsFocused } from '@react-navigation/native';
 import { Camera, useCameraDevice, useFrameProcessor } from 'react-native-vision-camera';
 import { useTensorflowModel } from 'react-native-fast-tflite';
+import { loadCustomModelUri } from '../storage';
 import { runOnJS } from 'react-native-reanimated';
 import { database } from '../../db';
 import { playSymbolAudio } from '../services/audioService';
@@ -46,7 +47,14 @@ const LearningScreen = ({ profile, vocabulary, navigation }: { profile: Profile,
   const [llmSuggestions, setLlmSuggestions] = useState<LLMSuggestions | null>(null);
   const [suggestionStatus, setSuggestionStatus] = useState<SuggestionStatus>('idle');
 
-  const { model } = useTensorflowModel(require('../../assets/models/gestures.tflite'));
+  const [customModelUri, setCustomModelUri] = useState<string | null>(null);
+  React.useEffect(() => {
+    loadCustomModelUri().then(setCustomModelUri);
+  }, []);
+
+  const { model } = useTensorflowModel(
+    customModelUri ? { uri: customModelUri } : require('../../assets/models/gestures.tflite'),
+  );
   const device = useCameraDevice('front');
   const isFocused = useIsFocused();
   const appState = AppState.currentState;

--- a/app/src/services/adaptiveLearningService.ts
+++ b/app/src/services/adaptiveLearningService.ts
@@ -1,3 +1,5 @@
+import { loadUsageStats } from './usageTracker';
+
 export const adaptiveLearningService = {
   /**
    * Fetch adaptive suggestions based on the user's vocabulary and usage history.
@@ -6,11 +8,22 @@ export const adaptiveLearningService = {
    * lightweight heuristics (e.g., most recent selections) to propose related
    * symbols. For now this is a stub that returns an empty array.
    */
-  async getSuggestions(
-    _vocabulary: any[],
-    _profileId: string,
-  ): Promise<any[]> {
-    return [];
+  async getSuggestions(vocabulary: any[], profileId: string): Promise<any[]> {
+    try {
+      const usage = await loadUsageStats(profileId);
+      const ranked = Object.entries(usage)
+        .sort((a, b) => b[1] - a[1])
+        .map(([id]) => id);
+      const suggestions: any[] = [];
+      for (const id of ranked) {
+        const sym = vocabulary.find((s) => s.id === id);
+        if (sym) suggestions.push(sym);
+        if (suggestions.length >= 3) break;
+      }
+      return suggestions;
+    } catch {
+      return [];
+    }
   },
 };
 

--- a/app/src/services/usageTracker.ts
+++ b/app/src/services/usageTracker.ts
@@ -10,3 +10,16 @@ export async function incrementUsage(entry: GestureModelEntry, profileId: string
   data[key] = (data[key] || 0) + 1;
   await AsyncStorage.setItem(KEY, JSON.stringify(data));
 }
+
+export async function loadUsageStats(profileId: string): Promise<Record<string, number>> {
+  const raw = await AsyncStorage.getItem(KEY);
+  const data: Record<string, number> = raw ? JSON.parse(raw) : {};
+  const out: Record<string, number> = {};
+  const prefix = `${profileId}:`;
+  for (const [key, value] of Object.entries(data)) {
+    if (key.startsWith(prefix)) {
+      out[key.slice(prefix.length)] = value;
+    }
+  }
+  return out;
+}

--- a/app/src/storage.ts
+++ b/app/src/storage.ts
@@ -92,3 +92,13 @@ export async function saveOpenAIApiKey(key: string): Promise<void> {
 export async function loadOpenAIApiKey(): Promise<string | null> {
   return AsyncStorage.getItem(API_KEY);
 }
+
+const CUSTOM_MODEL_KEY = 'customModelUri';
+
+export async function saveCustomModelUri(uri: string): Promise<void> {
+  await AsyncStorage.setItem(CUSTOM_MODEL_KEY, uri);
+}
+
+export async function loadCustomModelUri(): Promise<string | null> {
+  return AsyncStorage.getItem(CUSTOM_MODEL_KEY);
+}


### PR DESCRIPTION
## Summary
- store custom gesture model path in async storage
- allow downloading the latest personalised model from AdminScreen
- load personalised model in LearningScreen if it exists
- provide adaptive vocabulary suggestions using usage stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687966420b8c832283b0b439db278e50