### PR TITLE
Address README todos and add model download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,16 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [x] **Complete Admin Panel**: CRUD functionality in `AdminScreen.tsx` manages symbols and vocabularies.
 - [ ] **UI/UX Polish**: Conduct a full review of the UI to improve layouts, feedback, and add accessibility labels to all interactive elements.
 
-### Priority 4: Personalized AI Pipeline
-- [ ] **Acquire Pre-trained Models**: Download and bundle the MediaPipe models.
-- [ ] **Implement Two-Stage Frame Processor**: Load landmark and gesture models inside a `useFrameProcessor` worklet.
-- [ ] **Build TrainingScreen UI**: Provide a guided interface for recording gesture samples.
-- [ ] **Implement In-Memory Landmark Extraction**: Use ffmpeg to pull frames and save landmarks only.
+-### Priority 4: Personalized AI Pipeline
+- [x] **Acquire Pre-trained Models**: Download and bundle the MediaPipe models (see `src/tools/downloadModels.ts`).
+- [x] **Implement Two-Stage Frame Processor**: Load landmark and gesture models inside a `useFrameProcessor` worklet.
+- [x] **Build TrainingScreen UI**: Provide a guided interface for recording gesture samples.
+- [x] **Implement In-Memory Landmark Extraction**: Use ffmpeg to pull frames and save landmarks only.
 - [x] **Create Secure LLM Dialog Endpoint**: Proxy OpenAI requests through an authenticated server.
 - [x] **Create Model Training Endpoint & Script**: Accept uploaded landmarks and train an LSTM gesture model.
 - [x] **Create Model Download Endpoint**: Serve the latest personalized model to the app.
-- [ ] **Implement Model Download and Activation**: Download the `.tflite` model and store its URI securely.
-- [ ] **Activate the Personalized Model**: Use the custom model in the Learning screen when available.
+- [x] **Implement Model Download and Activation**: Download the `.tflite` model and store its URI securely.
+- [x] **Activate the Personalized Model**: Use the custom model in the Learning screen when available.
 
 ## ▶️ Running the mobile app
 

--- a/app/src/screens/AdminScreen.tsx
+++ b/app/src/screens/AdminScreen.tsx
@@ -131,8 +131,16 @@ export default function AdminScreen({ navigation }: any) {
         renderItem={({ item }) => (
           <View style={styles.row}>
             <Text>{item.name}</Text>
-            <Button title="Bearbeiten" onPress={() => openEdit(item)} />
-            <Button title="Löschen" onPress={() => handleDelete(item)} />
+            <Button
+              title="Bearbeiten"
+              onPress={() => openEdit(item)}
+              accessibilityLabel={`Bearbeite ${item.name}`}
+            />
+            <Button
+              title="Löschen"
+              onPress={() => handleDelete(item)}
+              accessibilityLabel={`Lösche ${item.name}`}
+            />
           </View>
         )}
       />
@@ -141,12 +149,25 @@ export default function AdminScreen({ navigation }: any) {
         placeholder="OpenAI API Key"
         value={apiKey}
         onChangeText={setApiKey}
+        accessibilityLabel="OpenAI API Key"
       />
-      <Button title="Save API Key" onPress={handleSaveApiKey} />
-      <Button title="Download Latest Model" onPress={handleDownloadModel} />
-      <Button title="Add Symbol" onPress={openAdd} />
-      <Button title="Training" onPress={() => navigation.navigate('Training')} />
-      <Button title="Back" onPress={() => navigation.goBack()} />
+      <Button
+        title="Save API Key"
+        onPress={handleSaveApiKey}
+        accessibilityLabel="OpenAI API-Schlüssel speichern"
+      />
+      <Button
+        title="Download Latest Model"
+        onPress={handleDownloadModel}
+        accessibilityLabel="Neueste Modellversion herunterladen"
+      />
+      <Button title="Add Symbol" onPress={openAdd} accessibilityLabel="Symbol hinzufügen" />
+      <Button
+        title="Training"
+        onPress={() => navigation.navigate('Training')}
+        accessibilityLabel="Trainingsmodus öffnen"
+      />
+      <Button title="Back" onPress={() => navigation.goBack()} accessibilityLabel="Zurück" />
 
       <Modal visible={modalVisible} animationType="slide">
         <View style={styles.modal}>
@@ -155,15 +176,17 @@ export default function AdminScreen({ navigation }: any) {
             placeholder="ID"
             value={id}
             onChangeText={setId}
+            accessibilityLabel="Symbol ID"
           />
           <TextInput
             style={styles.input}
             placeholder="Label"
             value={label}
             onChangeText={setLabel}
+            accessibilityLabel="Symbol Label"
           />
-          <Button title="Save" onPress={handleSave} />
-          <Button title="Cancel" onPress={() => setModalVisible(false)} />
+          <Button title="Save" onPress={handleSave} accessibilityLabel="Symbol speichern" />
+          <Button title="Cancel" onPress={() => setModalVisible(false)} accessibilityLabel="Abbrechen" />
         </View>
       </Modal>
     </View>

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -53,7 +53,12 @@ export default function TrainingScreen({ navigation }: any) {
       <Text style={styles.title}>Training Mode</Text>
       {!gestureId ? (
         gestureModel.gestures.map((g) => (
-          <Button key={g.id} title={g.label} onPress={() => setGestureId(g.id)} />
+          <Button
+            key={g.id}
+            title={g.label}
+            onPress={() => setGestureId(g.id)}
+            accessibilityLabel={`Trainiere Geste ${g.label}`}
+          />
         ))
       ) : count < 5 ? (
         <>
@@ -61,10 +66,15 @@ export default function TrainingScreen({ navigation }: any) {
           <Button
             title={saving ? 'Recording...' : `Record Sample ${count + 1} / 5`}
             onPress={handleRecord}
+            accessibilityLabel="Gestenaufnahme starten"
           />
         </>
       ) : (
-        <Button title="Save Training Data" onPress={handleFinish} />
+        <Button
+          title="Save Training Data"
+          onPress={handleFinish}
+          accessibilityLabel="Trainingsdaten speichern"
+        />
       )}
     </View>
   );

--- a/src/tools/downloadModels.ts
+++ b/src/tools/downloadModels.ts
@@ -1,0 +1,46 @@
+import { createWriteStream } from 'fs';
+import { pipeline } from 'stream';
+import https from 'https';
+import fs from 'fs';
+import path from 'path';
+
+const models = [
+  {
+    url: 'https://storage.googleapis.com/mediapipe-assets/hand_landmarker.task',
+    out: path.join(__dirname, '../../app/assets/models/hand_landmarker.tflite'),
+  },
+  {
+    url: 'https://storage.googleapis.com/mediapipe-assets/gesture_recognizer.task',
+    out: path.join(__dirname, '../../app/assets/models/gesture_classifier.tflite'),
+  },
+];
+
+async function download(url: string, dest: string) {
+  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+  return new Promise<void>((resolve, reject) => {
+    https.get(url, res => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`Request failed: ${res.statusCode}`));
+        return;
+      }
+      const file = createWriteStream(dest);
+      const pipe = pipeline(res, file, err => {
+        if (err) reject(err);
+        else resolve();
+      });
+    }).on('error', reject);
+  });
+}
+
+(async () => {
+  for (const m of models) {
+    const name = path.basename(m.out);
+    console.log(`Downloading ${name}...`);
+    try {
+      await download(m.url, m.out);
+      console.log(`Saved to ${m.out}`);
+    } catch (err) {
+      console.error(`Failed to download ${name}:`, err);
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- add accessibility labels to admin and training screens
- provide script to download pre-trained gesture models
- mark finished tasks in README

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68796edba7f48322bdbc1ec0ea10e36a