### PR TITLE
Improve accessibility labels

### DIFF
--- a/app/src/components/CorrectionPanel.tsx
+++ b/app/src/components/CorrectionPanel.tsx
@@ -58,16 +58,30 @@ export default function CorrectionPanel({
         <Animated.View style={[styles.panel, { transform: [{ translateY: slideAnim }] }]}>
           <View style={styles.row}>
             {options.slice(0, 2).map((g) => (
-              <Button key={g.id} title={g.label} onPress={() => onSelect(g.id)} />
+              <Button
+                key={g.id}
+                title={g.label}
+                onPress={() => onSelect(g.id)}
+                accessibilityLabel={`Korrektur ${g.label}`}
+              />
             ))}
           </View>
           <View style={styles.row}>
             {options.slice(2, 4).map((g) => (
-              <Button key={g.id} title={g.label} onPress={() => onSelect(g.id)} />
+              <Button
+                key={g.id}
+                title={g.label}
+                onPress={() => onSelect(g.id)}
+                accessibilityLabel={`Korrektur ${g.label}`}
+              />
             ))}
           </View>
           <View style={styles.row}>
-            <Button title="None of these" onPress={onAddNew} />
+            <Button
+              title="None of these"
+              onPress={onAddNew}
+              accessibilityLabel="Keine dieser Optionen"
+            />
           </View>
         </Animated.View>
       </View>

--- a/app/src/components/SymbolVideoPlayer.tsx
+++ b/app/src/components/SymbolVideoPlayer.tsx
@@ -29,6 +29,7 @@ export default function SymbolVideoPlayer({ entry, paused, useDgs, onEnd }: Symb
       useNativeControls
       resizeMode="contain"
       style={{ width: 300, height: 200 }}
+      accessibilityLabel={`Video ${entry.label}`}
     />
   );
 }

--- a/app/src/screens/DashboardScreen.tsx
+++ b/app/src/screens/DashboardScreen.tsx
@@ -40,7 +40,11 @@ export default function DashboardScreen({ navigation }: any) {
       ) : (
         <Text style={styles.label}>No data</Text>
       )}
-      <Button title="Back" onPress={() => navigation.goBack()} />
+      <Button
+        title="Back"
+        onPress={() => navigation.goBack()}
+        accessibilityLabel="Zurück"
+      />
     </View>
   );
 }

--- a/app/src/screens/LearningScreen.tsx
+++ b/app/src/screens/LearningScreen.tsx
@@ -154,7 +154,11 @@ const LearningScreen = ({ profile, vocabulary, navigation }: { profile: Profile,
           <Text style={styles.selectedSymbolLabel}>{selectedSymbol.name}</Text>
           <View style={styles.toggleContainer}>
             <Text>DGS Video anzeigen</Text>
-            <Switch value={showDgsVideo} onValueChange={setShowDgsVideo} />
+            <Switch
+              value={showDgsVideo}
+              onValueChange={setShowDgsVideo}
+              accessibilityLabel="DGS-Video anzeigen"
+            />
           </View>
           <SymbolVideoPlayer
             entry={{

--- a/app/src/screens/OnboardingScreen.tsx
+++ b/app/src/screens/OnboardingScreen.tsx
@@ -59,6 +59,7 @@ export default function OnboardingScreen({ navigation }: any) {
           value={consentDataUpload}
           onValueChange={setConsentDataUpload}
           style={styles.switch}
+          accessibilityLabel="Datenupload erlauben"
         />
       </View>
       <View style={styles.toggleRow}>
@@ -67,6 +68,7 @@ export default function OnboardingScreen({ navigation }: any) {
           value={consentHelpMeGetSmarter}
           onValueChange={setConsentHelpMeGetSmarter}
           style={styles.switch}
+          accessibilityLabel="Lernfunktion aktivieren"
         />
       </View>
       <View style={styles.toggleRow}>
@@ -75,6 +77,7 @@ export default function OnboardingScreen({ navigation }: any) {
           value={largeText}
           onValueChange={setLargeText}
           style={styles.switch}
+          accessibilityLabel="Große Schrift"
         />
       </View>
       <View style={styles.toggleRow}>
@@ -83,6 +86,7 @@ export default function OnboardingScreen({ navigation }: any) {
           value={highContrast}
           onValueChange={setHighContrast}
           style={styles.switch}
+          accessibilityLabel="Hoher Kontrast"
         />
       </View>
       <View style={styles.setRow}>
@@ -92,10 +96,15 @@ export default function OnboardingScreen({ navigation }: any) {
             title={s.label}
             onPress={() => setVocabSet(s.id)}
             color={vocabSet === s.id ? '#007aff' : undefined}
+            accessibilityLabel={`Vokabular ${s.label} auswählen`}
           />
         ))}
       </View>
-      <Button title="Continue" onPress={handleContinue} />
+      <Button
+        title="Continue"
+        onPress={handleContinue}
+        accessibilityLabel="Einrichtung abschließen"
+      />
     </SafeAreaView>
   );
 }

--- a/app/src/screens/ParentScreen.tsx
+++ b/app/src/screens/ParentScreen.tsx
@@ -10,9 +10,17 @@ export default function ParentScreen({ navigation }: any) {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Parent Screen</Text>
-      <Button title="Learning" onPress={() => navigation.navigate('Learning')} />
-      <Button title="Recognition" onPress={() => navigation.navigate('Recognition')} />
-      <Button title="Back" onPress={() => navigation.goBack()} />
+      <Button
+        title="Learning"
+        onPress={() => navigation.navigate('Learning')}
+        accessibilityLabel="Zum Lernmodus"
+      />
+      <Button
+        title="Recognition"
+        onPress={() => navigation.navigate('Recognition')}
+        accessibilityLabel="Zum Erkennungsmodus"
+      />
+      <Button title="Back" onPress={() => navigation.goBack()} accessibilityLabel="Zurück" />
     </View>
   );
 }

--- a/app/src/screens/ProfileSelectScreen.tsx
+++ b/app/src/screens/ProfileSelectScreen.tsx
@@ -16,9 +16,21 @@ export default function ProfileSelectScreen({ navigation }: any) {
     <View style={styles.container}>
       <Text style={styles.title}>Select Profile</Text>
       <View style={styles.row}>
-        <Button title="Parent" onPress={() => navigation.navigate('Parent')} />
-        <Button title="Admin" onPress={() => navigation.navigate('Admin')} />
-        <Button title="Neues Profil" onPress={() => navigation.navigate('Onboarding')} />
+        <Button
+          title="Parent"
+          onPress={() => navigation.navigate('Parent')}
+          accessibilityLabel="Elternprofil"
+        />
+        <Button
+          title="Admin"
+          onPress={() => navigation.navigate('Admin')}
+          accessibilityLabel="Adminbereich"
+        />
+        <Button
+          title="Neues Profil"
+          onPress={() => navigation.navigate('Onboarding')}
+          accessibilityLabel="Neues Profil anlegen"
+        />
       </View>
     </View>
   );

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -131,12 +131,28 @@ export default function RecognitionScreen({ navigation }: any) {
       )}
       <View style={styles.toggleRow}>
         <Text style={styles.suggestion}>Use DGS Video</Text>
-        <Switch value={useDgs} onValueChange={setUseDgs} />
+        <Switch
+          value={useDgs}
+          onValueChange={setUseDgs}
+          accessibilityLabel="DGS-Video verwenden"
+        />
       </View>
-      <Button title="Simulate recognition" onPress={handleRecognize} />
-      <Button title="Simulate low confidence" onPress={handleLowConfidence} />
+      <Button
+        title="Simulate recognition"
+        onPress={handleRecognize}
+        accessibilityLabel="Erkennung simulieren"
+      />
+      <Button
+        title="Simulate low confidence"
+        onPress={handleLowConfidence}
+        accessibilityLabel="Niedrige Sicherheit simulieren"
+      />
       {lastLabel && (
-        <Button title="Play video" onPress={handlePlayVideo} />
+        <Button
+          title="Play video"
+          onPress={handlePlayVideo}
+          accessibilityLabel="Video abspielen"
+        />
       )}
       <CorrectionPanel
         visible={showCorrection}
@@ -144,7 +160,11 @@ export default function RecognitionScreen({ navigation }: any) {
         onClose={() => setShowCorrection(false)}
         onAddNew={handleAddNew}
       />
-      <Button title="Analytics" onPress={() => navigation.navigate('Dashboard')} />
+      <Button
+        title="Analytics"
+        onPress={() => navigation.navigate('Dashboard')}
+        accessibilityLabel="Zur Statistik"
+      />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary
- add accessibility labels to onboarding switches and vocabulary buttons
- improve accessibility on recognition, parent, profile, and dashboard screens
- label correction panel buttons and symbol video players
- label DGS video toggle in learning screen

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879710da5d08322a0f87d5b56180ff3