### PR TITLE
Implement provider and lint configs

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -5,5 +5,6 @@ module.exports = {
     'prettier/prettier': ['error', { endOfLine: 'auto' }],
     'react/react-in-jsx-scope': 'off',
     'react/jsx-uses-react': 'off',
+    'react-hooks/exhaustive-deps': 'warn',
   },
 };

--- a/app/.prettierrc.js
+++ b/app/.prettierrc.js
@@ -5,4 +5,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
   endOfLine: 'auto',
+  printWidth: 100,
 };

--- a/app/context/AppServicesProvider.tsx
+++ b/app/context/AppServicesProvider.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useEffect, ReactNode } from
 import { mlService } from '../src/services/mlService';
 import { audioService } from '../src/services/audioService';
 import { adaptiveLearningService } from '../src/services/adaptiveLearningService';
+import { ActivityIndicator, View } from 'react-native';
 
 interface Services {
   mlService: typeof mlService;
@@ -37,14 +38,14 @@ export const AppServicesProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   if (!areServicesReady) {
-    return null;
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
   }
 
   const services = { mlService, audioService, adaptiveLearningService };
 
-  return (
-    <ServicesContext.Provider value={services}>
-      {children}
-    </ServicesContext.Provider>
-  );
+  return <ServicesContext.Provider value={services}>{children}</ServicesContext.Provider>;
 };

--- a/app/package.json
+++ b/app/package.json
@@ -8,8 +8,8 @@
     "ios": "react-native run-ios",
     "android": "react-native run-android",
     "web": "expo start --web",
-    "lint": "eslint .",
-    "format": "prettier --write .",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -37,6 +37,9 @@
     "lint-staged": "latest"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"]
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- update ESLint and Prettier configs
- update scripts to run linter/formatter
- show a loading indicator while services initialize

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'metro-react-native-babel-preset')*


------
https://chatgpt.com/codex/tasks/task_e_6879f00d3fb08322a0659d3fc360439f