### PR TITLE
Implement OpenAI client in dialog engine

### DIFF
--- a/app/src/screens/AdminScreen.tsx
+++ b/app/src/screens/AdminScreen.tsx
@@ -12,6 +12,8 @@ import { Alert } from 'react-native';
 import {
   loadOpenAIApiKey,
   saveOpenAIApiKey,
+  loadBackendApiToken,
+  saveBackendApiToken,
   saveCustomModelUri,
 } from '../storage';
 import * as FileSystem from 'expo-file-system';
@@ -25,6 +27,7 @@ export default function AdminScreen({ navigation }: any) {
   const [id, setId] = useState('');
   const [modalVisible, setModalVisible] = useState(false);
   const [apiKey, setApiKey] = useState('');
+  const [backendToken, setBackendToken] = useState('');
 
   React.useEffect(() => {
     const sub = database
@@ -34,6 +37,9 @@ export default function AdminScreen({ navigation }: any) {
       .subscribe(setSymbols);
     loadOpenAIApiKey().then((k) => {
       if (k) setApiKey(k);
+    });
+    loadBackendApiToken().then((t) => {
+      if (t) setBackendToken(t);
     });
     return () => sub.unsubscribe();
   }, []);
@@ -83,13 +89,18 @@ export default function AdminScreen({ navigation }: any) {
     await saveOpenAIApiKey(apiKey);
   };
 
+  const handleSaveBackendToken = async () => {
+    await saveBackendApiToken(backendToken);
+  };
+
   const handleDownloadModel = async () => {
     try {
       const uri = FileSystem.documentDirectory + 'custom_model.tflite';
+      const token = await loadBackendApiToken();
       const res = await FileSystem.downloadAsync(
         'http://localhost:5000/latest-model',
         uri,
-        { headers: { Authorization: 'Bearer secret' } },
+        { headers: { Authorization: `Bearer ${token || ''}` } },
       );
       await saveCustomModelUri(res.uri);
       Alert.alert('Model downloaded');
@@ -155,6 +166,18 @@ export default function AdminScreen({ navigation }: any) {
         title="Save API Key"
         onPress={handleSaveApiKey}
         accessibilityLabel="OpenAI API-Schlüssel speichern"
+      />
+      <TextInput
+        style={styles.apiInput}
+        placeholder="Backend API Token"
+        value={backendToken}
+        onChangeText={setBackendToken}
+        accessibilityLabel="Backend API Token"
+      />
+      <Button
+        title="Save Backend Token"
+        onPress={handleSaveBackendToken}
+        accessibilityLabel="Backend-Token speichern"
       />
       <Button
         title="Download Latest Model"

--- a/app/src/storage.ts
+++ b/app/src/storage.ts
@@ -94,6 +94,15 @@ export async function loadOpenAIApiKey(): Promise<string | null> {
   return SecureStore.getItemAsync(API_KEY);
 }
 
+const BACKEND_TOKEN_KEY = 'backendApiToken';
+export async function saveBackendApiToken(token: string): Promise<void> {
+  await SecureStore.setItemAsync(BACKEND_TOKEN_KEY, token);
+}
+
+export async function loadBackendApiToken(): Promise<string | null> {
+  return SecureStore.getItemAsync(BACKEND_TOKEN_KEY);
+}
+
 const CUSTOM_MODEL_KEY = 'customModelUri';
 
 export async function saveCustomModelUri(uri: string): Promise<void> {


### PR DESCRIPTION
## Summary
- integrate OpenAI API directly in `dialogEngine`
- store backend token alongside API key
- use backend token when downloading personalized models
- expose UI fields for both tokens in Admin screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b6746e7088322a54f9981354413c6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support in the admin interface for storing, displaying, and managing a backend API token.
  * Introduced a new input field and save button for the backend API token in the admin screen.

* **Improvements**
  * Model downloads now use the saved backend API token for authorization.
  * Suggestions are now fetched directly from the OpenAI API using the stored API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->