### PR TITLE
Implement gesture training DB storage

### DIFF
--- a/app/src/storage.ts
+++ b/app/src/storage.ts
@@ -1,5 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
+import { database } from '../db';
+import { GestureTrainingData } from '../db/models';
 
 export interface Profile {
   id: string;
@@ -83,6 +85,18 @@ export async function saveTrainingSample(
     syncStatus: 'pending',
   });
   await AsyncStorage.setItem(TRAINING_KEY, JSON.stringify(data));
+
+  const collection = database.get<GestureTrainingData>('gesture_training_data');
+  await database.write(async () => {
+    await collection.create((record) => {
+      record.gestureDefinition.id = gestureDefinitionId;
+      record.landmarkData = JSON.stringify(landmarkData);
+      record.source = 'HIP_2';
+      record.qualityScore = 1;
+      record.frameMetadata = '';
+      record.createdAt = new Date();
+    });
+  });
 }
 
 const API_KEY = 'openaiApiKey';


### PR DESCRIPTION
## Summary
- store training samples in WatermelonDB instead of only AsyncStorage

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b9c3e735c83229a3e518ab8a2f0ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training samples are now saved both locally and in a database, improving data persistence and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->