### PR TITLE
Implement dynamic gesture map

### DIFF
--- a/app/assets/models/gesture_map.json
+++ b/app/assets/models/gesture_map.json
@@ -1,0 +1,6 @@
+{
+  "OPEN_PALM": "Trinken",
+  "CLOSED_FIST": "Essen",
+  "POINT_UP": "Spielen",
+  "THUMB_UP": "Spielen"
+}

--- a/app/src/components/gestureMap.ts
+++ b/app/src/components/gestureMap.ts
@@ -1,9 +1,18 @@
-const gestureToSymbol: Record<string, string> = {
-  trinken: 'Trinken',
-  essen: 'Essen',
-  spielen: 'Spielen',
-};
+// Mapping of model gesture labels to symbol names. This acts as a fallback
+// when no matching symbol is found in the current vocabulary.
+// LLM Hint: Keeping this data in JSON allows the mapping to be updated
+// without touching the TypeScript code.
+const staticMap: Record<string, string> = require('../assets/models/gesture_map.json');
 
-export function getSymbolLabelForGesture(gesture: string): string | undefined {
-  return gestureToSymbol[gesture];
+export function getSymbolLabelForGesture(
+  gesture: string,
+  vocabulary?: { name: string }[],
+): string | undefined {
+  if (vocabulary) {
+    const match = vocabulary.find(
+      (s) => s.name.toLowerCase() === gesture.toLowerCase(),
+    );
+    if (match) return match.name;
+  }
+  return staticMap[gesture];
 }

--- a/app/src/screens/LearningScreen.tsx
+++ b/app/src/screens/LearningScreen.tsx
@@ -88,7 +88,7 @@ const LearningScreen = ({ profile, vocabulary, navigation }: { profile: Profile,
 
   const frameProcessor = mlService.classifyGesture((result) => {
     if (result && result.confidence > 0.85 && result.label !== lastGesture) {
-      const recognizedSymbolLabel = getSymbolLabelForGesture(result.label);
+      const recognizedSymbolLabel = getSymbolLabelForGesture(result.label, vocabulary);
       const foundSymbol = vocabulary.find(s => s.name === recognizedSymbolLabel);
       if (foundSymbol) {
         handlePress(foundSymbol);


### PR DESCRIPTION
## Summary
- allow mapping of new gesture labels to existing symbols via JSON config
- use vocabulary-aware fallback in gesture mapping helper
- pass vocabulary when decoding gestures in `LearningScreen`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bf2798ee483228d97c7748bd64725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading gesture-to-action mappings from an external resource, enabling dynamic updates to gesture labels.
* **Improvements**
  * Enhanced gesture recognition to prioritize custom vocabulary when matching gesture labels, providing more flexible and context-aware action names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->