### PR TITLE
Add missing logger tests and fix mlService unit test

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,8 @@
     "web": "expo start --web",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "npx ts-node test/run-tests.ts"
   },
   "dependencies": {
     "@nozbe/watermelondb": "^0.24.0",

--- a/app/src/utils/logger.ts
+++ b/app/src/utils/logger.ts
@@ -5,8 +5,11 @@ enum LogLevel {
   ERROR = 3,
 }
 
+declare const __DEV__: boolean | undefined;
+const isDev: boolean = typeof __DEV__ !== 'undefined' ? __DEV__ : false;
+
 class Logger {
-  private level: LogLevel = __DEV__ ? LogLevel.DEBUG : LogLevel.INFO;
+  private level: LogLevel = isDev ? LogLevel.DEBUG : LogLevel.INFO;
 
   debug(message: string, ...args: any[]): void {
     if (this.level <= LogLevel.DEBUG) {

--- a/app/test/logger.test.ts
+++ b/app/test/logger.test.ts
@@ -1,0 +1,23 @@
+import { logger, LogLevel } from '../src/utils/logger';
+
+(async () => {
+  let captured = '';
+  const orig = console.log;
+  console.log = (msg?: any, ...args: any[]) => {
+    captured += String(msg);
+  };
+
+  logger.setLevel(LogLevel.INFO);
+  logger.debug('secret');
+  if (captured.includes('secret')) {
+    throw new Error('Debug log should not appear when level INFO');
+  }
+
+  logger.setLevel(LogLevel.DEBUG);
+  logger.debug('hello');
+  console.log = orig;
+  if (!captured.includes('[DEBUG] hello')) {
+    throw new Error('Debug log missing when level DEBUG');
+  }
+  console.log('logger test ok');
+})();

--- a/app/test/mlService.test.ts
+++ b/app/test/mlService.test.ts
@@ -1,16 +1,13 @@
-import { mlService } from '../src/services';
+import { mlService } from '../src/services/mlService';
 
-describe('MachineLearningService', () => {
-  it('should load models successfully', async () => {
-    // @ts-ignore
-    const landmarkTflite: TfliteModel = {
-      runSync: () => [[1, 2, 3]],
-    };
-    // @ts-ignore
-    const gestureTflite: TfliteModel = {
-      runSync: () => [[0.1, 0.9]],
-    };
-    await mlService.loadModels(landmarkTflite, gestureTflite);
-    expect(mlService.isServiceReady()).toBe(true);
-  });
-});
+(async () => {
+  // @ts-ignore
+  const landmarkTflite: any = { runSync: () => [[1, 2, 3]] };
+  // @ts-ignore
+  const gestureTflite: any = { runSync: () => [[0.1, 0.9]] };
+  await mlService.loadModels(landmarkTflite, gestureTflite);
+  if (!mlService.isServiceReady()) {
+    throw new Error('mlService did not initialize');
+  }
+  console.log('mlService ready');
+})();

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -1,0 +1,11 @@
+import { readdirSync } from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const testDir = __dirname;
+const tests = readdirSync(testDir).filter(f => f.endsWith('.test.ts'));
+for (const file of tests) {
+  if (file === 'run-tests.ts') continue;
+  console.log('Running', file);
+  execSync(`npx ts-node ${path.join(testDir, file)}`, { stdio: 'inherit' });
+}


### PR DESCRIPTION
## Summary
- create a simple test runner and hook it up to `npm test`
- convert `mlService.test.ts` to standalone execution
- add a new test for the logger utility
- make logger usable outside React Native by checking `__DEV__`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c8740b9888322936f37ed78e62c35