### PR TITLE
Add offline model test and fix ts-node dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -52,7 +52,8 @@
     "ts-jest": "^29.0.0",
     "typescript": "^5.3.3",
     "react-native-worklets-core": "^0.2.0",
-    "metro-react-native-babel-preset": "^0.76.0"
+    "metro-react-native-babel-preset": "^0.76.0",
+    "ts-node": "^10.9.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/app/test/recognizerOffline.test.ts
+++ b/app/test/recognizerOffline.test.ts
@@ -1,0 +1,12 @@
+import path from 'path';
+
+(async () => {
+  process.env.OFFLINE_MODEL_PATH = path.join(__dirname, '../../server/src/offlineModel.json');
+  delete require.cache[require.resolve('../../server/src/recognizer')];
+  const { classifyGesture } = require('../../server/src/recognizer');
+  const result = await classifyGesture([0,0]);
+  if (result.label !== 'g1' || result.processedBy !== 'local') {
+    throw new Error('offline model classification failed');
+  }
+  console.log('offline model ok');
+})();


### PR DESCRIPTION
## Summary
- include `ts-node` in dev dependencies so tests run without prompts
- add a test covering offline model classification in `recognizer`
- run the test suite to ensure everything works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c8e17f308832290bcf6b9d2b3b139