### PR TITLE
test: add python suite and document both

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,13 @@ Amy's Echo is a multimodal, offline-first communication platform for non-verbal 
 -   `app/src/screens`: Main UI screen components.
 -   `app/src/services`: Business logic and external API clients.
 -   `app/src/components`: Reusable UI components.
--   `app/test/`: App Test files.
+-   `app/test/`: Test files for both the mobile app and backend modules.
+
+-   `server/test/`: Python tests for the training pipeline.
 
 -   `server/`: Backend server code.
 -   `server/src/services`: Backend service logic.
 -   `server/src/tools`: Scripts for tasks like model downloading and retraining.
--   `server/test/`: Backend Test files.
 
 -   `spec/`: Project specification.
 -   `docs/`: Project documentation.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -38,12 +38,13 @@ Amy's Echo is a multimodal, offline-first communication platform for non-verbal 
 -   `app/src/screens`: Main UI screen components.
 -   `app/src/services`: Business logic and external API clients.
 -   `app/src/components`: Reusable UI components.
--   `app/test/`: App Test files.
+-   `app/test/`: Test files for both the mobile app and backend modules.
+
+-   `server/test/`: Python tests for the training pipeline.
 
 -   `server/`: Backend server code.
 -   `server/src/services`: Backend service logic.
 -   `server/src/tools`: Scripts for tasks like model downloading and retraining.
--   `server/test/`: Backend Test files.
 
 -   `spec/`: Project specification.
 -   `docs/`: Project documentation.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ This is not a demo or experiment. It’s a production-grade, full-stack project 
 2. `cd app` – open the app code
 3. `npm install` - install mobile app deps
 4. `npm test` – run the Node test suite
-5. Inside `app`, run `npm run ios` or `npm run android` to launch the app
+   - Tests live in `app/test/` and cover both server and app modules.
+5. `cd ../server && npm install && npm test` – run Python training tests
+   - These tests live in `server/test/` and require Python with `numpy` and `pytest`.
+6. Inside `app`, run `npm run ios` or `npm run android` to launch the app
 
 ---
 

--- a/server/package.json
+++ b/server/package.json
@@ -11,5 +11,8 @@
     "express": "^4.18.4",
     "node-fetch": "^3.3.2",
     "typescript": "^5.8.3"
+  },
+  "scripts": {
+    "test": "pytest -q"
   }
 }

--- a/server/test/test_train.py
+++ b/server/test/test_train.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import types
+
+# Stub tensorflow so load_samples can be imported without heavy deps
+sys.modules['tensorflow'] = types.ModuleType('tensorflow')
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+from train import load_samples
+
+
+def test_load_samples_shapes():
+    sample = {'landmarkData': list(range(63)), 'gestureDefinitionId': 'wave'}
+    X, y, label_map = load_samples([sample])
+    assert X.shape == (1, 30, 63)
+    assert y.tolist() == [0]
+    assert label_map == {'wave': 0}
+
+
+def test_load_samples_multiple_labels():
+    samples = [
+        {'landmarkData': list(range(63)), 'gestureDefinitionId': 'a'},
+        {'landmarkData': list(range(63)), 'gestureDefinitionId': 'b'},
+    ]
+    X, y, label_map = load_samples(samples)
+    assert len(label_map) == 2
+    assert X.shape == (2, 30, 63)
+


### PR DESCRIPTION
## Summary
- restore `server/test` directory for python tests
- write a basic `load_samples` unit test
- document both Node and Python test suites

## Testing
- `npm test` in `app`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_687cb29dfbdc832286c2c988227d0c2d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and expanded descriptions of test directories in project documentation.
  * Updated setup instructions to include steps for running backend Python tests and clarified test locations.
* **Chores**
  * Added a test script to the backend server for running Python tests.
* **Tests**
  * Introduced new tests to validate backend training pipeline functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->