### PR TITLE
Add usage tracker and dialog service tests

### DIFF
--- a/app/test/dialogServiceApp.test.ts
+++ b/app/test/dialogServiceApp.test.ts
@@ -1,0 +1,16 @@
+import Module from 'module';
+const requireFn = Module.createRequire(__filename);
+(requireFn.cache as any)[requireFn.resolve('../src/storage')] = { exports: { loadOpenAIApiKey: async () => null } };
+const { getLLMSuggestions } = require('../src/services/dialogService');
+
+(async () => {
+  const res = await getLLMSuggestions('hello');
+  if (res.nextWords[0] !== 'Hi!' || !res.caregiverPhrases[0].includes('Ask')) {
+    throw new Error('fallback hello failed');
+  }
+  const res2 = await getLLMSuggestions('drink');
+  if (!res2.caregiverPhrases[0].includes('Try repeating drink')) {
+    throw new Error('default fallback failed');
+  }
+  console.log('dialog service ok');
+})();

--- a/app/test/recordInteraction.test.ts
+++ b/app/test/recordInteraction.test.ts
@@ -1,0 +1,21 @@
+import Module from 'module';
+const requireFn = Module.createRequire(__filename);
+const store: Record<string, string> = {};
+const AsyncStorage = {
+  async getItem(k: string) { return store[k] ?? null; },
+  async setItem(k: string, v: string) { store[k] = v; }
+};
+(requireFn.cache as any)[requireFn.resolve('@react-native-async-storage/async-storage')] = { exports: { default: AsyncStorage, ...AsyncStorage } };
+
+const { recordInteraction } = require('../src/services/adaptiveLearningService');
+
+(async () => {
+  let trigger = await recordInteraction('g1', true);
+  if (trigger) throw new Error('triggered on success');
+  for (let i = 0; i < 7; i++) await recordInteraction('g1', false);
+  trigger = await recordInteraction('g1', false);
+  if (!trigger) throw new Error('should trigger at low score');
+  const scores = JSON.parse(store['gestureHealthScores']);
+  if (scores['g1'] >= 70) throw new Error('score not lowered');
+  console.log('record interaction ok');
+})();

--- a/app/test/usageTracker.test.ts
+++ b/app/test/usageTracker.test.ts
@@ -1,0 +1,23 @@
+import Module from 'module';
+const requireFn = Module.createRequire(__filename);
+const store: Record<string, string> = {};
+const AsyncStorage = {
+  async getItem(key: string) { return store[key] ?? null; },
+  async setItem(key: string, value: string) { store[key] = value; }
+};
+(requireFn.cache as any)[requireFn.resolve('@react-native-async-storage/async-storage')] = { exports: { default: AsyncStorage, ...AsyncStorage } };
+
+const { incrementUsage, loadUsageStats } = require('../src/services/usageTracker');
+
+(async () => {
+  const entry = { id: 'wave', label: 'Wave' };
+  await incrementUsage(entry, 'p1');
+  await incrementUsage(entry, 'p1');
+  await incrementUsage(entry, 'p2');
+  const stats1 = await loadUsageStats('p1');
+  const stats2 = await loadUsageStats('p2');
+  if (stats1.wave !== 2 || stats2.wave !== 1) {
+    throw new Error('usage stats incorrect');
+  }
+  console.log('usage tracker ok');
+})();


### PR DESCRIPTION
## Summary
- expand test coverage for client code
- test dialog service fallback suggestions
- test adaptive learning recordInteraction logic
- test usage tracking with AsyncStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cfa290ba4832297a0eb84732e0c09