### PR TITLE
Add tests for model update and training

### DIFF
--- a/app/src/services/modelUpdate.ts
+++ b/app/src/services/modelUpdate.ts
@@ -2,9 +2,9 @@ import * as FileSystem from 'expo-file-system';
 import NetInfo from '@react-native-community/netinfo';
 import { loadBackendApiToken, saveCustomModelUri } from '../storage';
 
-export async function checkForModelUpdate(): Promise<void> {
+export async function checkForModelUpdate(): Promise<boolean> {
   const net = await NetInfo.fetch();
-  if (!net.isConnected || net.type !== 'wifi') return;
+  if (!net.isConnected || net.type !== 'wifi') return false;
   try {
     const token = await loadBackendApiToken();
     const uri = FileSystem.documentDirectory + 'custom_model.tflite';
@@ -14,7 +14,9 @@ export async function checkForModelUpdate(): Promise<void> {
       { headers: { Authorization: `Bearer ${token || ''}` } }
     );
     await saveCustomModelUri(res.uri);
+    return true;
   } catch (e) {
     console.log('model update failed', e);
+    return false;
   }
 }

--- a/app/test/modelUpdate.test.ts
+++ b/app/test/modelUpdate.test.ts
@@ -1,0 +1,67 @@
+const Module = require('module');
+
+(async () => {
+  let saved = '';
+  const orig = (Module as any)._load;
+  (Module as any)._load = (req: string, parent: any, isMain: boolean) => {
+    if (req === 'expo-file-system') {
+      return {
+        documentDirectory: '/tmp/',
+        downloadAsync: async (_url: string, dest: string) => ({ uri: dest }),
+      };
+    }
+    if (req === '@react-native-community/netinfo') {
+      return { fetch: async () => ({ isConnected: true, type: 'wifi' }) };
+    }
+    if (req.includes('../storage')) {
+      return {
+        loadBackendApiToken: async () => 'token',
+        saveCustomModelUri: async (uri: string) => { saved = uri; },
+      };
+    }
+    return orig(req, parent, isMain);
+  };
+
+  delete require.cache[require.resolve('../src/services/modelUpdate')];
+  const { checkForModelUpdate } = require('../src/services/modelUpdate');
+  (Module as any)._load = orig;
+
+  const result = await checkForModelUpdate();
+  if (!result || saved !== '/tmp/custom_model.tflite') {
+    throw new Error('model update should succeed');
+  }
+  console.log('model update success');
+})();
+
+(async () => {
+  const orig = (Module as any)._load;
+  let called = false;
+  (Module as any)._load = (req: string, parent: any, isMain: boolean) => {
+    if (req === 'expo-file-system') {
+      return {
+        documentDirectory: '/tmp/',
+        downloadAsync: async () => { called = true; return { uri: '/tmp/f' }; },
+      };
+    }
+    if (req === '@react-native-community/netinfo') {
+      return { fetch: async () => ({ isConnected: true, type: 'cellular' }) };
+    }
+    if (req.includes('../storage')) {
+      return {
+        loadBackendApiToken: async () => 'token',
+        saveCustomModelUri: async () => {},
+      };
+    }
+    return orig(req, parent, isMain);
+  };
+
+  delete require.cache[require.resolve('../src/services/modelUpdate')];
+  const { checkForModelUpdate } = require('../src/services/modelUpdate');
+  (Module as any)._load = orig;
+
+  const result = await checkForModelUpdate();
+  if (result || called) {
+    throw new Error('should skip update when not on wifi');
+  }
+  console.log('model update wifi skip');
+})();

--- a/server/test/test_train.py
+++ b/server/test/test_train.py
@@ -26,3 +26,36 @@ def test_load_samples_multiple_labels():
     assert len(label_map) == 2
     assert X.shape == (2, 30, 63)
 
+
+def test_load_samples_empty():
+    try:
+        load_samples([])
+    except ValueError:
+        assert True
+    else:
+        assert False
+
+
+def test_load_samples_padding_and_truncation():
+    long_seq = list(range(63 * 40))
+    short_seq = list(range(63 * 5))
+    samples = [
+        {'landmarkData': long_seq, 'gestureDefinitionId': 'long'},
+        {'landmarkData': short_seq, 'gestureDefinitionId': 'short'},
+    ]
+    X, y, label_map = load_samples(samples)
+    assert X.shape == (2, 30, 63)
+    assert label_map == {'long': 0, 'short': 1}
+    # second sample should be padded with zeros after frame 5
+    assert (X[1, 5:] == 0).all()
+
+def test_load_samples_ignore_invalid():
+    samples = [
+        {'landmarkData': None, 'gestureDefinitionId': 'bad'},
+        {'gestureDefinitionId': 'missing'},
+        {'landmarkData': list(range(63)), 'gestureDefinitionId': 'ok'},
+    ]
+    X, y, label_map = load_samples(samples)
+    assert X.shape == (1, 30, 63)
+    assert y.tolist() == [0]
+    assert label_map == {'ok': 0}


### PR DESCRIPTION
## Summary
- extend model update service with tests
- add coverage for padding and invalid samples in `load_samples`

## Testing
- `./scripts/full-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687e47c59aac83228b92dde3359d79d5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of model updates by providing clear success or failure feedback when checking for updates.

* **Tests**
  * Added new tests to verify model update behavior under different network conditions.
  * Expanded test coverage for data loading, including edge cases for empty input, variable sequence lengths, and invalid data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->