### PR TITLE
Fix npm install warning and run checks

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,6 @@
     "web": "expo start --web",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "prepare": "husky install",
     "test": "npx ts-node test/run-tests.ts",
     "type-check": "tsc --noEmit --project tsconfig.json",
     "build:android": "eas build --platform android --profile production --non-interactive",


### PR DESCRIPTION
## Summary
- remove obsolete `husky` prepare script so npm install succeeds without warnings
- run `npm install`, type checks, and tests for app and server

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `./scripts/full-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687f8fb2064c83228cfa865143304943