### PR TITLE
Add future roadmap tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [x] **Automate Offline Model Updates**: Regularly download newly trained personalized models and refresh the local classifier.
 - [x] **Log Caregiver Corrections**: Misidentified gestures are saved in the new `corrections` table for future training.
 - [x] **Background Sync Service**: Unsynced corrections are uploaded and model updates are checked on app launch.
+### Priority 6: Future Enhancements
+- [ ] **Multi-Profile Management**: Allow caregivers to add and switch between profiles.
+- [ ] **Expanded Analytics Dashboard**: Graph learning progress and sync data to the server.
+- [ ] **Caregiver Web Portal**: Web interface for managing training data and personalized models.
+- [ ] **Custom Audio Recording**: Record personalized voice prompts for each symbol.
+
 
 ## ▶️ Running the mobile app
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -108,3 +108,31 @@ This document provides a detailed, actionable checklist for implementing the cor
 * **Objective**: Allow caregivers to teach the system new gestures directly on the device.
 * **File**: `src/screens/TeachingScreen.tsx`
 * **Status**: Completed.
+
+---
+
+## **Part 5: Future Enhancements**
+
+### **TODO 5.1: Implement Multi-Profile Management**
+
+* **Objective**: Support multiple child profiles with separate preferences and vocabulary sets.
+* **File**: `src/screens/ProfileManagerScreen.tsx`, `db/models.ts`
+* **Status**: Planned.
+
+### **TODO 5.2: Expand Analytics Dashboard**
+
+* **Objective**: Visualize learning trends and sync analytics to the server for caregiver review.
+* **File**: `src/screens/DashboardScreen.tsx`, `server/src/services/analyticsService.ts`
+* **Status**: Planned.
+
+### **TODO 5.3: Build Caregiver Web Portal**
+
+* **Objective**: Provide a web interface to manage training data, view analytics, and download personalized models.
+* **File**: `server/src/portal/`
+* **Status**: Planned.
+
+### **TODO 5.4: Add Custom Audio Recording**
+
+* **Objective**: Allow caregivers to record personalized audio cues for each symbol.
+* **File**: `src/screens/AdminScreen.tsx`, `src/services/audioService.ts`
+* **Status**: Planned.


### PR DESCRIPTION
## Summary
- outline upcoming tasks in `docs/TODO.md`
- list future enhancement items in README

## Testing
- `./scripts/full-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fc9bf98948322bdb7015aa8759a85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section outlining planned future enhancements, including multi-profile management, an expanded analytics dashboard, a caregiver web portal, and custom audio recording features. These enhancements are listed as upcoming tasks in both the README and TODO documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->