### PR TITLE
Enable custom audio recordings

### DIFF
--- a/app/db/models.ts
+++ b/app/db/models.ts
@@ -24,6 +24,7 @@ export class Symbol extends Model {
   @text('icon_name') iconName!: string;
   @text('video_asset_path') videoAssetPath?: string;
   @text('dgs_video_asset_path') dgsVideoAssetPath?: string;
+  @text('audio_uri') audioUri?: string;
   @text('category') category!: string;
   @field('priority') priority!: number;
   @field('is_active') isActive!: boolean;

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -1,7 +1,7 @@
 import { appSchema, tableSchema } from '@nozbe/watermelondb';
 
 export const mySchema = appSchema({
-  version: 6,
+  version: 7,
   tables: [
     tableSchema({
       name: 'profiles',
@@ -23,6 +23,7 @@ export const mySchema = appSchema({
         { name: 'icon_name', type: 'string' },
         { name: 'video_asset_path', type: 'string', isOptional: true },
         { name: 'dgs_video_asset_path', type: 'string', isOptional: true },
+        { name: 'audio_uri', type: 'string', isOptional: true },
         { name: 'category', type: 'string', isIndexed: true },
         { name: 'priority', type: 'number' },
         { name: 'is_active', type: 'boolean' },

--- a/app/src/constants/audioPaths.ts
+++ b/app/src/constants/audioPaths.ts
@@ -1,0 +1,7 @@
+import * as FileSystem from 'expo-file-system';
+
+export const CUSTOM_AUDIO_DIR = FileSystem.documentDirectory + 'custom_audio/';
+
+export function getCustomAudioPath(symbolId: string): string {
+  return CUSTOM_AUDIO_DIR + `${symbolId}.m4a`;
+}

--- a/app/src/model.ts
+++ b/app/src/model.ts
@@ -8,6 +8,8 @@ export type GestureModelEntry = {
   videoUri?: string;
   /** Optional path to a DGS video */
   dgsVideoUri?: string;
+  /** Optional path to a default audio cue */
+  audioUri?: string;
 };
 
 export type GestureModel = {

--- a/app/src/screens/LearningScreen.tsx
+++ b/app/src/screens/LearningScreen.tsx
@@ -70,7 +70,7 @@ const LearningScreen = ({ profile, vocabulary, navigation }: { profile: Profile,
   const handlePress = async (symbol: Symbol) => {
     setSelectedSymbol(symbol);
     setVideoPaused(false);
-    await playSymbolAudio({ id: symbol.id, label: symbol.name });
+    await playSymbolAudio({ id: symbol.id, label: symbol.name, audioUri: (symbol as any).audioUri });
     await incrementUsage(symbol, profile.id);
     const trigger = await recordInteraction(symbol.id, true);
     if (trigger) setShowMaintenance(true);

--- a/app/src/services/audioService.ts
+++ b/app/src/services/audioService.ts
@@ -3,6 +3,8 @@ import * as Speech from 'expo-speech';
 import {logger} from '../utils/logger';
 import {AudioConfig, SoundEffect, SpeechOptions} from '../types/audio';
 import {InterruptionModeAndroid, InterruptionModeIOS} from "expo-av/src/Audio.types";
+import { database } from '../../db';
+import { Symbol } from '../../db/models';
 
 export class AudioService {
   private sounds: Map<string, Audio.Sound> = new Map();
@@ -10,6 +12,7 @@ export class AudioService {
   private config: AudioConfig;
   private speechQueue: Array<{ text: string; options: SpeechOptions }> = [];
   private isSpeaking = false;
+  private recording: Audio.Recording | null = null;
 
   constructor(config: AudioConfig) {
     this.config = {...config};
@@ -234,6 +237,57 @@ export class AudioService {
   }
 
   /**
+   * Start audio recording for custom cues
+   */
+  async startRecording(): Promise<void> {
+    const permission = await Audio.requestPermissionsAsync();
+    if (!permission.granted) {
+      throw new Error('Audio permission not granted');
+    }
+    this.recording = new Audio.Recording();
+    await this.recording.prepareToRecordAsync(
+      Audio.RecordingOptionsPresets.HIGH_QUALITY,
+    );
+    await this.recording.startAsync();
+  }
+
+  /**
+   * Stop recording and return file URI
+   */
+  async stopRecording(): Promise<string | null> {
+    if (!this.recording) return null;
+    try {
+      await this.recording.stopAndUnloadAsync();
+      const uri = this.recording.getURI();
+      this.recording = null;
+      return uri ?? null;
+    } catch (err) {
+      this.recording = null;
+      throw err;
+    }
+  }
+
+  /**
+   * Play custom audio from a file URI
+   */
+  async playCustomAudio(uri: string): Promise<void> {
+    if (!this.isInitialized) {
+      logger.warn('Audio service not initialized');
+      return;
+    }
+    try {
+      const { sound } = await Audio.Sound.createAsync(
+        { uri },
+        { shouldPlay: true, volume: this.config.volume },
+      );
+      await sound.playAsync();
+      await sound.unloadAsync();
+    } catch (error) {
+      logger.error('Failed to play custom audio:', error);
+    }
+  }
+
+  /**
    * Update audio configuration
    */
   updateConfig(newConfig: Partial<AudioConfig>): void {
@@ -275,6 +329,19 @@ export const audioService = new AudioService({
  * This mirrors the playSymbolAudio function that was used in
  * some screens before the AudioService refactor.
  */
-export async function playSymbolAudio(entry: { id: string; label: string }): Promise<void> {
-  await audioService.speak(entry.label);
+
+export async function playSymbolAudio(entry: { id: string; label: string; audioUri?: string }): Promise<void> {
+  let uri = entry.audioUri;
+  if (!uri) {
+    try {
+      const symbol = await database.get<Symbol>('symbols').find(entry.id);
+      uri = (symbol as any).audioUri || undefined;
+    } catch {}
+  }
+
+  if (uri) {
+    await audioService.playCustomAudio(uri);
+  } else {
+    await audioService.speak(entry.label);
+  }
 }

--- a/server/src/portal/index.ts
+++ b/server/src/portal/index.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import { loadAnalyticsFromFile } from '../services/analyticsService';
+import { TRAINED_MODEL_PATH } from '../constants/modelPaths';
+import { promises as fs } from 'fs';
+
+const router = express.Router();
+
+router.get('/', (_req, res) => {
+  res.send(`
+    <h1>Amy's Echo Portal</h1>
+    <ul>
+      <li><a href="/portal/analytics">View Analytics</a></li>
+      <li><a href="/portal/download-model">Download Personalized Model</a></li>
+    </ul>
+  `);
+});
+
+router.get('/analytics', async (_req, res) => {
+  const analytics = await loadAnalyticsFromFile();
+  if (!analytics) {
+    res.status(404).send('No analytics available');
+    return;
+  }
+  res.send(`<pre>${JSON.stringify(analytics, null, 2)}</pre>`);
+});
+
+router.get('/download-model', async (_req, res) => {
+  try {
+    await fs.access(TRAINED_MODEL_PATH);
+    res.download(TRAINED_MODEL_PATH);
+  } catch {
+    res.status(404).send('Model not found');
+  }
+});
+
+export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,9 +7,11 @@ import {
   saveAnalyticsToFile,
   loadAnalyticsFromFile,
 } from './services/analyticsService';
+import portalRouter from './portal';
 
 const app = express();
 app.use(express.json());
+app.use('/portal', portalRouter);
 
 const API_TOKEN = process.env.API_TOKEN || 'secret';
 


### PR DESCRIPTION
## Summary
- allow storing custom audio files in `app/src/constants/audioPaths.ts`
- update AudioService with custom recording playback
- move recorded audio into persistent folder on save
- pass custom audio to playSymbolAudio in LearningScreen
- use DB to play audio if symbol has recording

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68801f66c9ac83229725736abface04b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to record and associate custom audio files with symbols in the Admin interface.
  * Symbols can now play custom audio cues during learning sessions if available.
  * Introduced a portal with web endpoints to view analytics and download personalized models.

* **Enhancements**
  * Improved audio service to support recording, saving, and playback of custom audio files for symbols.

* **Database**
  * Updated schema to include an optional audio URI field for symbols, enabling storage of custom audio paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->