### PR TITLE
Fix bundler error from missing gesture-handler

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -29,6 +29,7 @@
         "react": "19.0.0",
         "react-native": "0.79.5",
         "react-native-fast-tflite": "^1.6.1",
+        "react-native-gesture-handler": "^2.27.1",
         "react-native-permissions": "^5.4.1",
         "react-native-reanimated": "~3.17.4",
         "react-native-vision-camera": "^4.0.0"

--- a/app/package.json
+++ b/app/package.json
@@ -37,6 +37,7 @@
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-fast-tflite": "^1.6.1",
+    "react-native-gesture-handler": "^2.27.1",
     "react-native-permissions": "^5.4.1",
     "react-native-reanimated": "~3.17.4",
     "react-native-vision-camera": "^4.0.0"


### PR DESCRIPTION
## Summary
- include `react-native-gesture-handler` in app dependencies

## Testing
- `./scripts/full-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883b122fa088322a2040efce12fd94b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added "react-native-gesture-handler" as a new dependency to enhance gesture handling capabilities in the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->