### PR TITLE
Fix bundler config for tflite models

### DIFF
--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -1,0 +1,7 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.assetExts.push('tflite');
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- add metro config with `tflite` extension so Expo can bundle local models

## Testing
- `npm run type-check --prefix app` *(fails: Property 'syncUnsyncedData' does not exist)*
- `npm test --prefix app` *(fails: ts-node prompt)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_6887588380988322ab5d40f036acc913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for handling TensorFlow Lite (.tflite) model files in the app build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->