### PR TITLE
Add parental gate before admin/parent screens

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -9,6 +9,7 @@ import ProfileManagerScreen from './src/screens/ProfileManagerScreen';
 import RecognitionScreen from './src/screens/RecognitionScreen';
 import AdminScreen from './src/screens/AdminScreen';
 import ParentScreen from './src/screens/ParentScreen';
+import ParentalGateScreen from './src/screens/ParentalGateScreen';
 import LearningScreen from './src/screens/LearningScreen';
 import TeachingScreen from './src/screens/TeachingScreen';
 import TrainingScreen from './src/screens/TrainingScreen';
@@ -118,6 +119,11 @@ export default function App() {
             name="ProfileSelect"
             component={ProfileSelectScreen}
             options={{ title: 'Profil auswählen' }}
+          />
+          <Stack.Screen
+            name="ParentalGate"
+            component={ParentalGateScreen}
+            options={{ title: 'Zugangsprüfung' }}
           />
           <Stack.Screen
             name="ProfileManager"

--- a/app/src/screens/ParentalGateScreen.tsx
+++ b/app/src/screens/ParentalGateScreen.tsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+
+export default function ParentalGateScreen({ route, navigation }: any) {
+  const { target } = route.params as { target: string };
+  const [problem, setProblem] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [solution, setSolution] = useState<number>(0);
+
+  useEffect(() => {
+    const a = Math.floor(Math.random() * 10) + 2; // 2..11
+    const b = Math.floor(Math.random() * 10) + 2;
+    setProblem(`${a} × ${b} = ?`);
+    setSolution(a * b);
+  }, []);
+
+  const handleCheck = () => {
+    if (parseInt(answer, 10) === solution) {
+      navigation.replace(target);
+    } else {
+      setAnswer('');
+      const a = Math.floor(Math.random() * 10) + 2;
+      const b = Math.floor(Math.random() * 10) + 2;
+      setProblem(`${a} × ${b} = ?`);
+      setSolution(a * b);
+    }
+  };
+
+  const styles = StyleSheet.create({
+    container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+    title: { fontSize: 24, marginBottom: 20 },
+    input: { borderWidth: 1, width: 120, padding: 8, textAlign: 'center', marginBottom: 20 },
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{problem}</Text>
+      <TextInput
+        style={styles.input}
+        keyboardType="number-pad"
+        value={answer}
+        onChangeText={setAnswer}
+        accessibilityLabel="Parental Gate Answer"
+      />
+      <Button title="OK" onPress={handleCheck} accessibilityLabel="Antwort bestätigen" />
+      <Button title="Back" onPress={() => navigation.goBack()} accessibilityLabel="Zurück" />
+    </View>
+  );
+}

--- a/app/src/screens/ProfileSelectScreen.tsx
+++ b/app/src/screens/ProfileSelectScreen.tsx
@@ -18,12 +18,12 @@ export default function ProfileSelectScreen({ navigation }: any) {
       <View style={styles.row}>
         <Button
           title="Parent"
-          onPress={() => navigation.navigate('Parent')}
+          onPress={() => navigation.navigate('ParentalGate', { target: 'Parent' })}
           accessibilityLabel="Elternprofil"
         />
         <Button
           title="Admin"
-          onPress={() => navigation.navigate('Admin')}
+          onPress={() => navigation.navigate('ParentalGate', { target: 'Admin' })}
           accessibilityLabel="Adminbereich"
         />
         <Button


### PR DESCRIPTION
## Summary
- add new ParentalGateScreen for simple math challenge
- require passing gate to reach Admin or Parent screens
- register the new screen in navigation

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_688919c905dc8322862aeaf752573e99