### PR TITLE
Document expo doctor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ This is not a demo or experiment. It’s a production-grade, full-stack project 
 7. Inside `app`, run `npm run ios` or `npm run android` to launch the app
 8. Or run `./scripts/full-check.sh` from the repo root to automatically install
    dependencies and execute all tests at once
-9. Or check the expo setup inside `app` via `npx expo install --check` + `npx expo-doctor`
+9. Or check the Expo setup inside `app`:
+
+   ```bash
+   npx expo install --check
+   npx expo-doctor    # skips WatermelonDB packages via package.json
+   ```
 10. Ensure `react-native-gesture-handler`, `react-native-safe-area-context`, and `react-native-screens` match Expo's expected versions (`~2.24.0`, `5.4.0`, and `~4.11.1` respectively)
 
 ## Process
@@ -164,6 +169,8 @@ Otherwise the command will fail when it prompts for login.
    npx expo whoami || npx expo login     # verify you are logged in
    ```
 
+   `expo-doctor` respects the configuration in `app/package.json` to ignore
+   WatermelonDB-related packages.
    When running in CI, set an `EXPO_TOKEN` environment variable instead of
    calling `expo login` interactively.
 

--- a/app/package.json
+++ b/app/package.json
@@ -69,5 +69,17 @@
       "eslint --fix",
       "prettier --write"
     ]
+  },
+  "expo": {
+    "doctor": {
+      "reactNativeDirectoryCheck": {
+        "exclude": [
+          "@nozbe/watermelondb",
+          "@nozbe/with-observables",
+          "better-sqlite3"
+        ],
+        "listUnknownPackages": false
+      }
+    }
   }
 }

--- a/docs/BUILD_AND_TEST.md
+++ b/docs/BUILD_AND_TEST.md
@@ -48,3 +48,10 @@ For store-ready binaries Amy's Echo relies on Expo's **EAS Build** service. The 
    eas build:list --limit 1
    ```
 Ensure you are logged in to Expo (`npx expo whoami`) or provide an `EXPO_TOKEN` when running in CI.
+
+Before building you can verify the local Expo setup:
+
+```bash
+npx expo install --check
+npx expo-doctor    # skips WatermelonDB packages via package.json
+```


### PR DESCRIPTION
## Summary
- configure `expo doctor` to skip WatermelonDB libraries via `app/package.json`
- document the new configuration in README and BUILD_AND_TEST guide

## Testing
- `./scripts/full-check.sh`
- `cd app && npx -y expo-doctor` *(fails: fetch failed due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688a41b1022483228399911f25bfc7d5