### PR TITLE
Ensure app-server API compatibility and add integration tests

### DIFF
--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,4 +1,4 @@
-export const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:5000/api';
+export const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:5000';
 export const API_TOKEN = process.env.EXPO_PUBLIC_API_TOKEN || 'demo-token';
 export const CONFIDENCE_THRESHOLD = 0.7;
 export const MODEL_VERSION_URL = `${API_URL}/model-version`;

--- a/app/src/services/syncService.ts
+++ b/app/src/services/syncService.ts
@@ -38,38 +38,31 @@ export const syncService = {
 
       logger.info(`Found ${pendingSamples.length} pending training samples.`);
 
-      for (const sample of pendingSamples) {
-        try {
-          const response = await fetch(`${API_URL}/upload_training_data`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${API_TOKEN}`,
-            },
-            body: JSON.stringify({
-              gestureDefinitionId: sample.gestureDefinition.id,
-              landmarkData: JSON.parse(sample.landmarkData),
-              source: sample.source,
-              qualityScore: sample.qualityScore,
-              frameMetadata: sample.frameMetadata,
-              createdAt: sample.createdAt.toISOString(),
-              profileId: activeProfileId,
-            }),
-          });
+      try {
+        const payload = pendingSamples.map((s) => JSON.parse(s.landmarkData));
+        const response = await fetch(`${API_URL}/train-model`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${API_TOKEN}`,
+          },
+          body: JSON.stringify({ landmarks: payload }),
+        });
 
-          if (response.ok) {
-            await database.write(async () => {
-              await sample.update(s => {
+        if (response.ok) {
+          await database.write(async () => {
+            for (const sample of pendingSamples) {
+              await sample.update((s) => {
                 s.customSyncStatus = 'synced';
               });
-            });
-            logger.info(`Successfully uploaded and marked as synced: ${sample.id}`);
-          } else {
-            logger.error(`Failed to upload sample ${sample.id}: ${response.status} ${response.statusText}`);
-          }
-        } catch (uploadError) {
-          logger.error(`Error uploading sample ${sample.id}:`, uploadError);
+            }
+          });
+          logger.info(`Uploaded ${pendingSamples.length} samples successfully.`);
+        } else {
+          logger.error(`Failed to upload training data: ${response.status} ${response.statusText}`);
         }
+      } catch (uploadError) {
+        logger.error('Error uploading training data:', uploadError);
       }
     } catch (error) {
       logger.error('Error in uploadPendingTrainingData:', error);

--- a/integration/package.json
+++ b/integration/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "integration-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "pretest": "npm run build --prefix ../server",
+    "test": "node --test"
+  }
+}

--- a/integration/test/api.test.js
+++ b/integration/test/api.test.js
@@ -1,0 +1,71 @@
+import { spawn } from 'child_process';
+import { once } from 'events';
+import assert from 'node:assert';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { test, before, after } from 'node:test';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverDir = join(__dirname, '..', '..', 'server');
+const PORT = 5050;
+let proc;
+
+async function startServer() {
+  proc = spawn('node', ['dist/server.js'], {
+    cwd: serverDir,
+    env: { ...process.env, PORT: PORT.toString(), API_TOKEN: 'testtoken' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('server start timeout')), 5000);
+    proc.stdout.on('data', (data) => {
+      if (data.toString().includes('Server is running')) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    proc.on('error', reject);
+    proc.on('exit', (code) => {
+      reject(new Error(`server exited ${code}`));
+    });
+  });
+}
+
+async function stopServer() {
+  if (proc) {
+    proc.kill();
+    await once(proc, 'exit').catch(() => {});
+  }
+}
+
+before(startServer);
+after(stopServer);
+
+test('POST /classify returns label and confidence', async () => {
+  const res = await fetch(`http://localhost:${PORT}/classify`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer testtoken',
+    },
+    body: JSON.stringify({ landmarks: [0, 0, 0] }),
+  });
+  assert.strictEqual(res.status, 200);
+  const data = await res.json();
+  assert.ok('label' in data);
+  assert.ok('confidence' in data);
+});
+
+test('POST /train-model invalid payload', async () => {
+  const res = await fetch(`http://localhost:${PORT}/train-model`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer testtoken',
+    },
+    body: JSON.stringify({ landmarks: 'bad' }),
+  });
+  assert.strictEqual(res.status, 400);
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -286,7 +286,7 @@ app.post('/classify', auth, async (req: Request, res: Response) => {
   }
 });
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 5000;
 
 app.listen(port, () => {
   console.log(`Server is running on port ${port}`);


### PR DESCRIPTION
## Summary
- adjust API base url used by the app
- send training data to `/train-model`
- run backend on port 5000
- add integration tests to exercise server endpoints

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_688a931c1a9c832286da6b5bff02fe8c