### PR TITLE
fix: correct model asset paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,22 @@ This is not a demo or experiment. It’s a production-grade, full-stack project 
    - (Python 3 required) Run `pip install -r requirements.txt` to install `numpy` and `pytest` for the training tests.
    - Then run `npm test` inside `server/` to execute the Python suite in `server/test/`.
    - Back in the repo root, run `npm test --prefix integration` to verify the app and server end-to-end
-7. Inside `app`, run `npm run ios` or `npm run android` to launch the app
-8. Or run `./scripts/full-check.sh` from the repo root to automatically install
+7. Fetch the default gesture models so the app can classify hands:
+   ```bash
+   npm run build --prefix server
+   node server/dist/tools/downloadModels.js
+   ```
+   This downloads `hand_landmarker.tflite` and `gesture_classifier.tflite` into `app/assets/models/`.
+8. Inside `app`, run `npm run ios` or `npm run android` to launch the app
+9. Or run `./scripts/full-check.sh` from the repo root to automatically install
    dependencies and execute all tests (including integration tests) at once
-9. Or check the Expo setup inside `app`:
+10. Or check the Expo setup inside `app`:
 
    ```bash
    npx expo install --check
    npx expo-doctor    # skips WatermelonDB packages via package.json
    ```
-10. Ensure `react-native-gesture-handler`, `react-native-safe-area-context`, and `react-native-screens` match Expo's expected versions (`~2.24.0`, `5.4.0`, and `~4.11.1` respectively)
+11. Ensure `react-native-gesture-handler`, `react-native-safe-area-context`, and `react-native-screens` match Expo's expected versions (`~2.24.0`, `5.4.0`, and `~4.11.1` respectively)
 
 ## Process
 

--- a/app/src/constants/modelPaths.ts
+++ b/app/src/constants/modelPaths.ts
@@ -1,6 +1,5 @@
 import * as FileSystem from 'expo-file-system';
-import { Asset } from 'expo-asset';
 
-export const HAND_LANDMARKER_MODEL =  Asset.fromModule(require('../../assets/models/hand_landmarker.tflite')).uri;
-export const GESTURE_CLASSIFIER_MODEL = Asset.fromModule(require('../../assets/models/gesture_classifier.tflite')).uri;
+export const HAND_LANDMARKER_MODEL = require('../../assets/models/hand_landmarker.tflite');
+export const GESTURE_CLASSIFIER_MODEL = require('../../assets/models/gesture_classifier.tflite');
 export const CUSTOM_GESTURE_MODEL_PATH = FileSystem.documentDirectory + 'custom_model.tflite';

--- a/app/test/mlService.test.ts
+++ b/app/test/mlService.test.ts
@@ -1,4 +1,4 @@
-import Module from 'module';
+const Module = require('module');
 
 const origLoad = (Module as any)._load;
 (Module as any)._load = (req: string, parent: any, isMain: boolean) => {
@@ -14,13 +14,22 @@ const origLoad = (Module as any)._load;
   if (req === 'expo-file-system') {
     return { downloadAsync: async () => ({ uri: 'test' }), documentDirectory: '/tmp/' };
   }
+  if (req === 'react') {
+    return { useCallback: (fn: any) => fn, useRef: (v: any) => ({ current: v }) };
+  }
+  if (req === 'react-native-vision-camera') {
+    return { useFrameProcessor: () => {} };
+  }
+  if (req === 'react-native-reanimated') {
+    return { useSharedValue: () => ({ value: 0 }) };
+  }
   if (req.startsWith('../../db')) {
     return { database: { write: async () => {}, get: () => ({ create: () => {}, query: () => ({ fetch: async () => [] }) }) }, InteractionLog: class {} };
   }
   return origLoad(req, parent, isMain);
 };
 
-import { mlService } from '../src/services/mlService';
+const { mlService } = require('../src/services/mlService');
 
 (async () => {
   // @ts-ignore

--- a/docs/GestureEnvironmentSetup.md
+++ b/docs/GestureEnvironmentSetup.md
@@ -1,0 +1,51 @@
+# Gesture Environment Setup
+
+This guide explains how to prepare the gesture recognition environment for Amy's Echo. It covers downloading the default MediaPipe models and where to place them so the app can load them.
+
+## Prerequisites
+
+- Node.js 18+
+- npm
+- Python 3 (for server tests)
+
+Install the repository dependencies first:
+
+```bash
+npm install
+npm install --prefix app
+npm install --prefix server
+pip install -r server/requirements.txt
+```
+
+## Download default models
+
+The app relies on two TensorFlow Lite models:
+
+- `hand_landmarker.tflite`
+- `gesture_classifier.tflite`
+
+They should live under `app/assets/models/`. The repository includes a helper script that downloads the latest versions from Google MediaPipe and saves them to that directory.
+
+From the repository root run:
+
+```bash
+npm run build --prefix server
+node server/dist/tools/downloadModels.js
+```
+
+If the files already exist you can skip this step.
+
+## Verify the assets
+
+After the download, confirm the files are present:
+
+```bash
+ls app/assets/models
+```
+
+You should see `gesture_classifier.tflite`, `hand_landmarker.tflite`, and `gesture_labels.json`.
+
+## Next steps
+
+With the models in place you can launch the app with `npm run ios` or `npm run android` from the `app` directory. For details on how the models are used at runtime, see [`docs/GestureRecognitionImplementationGuide.md`](./GestureRecognitionImplementationGuide.md).
+

--- a/server/src/tools/downloadModels.ts
+++ b/server/src/tools/downloadModels.ts
@@ -1,50 +1,99 @@
-import { createWriteStream } from 'fs';
-import { pipeline } from 'stream';
-import https from 'https';
 import fs from 'fs';
 import path from 'path';
+import https from 'https';
+import os from 'os';
+import { execFile } from 'child_process';
+import { createWriteStream } from 'fs';
+import { pipeline } from 'stream';
 import {
   HAND_LANDMARKER_MODEL_PATH,
   GESTURE_CLASSIFIER_MODEL_PATH,
 } from '../constants/modelPaths';
 
-const models = [
+interface ModelSpec {
+  url: string;
+  extract: (downloadedPath: string, destPath: string) => Promise<void>;
+  dest: string;
+}
+
+async function downloadFile(url: string, dest: string): Promise<void> {
+  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+  return new Promise<void>((resolve, reject) => {
+    https
+      .get(url, res => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Request failed: ${res.statusCode}`));
+          return;
+        }
+        const file = createWriteStream(dest);
+        pipeline(res, file, err => {
+          if (err) reject(err);
+          else resolve();
+        });
+      })
+      .on('error', reject);
+  });
+}
+
+async function unzip(src: string, dest: string): Promise<void> {
+  await fs.promises.mkdir(dest, { recursive: true });
+  return new Promise((resolve, reject) => {
+    execFile('unzip', ['-o', src, '-d', dest], err => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+async function extractHandLandmarker(taskPath: string, dest: string) {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'hand-'));
+  await unzip(taskPath, tmpDir);
+  const modelSrc = path.join(tmpDir, 'hand_landmarks_detector.tflite');
+  await fs.promises.copyFile(modelSrc, dest);
+}
+
+async function extractGestureClassifier(taskPath: string, dest: string) {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'gesture-'));
+  await unzip(taskPath, tmpDir);
+  const recognizerTask = path.join(tmpDir, 'hand_gesture_recognizer.task');
+  const nestedDir = path.join(tmpDir, 'recognizer');
+  await unzip(recognizerTask, nestedDir);
+  const modelSrc = path.join(nestedDir, 'canned_gesture_classifier.tflite');
+  await fs.promises.copyFile(modelSrc, dest);
+}
+
+const models: ModelSpec[] = [
   {
     url: 'https://storage.googleapis.com/mediapipe-assets/hand_landmarker.task',
-    out: HAND_LANDMARKER_MODEL_PATH,
+    dest: HAND_LANDMARKER_MODEL_PATH,
+    extract: extractHandLandmarker,
   },
   {
     url: 'https://storage.googleapis.com/mediapipe-assets/gesture_recognizer.task',
-    out: GESTURE_CLASSIFIER_MODEL_PATH,
+    dest: GESTURE_CLASSIFIER_MODEL_PATH,
+    extract: extractGestureClassifier,
   },
 ];
 
-async function download(url: string, dest: string) {
-  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
-  return new Promise<void>((resolve, reject) => {
-    https.get(url, res => {
-      if (res.statusCode !== 200) {
-        reject(new Error(`Request failed: ${res.statusCode}`));
-        return;
-      }
-      const file = createWriteStream(dest);
-      const pipe = pipeline(res, file, err => {
-        if (err) reject(err);
-        else resolve();
-      });
-    }).on('error', reject);
-  });
+async function ensureModel(model: ModelSpec) {
+  if (fs.existsSync(model.dest)) {
+    console.log(`${path.basename(model.dest)} already exists, skipping`);
+    return;
+  }
+  const tmpFile = path.join(os.tmpdir(), path.basename(model.url));
+  console.log(`Downloading ${model.url}...`);
+  await downloadFile(model.url, tmpFile);
+  await model.extract(tmpFile, model.dest);
+  await fs.promises.unlink(tmpFile).catch(() => {});
+  console.log(`Saved to ${model.dest}`);
 }
 
 (async () => {
   for (const m of models) {
-    const name = path.basename(m.out);
-    console.log(`Downloading ${name}...`);
     try {
-      await download(m.url, m.out);
-      console.log(`Saved to ${m.out}`);
+      await ensureModel(m);
     } catch (err) {
-      console.error(`Failed to download ${name}:`, err);
+      console.error(`Failed to process ${path.basename(m.dest)}:`, err);
     }
   }
 })();


### PR DESCRIPTION
## Summary
- serve TensorFlow model assets using `require` so Expo `Asset.fromModule` can resolve local URIs
- stub React Native dependencies in ML service tests to run without native modules
- document gesture environment setup and model download steps
- unpack MediaPipe task bundles to produce `.tflite` models for the app

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_688c17a348d08322ae357917b9f7bb3b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to include explicit steps for downloading required gesture models.
  * Added a new guide detailing gesture recognition environment setup and model download process.

* **Bug Fixes**
  * Improved model file loading for gesture recognition, enhancing reliability in accessing model assets.

* **Refactor**
  * Streamlined the model download and extraction process for better modularity and handling of complex archives.

* **Tests**
  * Updated test mocks and import styles to ensure compatibility with recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->