### PR TITLE
chore: update mediapipe model download URLs

### DIFF
--- a/server/src/tools/downloadModels.ts
+++ b/server/src/tools/downloadModels.ts
@@ -64,12 +64,12 @@ async function extractGestureClassifier(taskPath: string, dest: string) {
 
 const models: ModelSpec[] = [
   {
-    url: 'https://storage.googleapis.com/mediapipe-assets/hand_landmarker.task',
+    url: 'https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/latest/hand_landmarker.task',
     dest: HAND_LANDMARKER_MODEL_PATH,
     extract: extractHandLandmarker,
   },
   {
-    url: 'https://storage.googleapis.com/mediapipe-assets/gesture_recognizer.task',
+    url: 'https://storage.googleapis.com/mediapipe-models/gesture_recognizer/gesture_recognizer/float16/latest/gesture_recognizer.task',
     dest: GESTURE_CLASSIFIER_MODEL_PATH,
     extract: extractGestureClassifier,
   },


### PR DESCRIPTION
## Summary
- point model downloader at latest MediaPipe hand landmarker and gesture recognizer bundles
- revert accidentally committed model binaries

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_688c62070e648322b755f323a948ae0a