### PR TITLE
refactor: require tflite module

### DIFF
--- a/app/src/hooks/useTensorflowModel.ts
+++ b/app/src/hooks/useTensorflowModel.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { loadTensorflowModel, TensorflowModel } from 'react-native-fast-tflite';
+import type { TensorflowModel } from 'react-native-fast-tflite';
+const { loadTensorflowModel } = require('react-native-fast-tflite');
 import { loadCustomModelUri } from '../storage';
 
 /**

--- a/app/src/services/landmarkExtractor.ts
+++ b/app/src/services/landmarkExtractor.ts
@@ -1,7 +1,8 @@
 import * as FileSystem from 'expo-file-system';
 // TODO: ffmpeg-kit-react-native is not longer supported v1
 /*import { FFmpegKit } from 'ffmpeg-kit-react-native';*/
-import { loadTensorflowModel, TensorflowModel } from 'react-native-fast-tflite';
+import type { TensorflowModel } from 'react-native-fast-tflite';
+const { loadTensorflowModel } = require('react-native-fast-tflite');
 import { HAND_LANDMARKER_MODEL } from '../constants/modelPaths';
 
 let handModel: TensorflowModel | null = null;


### PR DESCRIPTION
## Summary
- load TensorFlow Lite models by requiring `react-native-fast-tflite`
- require tflite in hook for consistent on-device inference API

## Testing
- `./scripts/full-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_688dbe2936c08322ad534828ad395725