### PR TITLE
docs: explain building test APK with EAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ The LLM-powered suggestions require an OpenAI API key. You can set this via the 
 
 If you want to run the app on a physical device with a custom dev client, execute `npx expo prebuild` and `npx expo run:android` inside `app/` once to generate the native Android and iOS projects. These directories are not tracked in git to avoid committing large binaries. After the prebuild step you can launch the app with `npm run ios` or `npm run android`.
 
+### Creating test builds (APK)
+
+To produce a debuggable APK for testers, trigger a development build via EAS:
+
+```bash
+npm run build:android-dev
+```
+
+The CLI prints a link to the artifact. You can also download the most recent build later:
+
+```bash
+eas build:download --platform android --profile development --latest
+```
+
+Install the APK on a device and start the bundler with `npx expo start` to load the JavaScript bundle.
+
 ### Creating production builds
 
 To generate store-ready binaries using EAS Build, run:

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "test": "jest",
     "type-check": "tsc --noEmit --project tsconfig.json",
+    "build:android-dev": "eas build --platform android --profile development --non-interactive",
     "build:android": "eas build --platform android --profile production --non-interactive",
     "build:ios": "eas build --platform ios --profile production --non-interactive"
   },

--- a/docs/BUILD_AND_TEST.md
+++ b/docs/BUILD_AND_TEST.md
@@ -37,9 +37,36 @@ npm test --prefix integration
 
 The tests will build the server and exercise key endpoints. They are also executed by `./scripts/full-check.sh`.
 
-## Building a production APK with EAS
+## Building APKs with EAS
 
-For store-ready binaries Amy's Echo relies on Expo's **EAS Build** service. The recommended workflow is:
+Amy's Echo relies on Expo's **EAS Build** service. Two build profiles are available in `app/eas.json`.
+
+### Development build (testing APK)
+
+Use this to produce a debuggable APK for internal testing:
+
+1. Run the full test suite to verify everything is green:
+   ```bash
+   ./scripts/full-check.sh
+   ```
+2. Generate the native Android project if it doesn't already exist:
+   ```bash
+   npx expo prebuild --platform android
+   ```
+3. Trigger the remote build from the `app` directory:
+   ```bash
+   npm run build:android-dev
+   ```
+   The command prints a link where you can download the APK. You can also fetch the latest build later:
+   ```bash
+   eas build:download --platform android --profile development --latest
+   ```
+
+After installing the APK on a device, start the bundler with `npx expo start` to load the JavaScript bundle.
+
+### Production build (Play Store)
+
+For store-ready binaries the recommended workflow is:
 
 1. Run the full test suite to verify everything is green:
    ```bash


### PR DESCRIPTION
## Summary
- document EAS workflow for producing a testing APK and downloading artifacts
- add npm script `build:android-dev` for development profile builds

## Testing
- `npm test --prefix app`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68909134e8d483229a8210a854fab413