### PR TITLE
feat: apply UI style guide to App

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,12 +1,14 @@
 import 'react-native-gesture-handler';
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, View, Alert } from 'react-native';
-import { NavigationContainer } from '@react-navigation/native';
+import { ActivityIndicator, Alert, StyleSheet } from 'react-native';
+import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { setupDatabase } from './db';
 import { AppServicesProvider } from './src/context/AppServicesProvider';
 import { AccessibilityContext, AccessibilitySettings } from './src/components/AccessibilityContext';
 import { loadProfile, loadActiveProfileId, setActiveProfileId } from './src/storage';
 import RootNavigator from './src/navigation/RootNavigator';
+import { palette } from './src/constants/ui';
 
 export default function App() {
   const [isReady, setIsReady] = useState(false);
@@ -51,11 +53,29 @@ export default function App() {
     initialize();
   }, []);
 
+  const gradientColors = accessibility.highContrast
+    ? [palette.highContrastBg, palette.highContrastBg]
+    : [palette.backgroundStart, palette.backgroundEnd];
+
+  const navTheme = {
+    ...DefaultTheme,
+    colors: {
+      ...DefaultTheme.colors,
+      background: 'transparent',
+      text: accessibility.highContrast ? palette.highContrastText : palette.text,
+    },
+  };
+
   if (!isReady) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <ActivityIndicator size="large" />
-      </View>
+      <LinearGradient colors={gradientColors} style={styles.loadingContainer}>
+        <ActivityIndicator
+          size="large"
+          color={accessibility.highContrast ? palette.highContrastText : palette.accent}
+          accessibilityRole="progressbar"
+          accessibilityLabel="Loading Amy's Echo"
+        />
+      </LinearGradient>
     );
   }
 
@@ -68,10 +88,23 @@ export default function App() {
             setAccessibility((prev) => ({ ...prev, ...s })),
         }}
       >
-        <NavigationContainer>
-          <RootNavigator />
-        </NavigationContainer>
+        <LinearGradient colors={gradientColors} style={styles.appContainer}>
+          <NavigationContainer theme={navTheme}>
+            <RootNavigator />
+          </NavigationContainer>
+        </LinearGradient>
       </AccessibilityContext.Provider>
     </AppServicesProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  appContainer: {
+    flex: 1,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/app/src/constants/ui.ts
+++ b/app/src/constants/ui.ts
@@ -1,0 +1,13 @@
+export const palette = {
+  backgroundStart: '#EFF6FF',
+  backgroundEnd: '#F3F4F6',
+  text: '#333333',
+  mutedText: '#666666',
+  accent: '#3B82F6',
+  inactive: '#6B7280',
+  drink: '#AEDFF7',
+  eat: '#F7C5A8',
+  play: '#A8F7A8',
+  highContrastBg: '#000000',
+  highContrastText: '#ffffff',
+} as const;


### PR DESCRIPTION
## Summary
- add shared UI palette constants
- wrap App component in gradient with high-contrast theme
- sync with latest main

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6890f92247ac8322b6085d6aa4d302f0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a visually enhanced linear gradient background throughout the app, including during loading and regular use.
  * Improved accessibility by adapting gradient and text colors based on high contrast settings.

* **Style**
  * Updated theming with a new color palette for backgrounds, text, and category-specific accents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->