### PR TITLE
feat: centralize UI style constants

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -8,6 +8,7 @@ import { AppServicesProvider } from './src/context/AppServicesProvider';
 import { AccessibilityContext, AccessibilitySettings } from './src/components/AccessibilityContext';
 import { loadProfile, loadActiveProfileId, setActiveProfileId } from './src/storage';
 import RootNavigator from './src/navigation/RootNavigator';
+import { COLORS } from './src/constants/ui';
 
 export default function App() {
   const [isReady, setIsReady] = useState(false);
@@ -53,15 +54,15 @@ export default function App() {
   }, []);
 
   const gradientColors = accessibility.highContrast
-    ? ['#000000', '#000000']
-    : ['#EFF6FF', '#F3F4F6'];
+    ? [COLORS.highContrastBackground, COLORS.highContrastBackground]
+    : [COLORS.backgroundStart, COLORS.backgroundEnd];
 
   if (!isReady) {
     return (
       <LinearGradient colors={gradientColors} style={styles.container}>
         <ActivityIndicator
           size="large"
-          color={accessibility.highContrast ? '#FFFFFF' : '#3B82F6'}
+          color={accessibility.highContrast ? COLORS.highContrastText : COLORS.primaryAccent}
           accessibilityRole="progressbar"
           accessibilityLabel="Loading Amy's Echo"
         />

--- a/app/src/constants/ui.ts
+++ b/app/src/constants/ui.ts
@@ -1,0 +1,23 @@
+export const COLORS = {
+  backgroundStart: '#EFF6FF',
+  backgroundEnd: '#F3F4F6',
+  text: '#333333',
+  textMuted: '#666666',
+  primaryAccent: '#3B82F6',
+  secondaryAccent: '#6B7280',
+  vocabDrink: '#AEDFF7',
+  vocabEat: '#F7C5A8',
+  vocabPlay: '#A8F7A8',
+  highContrastBackground: '#000000',
+  highContrastText: '#FFFFFF',
+} as const;
+
+export const SPACING = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+} as const;
+
+export const RADIUS = 8;


### PR DESCRIPTION
## Summary
- add shared UI style constants with palette, spacing, and radius
- refactor App component to use constants for gradients and loader colors

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689102a666848322bd09224e41858a60