### PR TITLE
Fix camera resume and add training feedback

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -64,7 +64,11 @@ export default function RecognitionScreen({ navigation }: any) {
   const devices = useCameraDevices();
   const device = devices.find(d => d.position === 'back') ?? devices.find(d => d.position === 'front') ?? devices[0];
   const isFocused = useIsFocused();
-  const appState = AppState.currentState;
+  const [appState, setAppState] = useState(AppState.currentState);
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', setAppState);
+    return () => sub.remove();
+  }, []);
 
   const canUseCamera =
     permissionStatus && device != null && isFocused && isCameraActive && appState === 'active';

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, Text, Button, StyleSheet, AppState } from 'react-native';
+import { useIsFocused } from '@react-navigation/native';
 import {
   Camera,
   useCameraDevice,
@@ -23,14 +24,38 @@ export default function TrainingScreen({ navigation, route }: any) {
   const [count, setCount] = useState(0);
   const [isRecording, setIsRecording] = useState(false);
   const [recordedLandmarks, setRecordedLandmarks] = useState<number[][][]>([]);
+  const [framesCaptured, setFramesCaptured] = useState(0);
+  const [lastDetection, setLastDetection] = useState(0);
+  const [now, setNow] = useState(Date.now());
+
+  const isFocused = useIsFocused();
+  const [appState, setAppState] = useState(AppState.currentState);
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', setAppState);
+    return () => sub.remove();
+  }, []);
+
+  useEffect(() => {
+    if (!isRecording) return;
+    const id = setInterval(() => setNow(Date.now()), 500);
+    return () => clearInterval(id);
+  }, [isRecording]);
+
+  const canUseCamera =
+    hasPermission && device != null && isFocused && appState === 'active';
+  const detectionActive = now - lastDetection < 1000;
 
   const recordingProcessor = useRecordingProcessor((landmarks) => {
     setRecordedLandmarks((prev) => [...prev, landmarks]);
+    setFramesCaptured((c) => c + 1);
+    setLastDetection(Date.now());
   }, isRecording);
 
   const startRecording = () => {
     if (!gestureId) return;
     setRecordedLandmarks([]);
+    setFramesCaptured(0);
+    setLastDetection(0);
     setIsRecording(true);
   };
 
@@ -58,6 +83,21 @@ export default function TrainingScreen({ navigation, route }: any) {
       color: highContrast ? COLORS.highContrastText : COLORS.text,
     },
     camera: { width: 200, height: 200, marginBottom: SPACING.sm },
+    recordingIndicator: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: SPACING.sm,
+    },
+    dot: {
+      width: 12,
+      height: 12,
+      borderRadius: 6,
+      marginRight: SPACING.sm,
+    },
+    recordingText: {
+      color: highContrast ? COLORS.highContrastText : COLORS.text,
+      fontSize: largeText ? 18 : 16,
+    },
   });
 
   if (!hasPermission) {
@@ -91,9 +131,21 @@ export default function TrainingScreen({ navigation, route }: any) {
             <Camera
               style={styles.camera}
               device={device}
-              isActive={true}
+              isActive={canUseCamera}
               frameProcessor={recordingProcessor}
             />
+          )}
+          {isRecording && (
+            <View style={styles.recordingIndicator}>
+              <View
+                style={[styles.dot, { backgroundColor: detectionActive ? 'lime' : 'red' }]}
+              />
+              <Text style={styles.recordingText}>
+                {detectionActive
+                  ? `Recording... ${framesCaptured}`
+                  : 'No hand detected'}
+              </Text>
+            </View>
           )}
           <Button
             title={isRecording ? 'Stop Recording' : `Record Sample ${count + 1} / 5`}


### PR DESCRIPTION
## Summary
- ensure cameras resume when app returns from background by listening to `AppState`
- add on-screen recording indicator during training showing detection and frame count

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68913f9c9f488322bef90c875d45eb34