### PR TITLE
feat: add profile menu and training nav

### DIFF
--- a/app/src/components/BottomNav.tsx
+++ b/app/src/components/BottomNav.tsx
@@ -6,7 +6,7 @@ import type { RootStackParamList } from '../navigation/types';
 import { COLORS, SPACING } from '../constants/ui';
 
 interface Props {
-  active: 'recognition' | 'symbols' | 'training';
+  active: 'recognition' | 'training' | 'parent';
   profileId: string;
 }
 
@@ -31,12 +31,24 @@ export default function BottomNav({ active, profileId }: Props) {
         style={styles.item}
         accessibilityLabel="Learn"
       >
-        <Settings
+        <BookOpen
           size={24}
           color={active === 'training' ? COLORS.primaryAccent : COLORS.secondaryAccent}
           style={styles.icon}
         />
         <Text style={[styles.label, active === 'training' && styles.active]}>Learn</Text>
+      </Pressable>
+      <Pressable
+        onPress={() => navigation.navigate('ProfileSelect')}
+        style={styles.item}
+        accessibilityLabel="Menu"
+      >
+        <Settings
+          size={24}
+          color={active === 'parent' ? COLORS.primaryAccent : COLORS.secondaryAccent}
+          style={styles.icon}
+        />
+        <Text style={[styles.label, active === 'parent' && styles.active]}>Menu</Text>
       </Pressable>
     </View>
   );

--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import OnboardingScreen from '../screens/OnboardingScreen';
+import ProfileSelectScreen from '../screens/ProfileSelectScreen';
 import RecognitionScreen from '../screens/RecognitionScreen';
 import CorrectionScreen from '../screens/CorrectionScreen';
 import TrainingScreen from '../screens/TrainingScreen';
@@ -21,6 +22,11 @@ const RootNavigator = () => {
       <Stack.Screen
         name="Onboarding"
         component={OnboardingScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="ProfileSelect"
+        component={ProfileSelectScreen}
         options={{ headerShown: false }}
       />
       <Stack.Screen

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -1,5 +1,6 @@
 export type RootStackParamList = {
   Onboarding: undefined;
+  ProfileSelect: undefined;
   Recognition: { profileId: string; simulateLowConfidence?: boolean };
   Correction: { gesture: string; suggestions: string[] };
   Training: { gestureLabel?: string };

--- a/app/src/screens/OnboardingScreen.tsx
+++ b/app/src/screens/OnboardingScreen.tsx
@@ -29,7 +29,7 @@ export default function OnboardingScreen({ navigation }: any) {
     });
     setActiveVocabularySet(vocabSet);
     update({ largeText, highContrast });
-    navigation.replace('Recognition', { profileId: profile.id });
+    navigation.replace('ProfileSelect');
   };
 
   const styles = StyleSheet.create({

--- a/app/src/screens/ParentScreen.tsx
+++ b/app/src/screens/ParentScreen.tsx
@@ -55,7 +55,7 @@ export default function ParentScreen({ navigation }: any) {
       />
       <Button
         title="Parental Gate"
-        onPress={() => navigation.navigate('ParentalGate')}
+        onPress={() => navigation.navigate('ParentalGate', { target: 'Parent' })}
         accessibilityLabel="Zugangsprüfung"
       />
       <Button

--- a/app/src/screens/ProfileSelectScreen.tsx
+++ b/app/src/screens/ProfileSelectScreen.tsx
@@ -1,8 +1,14 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Button, StyleSheet, Text } from 'react-native';
 import { SPACING } from '../constants/ui';
+import { loadProfile, Profile } from '../storage';
 
 export default function ProfileSelectScreen({ navigation }: any) {
+  const [profile, setProfile] = useState<Profile | null>(null);
+  useEffect(() => {
+    loadProfile().then(setProfile);
+  }, []);
+
   const styles = StyleSheet.create({
     container: {
       flex: 1,
@@ -10,12 +16,25 @@ export default function ProfileSelectScreen({ navigation }: any) {
       alignItems: 'center',
     },
     title: { fontSize: 24, marginBottom: SPACING.lg },
-    row: { flexDirection: 'row', gap: SPACING.lg },
+    row: { flexDirection: 'row', gap: SPACING.lg, marginBottom: SPACING.lg },
   });
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Select Profile</Text>
+      <Text style={styles.title}>What do you want to do?</Text>
+      <View style={styles.row}>
+        <Button
+          title="Listen"
+          onPress={() => profile && navigation.navigate('Recognition', { profileId: profile.id })}
+          accessibilityLabel="Zum Erkennungsmodus"
+          disabled={!profile}
+        />
+        <Button
+          title="Learn"
+          onPress={() => navigation.navigate('Training', { gestureLabel: undefined })}
+          accessibilityLabel="Zum Lernmodus"
+        />
+      </View>
       <View style={styles.row}>
         <Button
           title="Parent"

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, Button, StyleSheet, AppState } from 'react-native';
+import { View, Text, Button, StyleSheet, AppState, SafeAreaView } from 'react-native';
 import { useIsFocused } from '@react-navigation/native';
 import {
   Camera,
@@ -7,11 +7,12 @@ import {
   useCameraPermission,
 } from 'react-native-vision-camera';
 import Svg, { Circle } from 'react-native-svg';
-import { saveTrainingSample } from '../storage';
+import { saveTrainingSample, loadProfile, Profile } from '../storage';
 import { gestureModel } from '../model';
 import { useAccessibility } from '../components/AccessibilityContext';
 import { useRecordingProcessor } from '../services';
 import { COLORS, SPACING } from '../constants/ui';
+import BottomNav from '../components/BottomNav';
 
 export default function TrainingScreen({ navigation, route }: any) {
   const { largeText, highContrast } = useAccessibility();
@@ -30,6 +31,7 @@ export default function TrainingScreen({ navigation, route }: any) {
   const [lastDetection, setLastDetection] = useState(0);
   const [now, setNow] = useState(Date.now());
   const [landmarks, setLandmarks] = useState<number[][]>([]);
+  const [profile, setProfile] = useState<Profile | null>(null);
   const isRecordingRef = useRef(isRecording);
   useEffect(() => {
     isRecordingRef.current = isRecording;
@@ -45,6 +47,10 @@ export default function TrainingScreen({ navigation, route }: any) {
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 500);
     return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    loadProfile().then(setProfile);
   }, []);
 
   const canUseCamera =
@@ -86,9 +92,12 @@ export default function TrainingScreen({ navigation, route }: any) {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
+      backgroundColor: highContrast ? COLORS.highContrastBackground : COLORS.backgroundStart,
+    },
+    content: {
+      flex: 1,
       justifyContent: 'center',
       alignItems: 'center',
-      backgroundColor: highContrast ? COLORS.highContrastBackground : COLORS.backgroundStart,
     },
     title: {
       fontSize: largeText ? 24 : 20,
@@ -125,80 +134,86 @@ export default function TrainingScreen({ navigation, route }: any) {
 
   if (!hasPermission) {
     return (
-      <View style={styles.container}>
-        <Text style={styles.title}>Training Mode</Text>
-        <Button
-          title="Grant Camera Permission"
-          onPress={requestPermission}
-          accessibilityLabel="Kameraberechtigung erteilen"
-        />
-      </View>
+      <SafeAreaView style={styles.container}>
+        <View style={styles.content}>
+          <Text style={styles.title}>Training Mode</Text>
+          <Button
+            title="Grant Camera Permission"
+            onPress={requestPermission}
+            accessibilityLabel="Kameraberechtigung erteilen"
+          />
+        </View>
+        {profile && <BottomNav active="training" profileId={profile.id} />}
+      </SafeAreaView>
     );
   }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Training {gestureId ? `for ${gestureId}` : 'Mode'}</Text>
-      {!gestureId ? (
-        gestureModel.gestures.map((g) => (
-          <Button
-            key={g.id}
-            title={g.label}
-            onPress={() => setGestureId(g.id)}
-            accessibilityLabel={`Trainiere Geste ${g.label}`}
-          />
-        ))
-      ) : count < 5 ? (
-        <>
-          {device && (
-            <View style={styles.cameraContainer}>
-              <Camera
-                style={styles.camera}
-                device={device}
-                isActive={canUseCamera}
-                frameProcessor={recordingProcessor}
-              />
-              {landmarks.length > 0 && (
-                <Svg
-                  style={StyleSheet.absoluteFill}
-                  viewBox={`0 0 ${PREVIEW_SIZE} ${PREVIEW_SIZE}`}
-                  pointerEvents="none"
-                >
-                  {landmarks.map((l, idx) => (
-                    <Circle key={idx} cx={l[0] * PREVIEW_SIZE} cy={l[1] * PREVIEW_SIZE} r={3} fill="yellow" />
-                  ))}
-                </Svg>
-              )}
-              <View style={styles.detectionIndicator}>
-                <View
-                  style={[styles.dot, { backgroundColor: detectionActive ? 'lime' : 'red' }]}
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Training {gestureId ? `for ${gestureId}` : 'Mode'}</Text>
+        {!gestureId ? (
+          gestureModel.gestures.map((g) => (
+            <Button
+              key={g.id}
+              title={g.label}
+              onPress={() => setGestureId(g.id)}
+              accessibilityLabel={`Trainiere Geste ${g.label}`}
+            />
+          ))
+        ) : count < 5 ? (
+          <>
+            {device && (
+              <View style={styles.cameraContainer}>
+                <Camera
+                  style={styles.camera}
+                  device={device}
+                  isActive={canUseCamera}
+                  frameProcessor={recordingProcessor}
                 />
-                <Text style={styles.detectionText}>
-                  {isRecording
-                    ? detectionActive
-                      ? `Recording... ${framesCaptured}`
-                      : 'No hand detected'
-                    : detectionActive
-                    ? 'Hand detected'
-                    : 'No hand'}
-                </Text>
+                {landmarks.length > 0 && (
+                  <Svg
+                    style={StyleSheet.absoluteFill}
+                    viewBox={`0 0 ${PREVIEW_SIZE} ${PREVIEW_SIZE}`}
+                    pointerEvents="none"
+                  >
+                    {landmarks.map((l, idx) => (
+                      <Circle key={idx} cx={l[0] * PREVIEW_SIZE} cy={l[1] * PREVIEW_SIZE} r={3} fill="yellow" />
+                    ))}
+                  </Svg>
+                )}
+                <View style={styles.detectionIndicator}>
+                  <View
+                    style={[styles.dot, { backgroundColor: detectionActive ? 'lime' : 'red' }]}
+                  />
+                  <Text style={styles.detectionText}>
+                    {isRecording
+                      ? detectionActive
+                        ? `Recording... ${framesCaptured}`
+                        : 'No hand detected'
+                      : detectionActive
+                      ? 'Hand detected'
+                      : 'No hand'}
+                  </Text>
+                </View>
               </View>
-            </View>
-          )}
+            )}
+            <Button
+              title={isRecording ? 'Stop Recording' : `Record Sample ${count + 1} / 5`}
+              onPress={isRecording ? stopRecording : startRecording}
+              accessibilityLabel="Gestenaufnahme starten"
+              disabled={!gestureId}
+            />
+          </>
+        ) : (
           <Button
-            title={isRecording ? 'Stop Recording' : `Record Sample ${count + 1} / 5`}
-            onPress={isRecording ? stopRecording : startRecording}
-            accessibilityLabel="Gestenaufnahme starten"
-            disabled={!gestureId}
+            title="Save Training Data"
+            onPress={handleFinish}
+            accessibilityLabel="Trainingsdaten speichern"
           />
-        </>
-      ) : (
-        <Button
-          title="Save Training Data"
-          onPress={handleFinish}
-          accessibilityLabel="Trainingsdaten speichern"
-        />
-      )}
-    </View>
+        )}
+      </View>
+      {profile && <BottomNav active="training" profileId={profile.id} />}
+    </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary
- introduce ProfileSelect menu and expose it via bottom navigation
- route onboarding to the new menu and register it in the navigator
- load profile and display bottom nav on Training screen

## Testing
- `./scripts/full-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_689148d922ac8322bd7ceb995f535240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Menu" tab to the bottom navigation bar, providing quick access to the profile selection screen.
  * Introduced a new "Profile Select" screen, allowing users to choose their desired action after onboarding.
  * The "Learn" tab icon in the navigation bar is now a book icon for improved clarity.

* **Improvements**
  * Enhanced the training screen layout for better device compatibility and added bottom navigation for easier access.
  * The profile selection screen now displays action buttons for "Listen" and "Learn," improving user guidance.
  * Navigation flows have been updated for a more intuitive user experience after profile creation and parental actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->