### PR TITLE
docs: expand kindergarten workflow guide

### DIFF
--- a/docs/KindergartenWorkflow.md
+++ b/docs/KindergartenWorkflow.md
@@ -1,30 +1,39 @@
 # Kindergarten Workflow for Non-DGS Staff
 
-This guide explains how kindergarten staff who do not understand German Sign Language (DGS) can use **Amy's Echo** to communicate with Amy.
+This short field guide shows how kindergarten staff who do not understand German Sign Language (DGS) can use **Amy's Echo** to communicate with Amy.
 
-## Step 1: Prepare the App
+## Step 0: Get Ready
+1. Charge the device and turn the volume up so Amy can hear the spoken words.
+2. Connect to Wi‑Fi if possible. The app works offline but recognition is more accurate online.
+
+## Step 1: Start the App
 1. Launch the Amy's Echo app on the tablet or phone.
-2. From the **Profile Select** screen, choose Amy's profile.
+2. On the **Profile Select** screen choose Amy's profile.
+3. Tap **Recognition** to open the camera view. (The **Parent** button is for caregivers and is protected by a multiplication gate.)
 
 ## Step 2: Recognize Gestures
-1. The **Recognition** screen opens with the camera already active.
-2. When Amy performs a gesture, the system tries to classify it. If it is confident, the system:
+1. Keep Amy's hands within the camera frame.
+2. When she performs a gesture, the system tries to classify it. On a confident match it:
    - Speaks the associated word aloud.
-   - Shows a large symbol or emoji.
+   - Shows a large symbol or emoji on screen.
 
 ## Step 3: Handle Low Confidence
 1. If the match confidence is low, a **Help Me** button appears.
 2. Tap **Help Me** to open a panel with the top suggested symbols in a 2-by-2 grid.
-3. Select the correct symbol; the app responds as if it recognized the gesture and remembers the correction.
+3. Select the correct symbol. The app responds as if it recognized the gesture and remembers the correction for next time.
 
 ## Step 4: Show DGS Reference Videos
-1. On the recognition screen, toggle **Show DGS Video** to display DGS clips for each symbol.
-2. These videos help staff learn the correct sign if they are curious or want to practice.
+1. Toggle **Show DGS Video** on the recognition screen to display a short clip for each symbol.
+2. These videos help staff learn or review the correct sign without leaving recognition mode.
 
 ## Step 5: Review and Practice
-1. If the app shows a practice banner, tap it to begin a guided session and practice specific signs with Amy.
-2. Corrections and practice sessions improve future recognition automatically.
+1. If a practice banner appears, tap it to begin a guided session and rehearse specific signs with Amy.
+2. Each correction and practice session improves future recognition automatically.
+
+## Step 6: Finish the Session
+1. When done, exit any practice flow and lock or hand back the device.
 
 ---
 
 Following this workflow allows non‑DGS kindergarten staff to respond to Amy's gestures with confidence and empathy.
+


### PR DESCRIPTION
## Summary
- expand kindergarten workflow with preparation, session, and wrap-up steps for non-DGS staff

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68918fd805c08322add4146321cddb52