### PR TITLE
Fix landmark extraction with RGB camera frames

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -538,6 +538,7 @@ export default function RecognitionScreen({ navigation }: any) {
               device={device}
               isActive={true}
               frameProcessor={frameProcessor}
+              pixelFormat="rgb"
             />
           )}
 

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -179,6 +179,7 @@ export default function TrainingScreen({ navigation, route }: any) {
                   device={device}
                   isActive={canUseCamera}
                   frameProcessor={recordingProcessor}
+                  pixelFormat="rgb"
                 />
                 {landmarks.length > 0 && (
                   <Svg

--- a/app/src/services/landmarkExtractor.ts
+++ b/app/src/services/landmarkExtractor.ts
@@ -13,8 +13,12 @@ export function extractHandLandmarks(frame: Frame): number[][] | null {
   'worklet';
   if (!handModel) return null;
   try {
-    // Assuming frame.buffer contains the raw pixel data as a Uint8Array
-    const result = handModel.runSync([new Uint8Array(frame.toArrayBuffer())]) as any[];
+    if (frame.pixelFormat !== 'rgb') {
+      console.warn(`Unsupported pixel format: ${frame.pixelFormat}`);
+      return null;
+    }
+    const buffer = frame.toArrayBuffer();
+    const result = handModel.runSync([new Uint8Array(buffer)]) as any[];
     const landmarks = result[0] as number[][] | undefined;
     return landmarks ?? null;
   } catch (e) {


### PR DESCRIPTION
## Summary
- ensure VisionCamera outputs RGB frames so `toArrayBuffer` works
- guard landmark extractor against non-RGB frames

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6891b3e817408322a767805a0e523a29