### PR TITLE
feat: centralize error handling

### DIFF
--- a/app/src/components/ErrorMessage.tsx
+++ b/app/src/components/ErrorMessage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useAccessibility } from './AccessibilityContext';
+import { SPACING, RADIUS, COLORS } from '../constants/ui';
+
+interface ErrorMessageProps {
+  message: string | null;
+}
+
+export default function ErrorMessage({ message }: ErrorMessageProps) {
+  const { largeText } = useAccessibility();
+  if (!message) return null;
+  return (
+    <View style={styles.overlay} pointerEvents="none">
+      <Text style={[styles.text, { fontSize: largeText ? 16 : 14 }]}>{message}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    bottom: SPACING.md,
+    left: SPACING.md,
+    right: SPACING.md,
+    backgroundColor: 'rgba(255, 0, 0, 0.7)',
+    padding: SPACING.sm,
+    borderRadius: RADIUS,
+  },
+  text: {
+    color: COLORS.highContrastText,
+    textAlign: 'center',
+  },
+});

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -36,6 +36,7 @@ import BottomNav from '../components/BottomNav';
 import { COLORS, SPACING, RADIUS } from '../constants/ui';
 import Svg, { Circle, Line } from 'react-native-svg';
 import { HAND_CONNECTIONS } from '../constants/hand';
+import ErrorMessage from '../components/ErrorMessage';
 
 const { width, height } = Dimensions.get('window');
 
@@ -349,20 +350,6 @@ export default function RecognitionScreen({ navigation }: any) {
       color: COLORS.highContrastText,
       fontSize: largeText ? 18 : 16,
     },
-    errorOverlay: {
-      position: 'absolute',
-      bottom: SPACING.md,
-      left: SPACING.md,
-      right: SPACING.md,
-      backgroundColor: 'rgba(255, 0, 0, 0.7)',
-      padding: SPACING.sm,
-      borderRadius: RADIUS,
-    },
-    errorText: {
-      color: COLORS.highContrastText,
-      fontSize: largeText ? 16 : 14,
-      textAlign: 'center',
-    },
     status: {
       fontSize: largeText ? 48 : 40,
       fontWeight: 'bold',
@@ -570,11 +557,7 @@ export default function RecognitionScreen({ navigation }: any) {
                 ))}
               </Svg>
             )}
-            {processingError && (
-              <View style={styles.errorOverlay}>
-                <Text style={styles.errorText}>{processingError}</Text>
-              </View>
-            )}
+            <ErrorMessage message={processingError} />
             <View style={styles.detectionIndicator}>
               <View
                 style={[styles.dot, { backgroundColor: detectionActive ? 'lime' : 'red' }]}

--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -529,7 +529,7 @@ export const useGestureClassifier = (
 
         runOnJS(enqueueFrame)(processed);
       } catch (error: any) {
-        console.error('WORKLET ERROR:', error.message);
+        runOnJS(logger.error)('WORKLET ERROR:', error);
         if (onErrorRef.current) {
           runOnJS(onErrorRef.current)(error.message);
         }
@@ -574,7 +574,7 @@ export const useRecordingProcessor = (
         }
         runOnJS(onLandmarksRef.current)(landmarks);
       } catch (error: any) {
-        console.error('WORKLET ERROR:', error.message);
+        runOnJS(logger.error)('WORKLET ERROR:', error);
       }
     },
     [fps],

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -1,0 +1,48 @@
+# Error Handling in Amy's Echo
+
+Amy's Echo aims to surface user-friendly messages while capturing technical details for developers. This document describes the standard pattern for dealing with errors in the mobile app.
+
+## 1. Log with the shared logger
+
+Use the `logger` utility instead of `console.*` to record errors:
+
+```ts
+import { logger } from '../utils/logger';
+
+try {
+  // ...
+} catch (err) {
+  logger.error('Failed to perform action:', err);
+}
+```
+
+The logger automatically filters output by build type and keeps the console consistent.
+
+## 2. Pass errors through callbacks
+
+Hooks such as `useGestureClassifier` accept an optional `onError` callback. The hook invokes the callback whenever a processing failure occurs, allowing screens to react:
+
+```ts
+const handleError = (msg: string) => {
+  logger.warn('Frame processor error:', msg);
+  setProcessingError(msg);
+};
+
+const frameProcessor = useGestureClassifier(onGestureResult, isProcessing, handleError);
+```
+
+## 3. Display a friendly message
+
+Use the shared `ErrorMessage` component to surface problems to the user. It respects accessibility settings and can be reused on any screen.
+
+```tsx
+import ErrorMessage from '../components/ErrorMessage';
+
+<ErrorMessage message={processingError} />
+```
+
+## 4. Reset when recovered
+
+Clear the error state when the operation succeeds so the UI returns to normal. In gesture recognition, `onGestureResult` resets the `processingError` state when a frame is processed successfully.
+
+Following this pattern keeps technical information in logs while presenting clear, concise messages to Amy and caregivers.

--- a/docs/GestureRecognitionImplementationGuide.md
+++ b/docs/GestureRecognitionImplementationGuide.md
@@ -54,6 +54,8 @@ Screens that perform recognition use the `useGestureClassifier` hook from `app/s
 Example from `RecognitionScreen.tsx`:
 
 ```typescript
+const [processingError, setProcessingError] = useState<string | null>(null);
+
 const onGestureResult = useCallback(async (result: any) => {
   if (isProcessing) return;
 
@@ -65,7 +67,8 @@ const onGestureResult = useCallback(async (result: any) => {
 }, [isProcessing, useDgs, profile, startFeedbackAnimation]);
 
 const handleError = (msg: string) => {
-  console.warn('Frame processor error:', msg);
+  logger.warn('Frame processor error:', msg);
+  setProcessingError(msg);
 };
 
 const frameProcessor = useGestureClassifier(onGestureResult, isProcessing, handleError);
@@ -81,6 +84,12 @@ Attach the frame processor to the camera component:
   frameProcessor={frameProcessor}
   frameProcessorFps={5}
 />
+```
+
+Use the `ErrorMessage` component to surface processing issues to the user:
+
+```tsx
+<ErrorMessage message={processingError} />
 ```
 
 ## 4. Offline Fallback Logic


### PR DESCRIPTION
## Summary
- add reusable `ErrorMessage` component for accessible user-facing errors
- log worklet failures with shared logger instead of console
- document standard error-handling pattern and reference `ErrorMessage` in gesture guide

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6891b5ff25dc8322acd2b3dbed45a327