### PR TITLE
feat: surface workflow errors

### DIFF
--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -5,7 +5,6 @@ import {
   Camera,
   useCameraDevices,
   useCameraPermission,
-  type VideoFile,
 } from 'react-native-vision-camera';
 import { mlService } from '../services/mlService';
 import { audioService } from '../services/audioService';
@@ -14,6 +13,7 @@ import { extractLandmarksFromImages } from '../services/landmarkExtractor';
 import BottomNav from '../components/BottomNav';
 import { useAccessibility } from '../components/AccessibilityContext';
 import { COLORS, SPACING, RADIUS } from '../constants/ui';
+import ErrorMessage from '../components/ErrorMessage';
 
 export default function TeachingScreen({ navigation }: any) {
   const { largeText, highContrast } = useAccessibility();
@@ -28,11 +28,17 @@ export default function TeachingScreen({ navigation }: any) {
   const sessionId = useRef<string | null>(null);
   const SAMPLES_NEEDED = 5;
   const [profile, setProfile] = useState<Profile | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const sampleCaptureAnim = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
-    loadProfile().then(setProfile);
+    loadProfile()
+      .then(setProfile)
+      .catch((e) => {
+        console.error('Failed to load profile', e);
+        setError('Failed to load profile');
+      });
   }, []);
 
   const startSampleCaptureAnimation = useCallback(() => {
@@ -55,37 +61,45 @@ export default function TeachingScreen({ navigation }: any) {
 
   const startSession = async () => {
     if (!gestureLabel.trim()) {
-      Alert.alert('Error', 'Please enter a name for the gesture.');
+      setError('Please enter a name for the gesture.');
       return;
     }
-    sessionId.current = await mlService.startTeachingSession(gestureLabel);
-    setIsSessionActive(true);
-    setSampleCount(0);
-    audioService.speak(`Okay, let's learn how to make "${gestureLabel}".`);
+    try {
+      sessionId.current = await mlService.startTeachingSession(gestureLabel);
+      setError(null);
+      setIsSessionActive(true);
+      setSampleCount(0);
+      audioService.speak(`Okay, let's learn how to make "${gestureLabel}".`);
+    } catch (e) {
+      console.error('Failed to start teaching session', e);
+      setError('Failed to start teaching session');
+    }
   };
 
   const recordSample = async () => {
     if (!camera.current || !sessionId.current || isRecording) return;
     setIsRecording(true);
+    setError(null);
     const imageUris: string[] = [];
-    for (let i = 0; i < 30; i++) { // Capture 30 images over 3 seconds
-      try {
+    try {
+      for (let i = 0; i < 30; i++) {
         const photo = await camera.current.takePhoto({});
         imageUris.push(photo.path);
-      } catch (error) {
-        console.error('Failed to take photo:', error);
+        await new Promise((resolve) => setTimeout(resolve, 100));
       }
-      await new Promise(resolve => setTimeout(resolve, 100)); // 100ms delay for 10 FPS
-    }
-
-    const landmarks = await extractLandmarksFromImages(imageUris);
-    await saveTrainingSample(gestureLabel, landmarks);
-    setSampleCount((c) => c + 1);
-    startSampleCaptureAnimation();
-    audioService.playSound('confirmation');
-    setIsRecording(false);
-    if (sampleCount + 1 >= SAMPLES_NEEDED) {
-      endSession();
+      const landmarks = await extractLandmarksFromImages(imageUris);
+      await saveTrainingSample(gestureLabel, landmarks);
+      setSampleCount((c) => c + 1);
+      startSampleCaptureAnimation();
+      audioService.playSound('confirmation');
+      if (sampleCount + 1 >= SAMPLES_NEEDED) {
+        endSession();
+      }
+    } catch (e) {
+      console.error('Recording failed', e);
+      setError('Recording failed');
+    } finally {
+      setIsRecording(false);
     }
   };
 
@@ -113,7 +127,7 @@ export default function TeachingScreen({ navigation }: any) {
     return (
       <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
         <SafeAreaView style={styles.container}>
-          <Text>Camera not available</Text>
+          <ErrorMessage message={error || 'Camera not available'} />
         </SafeAreaView>
       </LinearGradient>
     );
@@ -132,6 +146,7 @@ export default function TeachingScreen({ navigation }: any) {
             onPress={requestPermission}
             accessibilityLabel="Kameraberechtigung erteilen"
           />
+          <ErrorMessage message={error} />
         </SafeAreaView>
       </LinearGradient>
     );
@@ -189,6 +204,7 @@ export default function TeachingScreen({ navigation }: any) {
         </View>
       )}
       <Button title="Back" onPress={() => navigation.goBack()} />
+      <ErrorMessage message={error} />
       {profile && <BottomNav active="training" profileId={profile.id} />}
     </SafeAreaView>
     </LinearGradient>

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -16,6 +16,7 @@ import { HAND_LANDMARKER_MODEL } from '../constants/modelPaths';
 import { setHandLandmarkModel } from '../services/landmarkExtractor';
 import { COLORS, SPACING } from '../constants/ui';
 import BottomNav from '../components/BottomNav';
+import ErrorMessage from '../components/ErrorMessage';
 
 export default function TrainingScreen({ navigation, route }: any) {
   const { largeText, highContrast } = useAccessibility();
@@ -35,6 +36,7 @@ export default function TrainingScreen({ navigation, route }: any) {
   const [now, setNow] = useState(Date.now());
   const [landmarks, setLandmarks] = useState<number[][]>([]);
   const [profile, setProfile] = useState<Profile | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const landmarkModel = useTensorflowModel(HAND_LANDMARKER_MODEL);
   const isRecordingRef = useRef(isRecording);
   useEffect(() => {
@@ -59,7 +61,12 @@ export default function TrainingScreen({ navigation, route }: any) {
   }, []);
 
   useEffect(() => {
-    loadProfile().then(setProfile);
+    loadProfile()
+      .then(setProfile)
+      .catch((e) => {
+        console.error('Failed to load profile', e);
+        setError('Failed to load profile');
+      });
   }, []);
 
   const canUseCamera =
@@ -81,6 +88,11 @@ export default function TrainingScreen({ navigation, route }: any) {
 
   const startRecording = () => {
     if (!gestureId) return;
+    if (!device) {
+      setError('Camera not available');
+      return;
+    }
+    setError(null);
     setRecordedLandmarks([]);
     setFramesCaptured(0);
     setLastDetection(0);
@@ -90,8 +102,13 @@ export default function TrainingScreen({ navigation, route }: any) {
   const stopRecording = async () => {
     setIsRecording(false);
     if (!gestureId || recordedLandmarks.length < 10) return;
-    await saveTrainingSample(gestureId, recordedLandmarks);
-    setCount((c) => c + 1);
+    try {
+      await saveTrainingSample(gestureId, recordedLandmarks);
+      setCount((c) => c + 1);
+    } catch (e) {
+      console.error('Failed to save training sample', e);
+      setError('Failed to save training sample');
+    }
   };
 
   const handleFinish = () => {
@@ -152,6 +169,7 @@ export default function TrainingScreen({ navigation, route }: any) {
             accessibilityLabel="Kameraberechtigung erteilen"
           />
         </View>
+        <ErrorMessage message={error} />
         {profile && <BottomNav active="training" profileId={profile.id} />}
       </SafeAreaView>
     );
@@ -223,6 +241,7 @@ export default function TrainingScreen({ navigation, route }: any) {
           />
         )}
       </View>
+      <ErrorMessage message={error} />
       {profile && <BottomNav active="training" profileId={profile.id} />}
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary
- use shared `ErrorMessage` component in training and teaching screens
- handle failures when loading profiles, starting sessions, and saving samples
- show camera or permission problems through visible error overlays

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6891bdc5257c8322809196581547bcd4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced consistent error messages displayed in the UI for both Teaching and Training screens, replacing previous alert dialogs.
  * Added visible error feedback for issues such as profile loading failures, camera unavailability, permission issues, and training sample saving errors.

* **Bug Fixes**
  * Unified error handling ensures users are promptly informed of issues, reducing silent failures and improving overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->