### PR TITLE
fix: ensure gesture model readiness updates

### DIFF
--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -444,13 +444,16 @@ export const useGestureClassifier = (
   const frameQueueRef = useRef<ProcessedFrame[]>([]);
   const internalProcessingRef = useRef(false);
   const maxQueueSize = 3;
-  const isServiceReady = mlService.isServiceReady();
+  const serviceReady = useSharedValue(mlService.isServiceReady());
   const processingTimesRef = useRef<number[]>([]);
   const targetFps = useSharedValue(30);
   const lastFrameTime = useSharedValue(0);
   const smootherRef = useRef(new LandmarkSmoother());
 
   useEffect(() => {
+    const readyInterval = setInterval(() => {
+      serviceReady.value = mlService.isServiceReady();
+    }, 500);
     const monitor = setInterval(() => {
       const times = processingTimesRef.current;
       if (times.length === 0) return;
@@ -462,8 +465,11 @@ export const useGestureClassifier = (
         targetFps.value = Math.min(30, targetFps.value + 5);
       }
     }, 5000);
-    return () => clearInterval(monitor);
-  }, []);
+    return () => {
+      clearInterval(monitor);
+      clearInterval(readyInterval);
+    };
+  }, [serviceReady, targetFps]);
 
   const processNextFrame = useCallback(() => {
     if (internalProcessingRef.current) {
@@ -504,7 +510,7 @@ export const useGestureClassifier = (
   const frameProcessor = useFrameProcessor(
     (frame: Frame) => {
       'worklet';
-      if (externalProcessingRef.current || !isServiceReady) {
+      if (externalProcessingRef.current || !serviceReady.value) {
         return;
       }
 
@@ -535,7 +541,7 @@ export const useGestureClassifier = (
         }
       }
     },
-    [isServiceReady],
+    [serviceReady],
   );
 
   return frameProcessor;


### PR DESCRIPTION
## Summary
- poll machine learning service readiness so gesture detection activates once models load
- gate frame processing on live readiness value to avoid perpetual "No hand" state

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6891e03e500c832283d2e0a92224d904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the responsiveness of the gesture classifier by making service readiness updates reactive and dynamic.

* **Refactor**
  * Enhanced the internal mechanism for tracking service readiness, allowing the app to better respond to changes in the underlying service state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->