### PR TITLE
feat: add lazy screen loading and configurable logging

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -9,6 +9,7 @@ import { AccessibilityContext, AccessibilitySettings } from './src/components/Ac
 import { loadProfile, loadActiveProfileId, setActiveProfileId } from './src/storage';
 import RootNavigator from './src/navigation/RootNavigator';
 import { COLORS } from './src/constants/ui';
+import { logger } from './src/utils/logger';
 
 export default function App() {
   const [isReady, setIsReady] = useState(false);
@@ -20,9 +21,9 @@ export default function App() {
   useEffect(() => {
     async function initialize() {
       try {
-        console.log("Initializing Amy's Echo...");
+        logger.info("Initializing Amy's Echo...");
         const profileId = await setupDatabase();
-        console.log('Database setup complete, initial profile:', profileId);
+        logger.info('Database setup complete, initial profile:', profileId);
 
         const activeId = await loadActiveProfileId();
         if (!activeId) {
@@ -35,12 +36,12 @@ export default function App() {
             largeText: !!profile.largeText,
             highContrast: !!profile.highContrast,
           });
-          console.log('Profile loaded:', profile.name);
+          logger.info('Profile loaded:', profile.name);
         } else {
-          console.log('No profile found, user needs onboarding');
+          logger.warn('No profile found, user needs onboarding');
         }
       } catch (e) {
-        console.error('Failed to initialize app:', e);
+        logger.error('Failed to initialize app:', e);
         Alert.alert(
           'Initialization Error',
           "Amy's Echo failed to start properly. Please restart the app.",

--- a/app/db/index.ts
+++ b/app/db/index.ts
@@ -14,6 +14,7 @@ import {
   LearningAnalytic,
   Correction,
 } from './models';
+import { logger } from '../src/utils/logger';
 
 const adapter = new SQLiteAdapter({
   schema: mySchema,
@@ -42,13 +43,13 @@ export const setupDatabase = async () => {
   const profiles = await profileCollection.query().fetch();
 
   if (profiles.length > 0) {
-    console.log('Database already populated.');
+    logger.info('Database already populated.');
     return profiles[0].id;
   }
 
   let amyProfileId = '';
   await database.write(async () => {
-    console.log('Setting up database with initial data...');
+    logger.info('Setting up database with initial data...');
     const now = Date.now();
     const symbolCollection = database.get<Symbol>('symbols');
 

--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -1,24 +1,44 @@
 
-import React from 'react';
+import React, { Suspense } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import OnboardingScreen from '../screens/OnboardingScreen';
-import ProfileSelectScreen from '../screens/ProfileSelectScreen';
-import RecognitionScreen from '../screens/RecognitionScreen';
-import CorrectionScreen from '../screens/CorrectionScreen';
-import TrainingScreen from '../screens/TrainingScreen';
-import ParentScreen from '../screens/ParentScreen';
-import ProfileManagerScreen from '../screens/ProfileManagerScreen';
-import ParentalGateScreen from '../screens/ParentalGateScreen';
-import AdminScreen from '../screens/AdminScreen';
-import DashboardScreen from '../screens/DashboardScreen';
-import HelpScreen from '../screens/HelpScreen';
 import { RootStackParamList } from './types';
+
+const lazyScreen = (
+  factory: () => Promise<any>,
+): React.LazyExoticComponent<React.ComponentType<any>> =>
+  React.lazy(
+    factory as () => Promise<{ default: React.ComponentType<any> }>,
+  );
+
+const OnboardingScreen = lazyScreen(() => import('../screens/OnboardingScreen.js'));
+const ProfileSelectScreen = lazyScreen(() => import('../screens/ProfileSelectScreen.js'));
+const RecognitionScreen = lazyScreen(() => import('../screens/RecognitionScreen.js'));
+const CorrectionScreen = lazyScreen(() => import('../screens/CorrectionScreen.js'));
+const TrainingScreen = lazyScreen(() => import('../screens/TrainingScreen.js'));
+const ParentScreen = lazyScreen(() => import('../screens/ParentScreen.js'));
+const ProfileManagerScreen = lazyScreen(
+  () => import('../screens/ProfileManagerScreen.js'),
+);
+const ParentalGateScreen = lazyScreen(
+  () => import('../screens/ParentalGateScreen.js'),
+);
+const AdminScreen = lazyScreen(() => import('../screens/AdminScreen.js'));
+const DashboardScreen = lazyScreen(() => import('../screens/DashboardScreen.js'));
+const HelpScreen = lazyScreen(() => import('../screens/HelpScreen.js'));
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
+const Loading = () => (
+  <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <ActivityIndicator size="large" />
+  </View>
+);
+
 const RootNavigator = () => {
   return (
-    <Stack.Navigator initialRouteName="Onboarding">
+    <Suspense fallback={<Loading />}>
+      <Stack.Navigator initialRouteName="Onboarding">
       <Stack.Screen
         name="Onboarding"
         component={OnboardingScreen}
@@ -74,7 +94,8 @@ const RootNavigator = () => {
         component={HelpScreen}
         options={{ title: 'Hilfe' }}
       />
-    </Stack.Navigator>
+      </Stack.Navigator>
+    </Suspense>
   );
 };
 

--- a/docs/optimization-ideas.md
+++ b/docs/optimization-ideas.md
@@ -9,9 +9,9 @@
 5. **Efficient Data Synchronization:** Optimize `syncService.ts` to use more efficient data synchronization algorithms (e.g., differential sync, compression) to reduce network usage and speed up data transfer for corrections and personalized models.
 6. **Database Query Optimization:** Analyze and optimize WatermelonDB queries, especially for frequently accessed data like gesture definitions, user profiles, and correction logs, to ensure fast retrieval and storage.
 7. **Image/Video Asset Optimization:** Implement automatic compression and resolution scaling for DGS demonstration videos and other visual assets to reduce app size and improve loading times.
-8. **Lazy Loading of UI Components:** Implement lazy loading for less frequently used UI components and screens to reduce initial app load time and memory footprint.
+8. **Lazy Loading of UI Components (Implemented):** Implement lazy loading for less frequently used UI components and screens to reduce initial app load time and memory footprint.
 9. **Background Data Pre-fetching:** Pre-fetch necessary data (e.g., common gesture models, user-specific data) in the background when the app is idle or on Wi-Fi to improve responsiveness when the user actively uses the app.
-10. **Reduced Logging Verbosity:** Implement configurable logging levels to reduce verbose logging in production builds, which can impact performance and storage.
+10. **Reduced Logging Verbosity (Implemented):** Implement configurable logging levels to reduce verbose logging in production builds, which can impact performance and storage.
 
 ## II. User Experience & Accessibility
 


### PR DESCRIPTION
## Summary
- lazy load navigation screens with suspense fallback
- centralize logging to allow configurable verbosity
- document implemented optimization ideas

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6892661aad6083228c81660312ffc59a