### PR TITLE
feat: compute analytics rates

### DIFF
--- a/app/test/analytics.test.ts
+++ b/app/test/analytics.test.ts
@@ -30,6 +30,8 @@ describe('Analytics Service', () => {
     const analytics = db.learningAnalytics[0];
     expect(analytics).toBeDefined();
     expect(analytics.successRate7d).toBe(1);
+    expect(analytics.successRate24h).toBe(1);
+    expect(analytics.avgConfidenceScore).toBe(1);
     expect(analytics.improvementTrend).toBeGreaterThan(0);
   });
 
@@ -37,6 +39,8 @@ describe('Analytics Service', () => {
     const db = createDatabase();
     const analytics = computeLearningAnalytics(db);
     expect(analytics.successRate7d).toBe(0);
+    expect(analytics.successRate24h).toBe(0);
+    expect(analytics.avgConfidenceScore).toBe(0);
     expect(analytics.improvementTrend).toBe(0);
   });
 
@@ -80,6 +84,8 @@ describe('Analytics Service', () => {
     refreshLearningAnalytics(db);
     expect(db.learningAnalytics.length).toBe(1);
     expect(db.learningAnalytics[0].successRate7d).toBe(0.5);
+    expect(db.learningAnalytics[0].successRate24h).toBe(0.5);
+    expect(db.learningAnalytics[0].avgConfidenceScore).toBe(0.5);
     expect(db.learningAnalytics[0].improvementTrend).toBe(0.1);
 
     // add an additional failed interaction and refresh again
@@ -96,6 +102,8 @@ describe('Analytics Service', () => {
     const updated = db.learningAnalytics[0];
     expect(db.learningAnalytics.length).toBe(1);
     expect(updated.successRate7d).toBe(0.45);
+    expect(updated.successRate24h).toBe(0.45);
+    expect(updated.avgConfidenceScore).toBe(0.45);
     expect(updated.improvementTrend).toBe(0.05);
   });
 });

--- a/server/src/services/analyticsService.ts
+++ b/server/src/services/analyticsService.ts
@@ -16,20 +16,30 @@ export function computeLearningAnalytics(db: Database): LearningAnalytics {
     (l) => l.timestamp >= prevWeekAgo && l.timestamp < weekAgo,
   );
 
+  const dayAgo = now - 24 * 60 * 60 * 1000;
+  const lastDay = db.interactionLogs.filter((l) => l.timestamp >= dayAgo);
+
   const rate = (logs: typeof recent) =>
     logs.length === 0
       ? 0
       : logs.filter((l) => l.wasSuccessful).length / logs.length;
 
+  const successRate24h = rate(lastDay);
   const successRate7d = rate(recent);
   const improvementTrend = successRate7d - rate(prev);
 
+  const avgConfidenceScore =
+    recent.length === 0
+      ? 0
+      : recent.reduce((sum, l) => sum + l.confidenceScore, 0) /
+        recent.length;
+
   return {
     id: 'default',
-    gestureDefinitionId: 'overall', // Placeholder for now
-    successRate24h: 0, // Placeholder for now
+    gestureDefinitionId: 'overall',
+    successRate24h: Number(successRate24h.toFixed(2)),
     successRate7d: Number(successRate7d.toFixed(2)),
-    avgConfidenceScore: 0, // Placeholder for now
+    avgConfidenceScore: Number(avgConfidenceScore.toFixed(2)),
     improvementTrend: Number(improvementTrend.toFixed(2)),
     lastCalculated: now,
   };
@@ -39,8 +49,11 @@ export function refreshLearningAnalytics(db: Database): void {
   const analytics = computeLearningAnalytics(db);
   const existing = db.learningAnalytics.find((a) => a.id === 'default');
   if (existing) {
+    existing.successRate24h = analytics.successRate24h;
     existing.successRate7d = analytics.successRate7d;
+    existing.avgConfidenceScore = analytics.avgConfidenceScore;
     existing.improvementTrend = analytics.improvementTrend;
+    existing.lastCalculated = analytics.lastCalculated;
   } else {
     db.learningAnalytics.push(analytics);
   }


### PR DESCRIPTION
## Summary
- compute 24h and 7d success rates along with average confidence score
- refresh analytics to persist new metrics
- extend analytics tests to cover new metrics

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68926f930a4c832294b5df3e3c05127f