### PR TITLE
feat: add audio feedback to recognition flow

### DIFF
--- a/app/src/context/AppServicesProvider.tsx
+++ b/app/src/context/AppServicesProvider.tsx
@@ -35,6 +35,7 @@ export const AppServicesProvider = ({ children }: { children: ReactNode }) => {
   
 
   useEffect(() => {
+    let interval: ReturnType<typeof setInterval>;
     async function initializeServices() {
       try {
         const landmarkAsset = Asset.fromModule(HAND_LANDMARKER_MODEL);
@@ -69,9 +70,9 @@ export const AppServicesProvider = ({ children }: { children: ReactNode }) => {
             processingTimeout: REMOTE_TIMEOUT_MS,
           },
         );
+        await audioService.initialize();
         setAreServicesReady(true);
-
-        const interval = setInterval(() => {
+        interval = setInterval(() => {
           syncTrainingData().catch(() => {});
           checkForModelUpdate().catch(() => {});
           syncService.uploadPendingTrainingData().catch(() => {});
@@ -83,7 +84,6 @@ export const AppServicesProvider = ({ children }: { children: ReactNode }) => {
         syncService.uploadPendingTrainingData().catch(() => {});
         syncService.checkForNewModel().catch(() => {});
 
-        return () => clearInterval(interval);
       } catch (e) {
         logger.error('Failed to initialize services:', e);
         setAreServicesReady(true);
@@ -91,6 +91,10 @@ export const AppServicesProvider = ({ children }: { children: ReactNode }) => {
     }
 
     initializeServices();
+    return () => {
+      if (interval) clearInterval(interval);
+      audioService.dispose().catch(() => {});
+    };
   }, []);
 
   if (!areServicesReady) {

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -22,7 +22,7 @@ import { useIsFocused } from '@react-navigation/native';
 import CorrectionPanel from '../components/CorrectionPanel';
 import SymbolVideoPlayer from '../components/SymbolVideoPlayer';
 import { loadProfile, Profile } from '../storage';
-import { playSymbolAudio } from '../services';
+import { audioService } from '../services';
 import { adaptiveLearningService } from '../services/adaptiveLearningService';
 import { database } from '../../db';
 import { Correction, GestureDefinition } from '../../db/models';
@@ -160,12 +160,11 @@ export default function RecognitionScreen({ navigation }: any) {
       setLastRecognizedGesture(entry);
       setStatus(recognizedSymbolLabel);
       startFeedbackAnimation();
-
-      try {
-        playSymbolAudio(entry);
-      } catch (error) {
-        logger.warn('Audio playback failed:', error);
-      }
+      audioService
+        .playSuccessFeedback(recognizedSymbolLabel, result.confidence)
+        .catch((error) => {
+          logger.warn('Audio feedback failed:', error);
+        });
 
       if (useDgs && entry.dgsVideoUri) {
         setShowVideoPlayer(true);
@@ -213,6 +212,9 @@ export default function RecognitionScreen({ navigation }: any) {
       setStatus("Can you help me?");
       setShowHelp(true);
       startFeedbackAnimation();
+      audioService.playErrorFeedback().catch((error) => {
+        logger.warn('Error feedback failed:', error);
+      });
     }
   }, [isProcessing, useDgs, profile, startFeedbackAnimation]);
 
@@ -250,12 +252,11 @@ export default function RecognitionScreen({ navigation }: any) {
       setLastRecognizedGesture(entry);
       setStatus(entry.label);
       startFeedbackAnimation();
-
-      try {
-        playSymbolAudio(entry);
-      } catch (error) {
-        logger.warn('Audio playback failed:', error);
-      }
+      audioService
+        .playSuccessFeedback(entry.label, 1)
+        .catch((error) => {
+          logger.warn('Audio feedback failed:', error);
+        });
 
       if (useDgs && entry.dgsVideoUri) {
         setShowVideoPlayer(true);

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,10 +20,10 @@ The project has a stable foundation after a major refactor. The database, naviga
   - Validate recognition accuracy with test gestures
 
 - [ ] **Rich Audio Feedback System**
-  - Complete `audioService.ts` implementation using `expo-av`
-  - Add success/error sound effects
-  - Implement speech synthesis for recognized gestures
-  - Test audio output quality and timing
+  - [x] Complete `audioService.ts` implementation using `expo-av`
+  - [x] Add success/error sound effects
+  - [x] Implement speech synthesis for recognized gestures
+  - [ ] Test audio output quality and timing
 
 - [ ] **Camera Integration**
   - Finalize `react-native-vision-camera` integration


### PR DESCRIPTION
## Summary
- initialize audio service during app startup and clean up on unmount
- play success and error sounds with speech in gesture recognition screens
- update TODO doc to reflect completed audio feedback steps

## Testing
- `./scripts/full-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68927218dc488322adae03a8a51bb822