### PR TITLE
test: cover offline gesture fallback

### DIFF
--- a/app/test/mlService.test.ts
+++ b/app/test/mlService.test.ts
@@ -40,6 +40,14 @@ jest.mock('react-native-reanimated', () => ({
 }));
 
 describe('mlService', () => {
+  beforeEach(() => {
+    mlService.unloadModels();
+    (mlService as any).gestureBuffer = [];
+    (mlService as any).lastRecognizedGesture = null;
+    (mlService as any).lastGestureTime = 0;
+    jest.resetAllMocks();
+  });
+
   it('should load models and be ready', async () => {
     const landmarkTflite: any = { runSync: () => [[1, 2, 3]] };
     const gestureTflite: any = { runSync: () => [[0.1, 0.9]] };
@@ -47,5 +55,37 @@ describe('mlService', () => {
     await mlService.loadModels(landmarkTflite, gestureTflite, []);
 
     expect(mlService.isServiceReady()).toBe(true);
+  });
+
+  it('falls back to local model when remote classification fails', async () => {
+    const landmarkTflite: any = { runSync: () => [[1, 2, 3]] };
+    const gestureTflite: any = { runSync: () => [[0.2, 0.8]] };
+
+    await mlService.loadModels(landmarkTflite, gestureTflite, ['a', 'b']);
+
+    // simulate remote API failure
+    global.fetch = jest.fn().mockRejectedValue(new Error('network error')) as any;
+
+    const frame = {
+      landmarks: [
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ],
+      width: 1,
+      height: 1,
+      timestamp: Date.now(),
+    } as any;
+
+    const onResult = jest.fn();
+
+    // first call warms up smoothing buffer
+    await mlService.processFrameAsync(frame, onResult);
+    await mlService.processFrameAsync(frame, onResult);
+
+    expect(onResult).toHaveBeenLastCalledWith(
+      expect.objectContaining({ label: 'b', isLocal: true }),
+      frame.landmarks,
+    );
   });
 });

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,10 +14,10 @@ The project has a stable foundation after a major refactor. The database, naviga
 
 ### 🔄 IN PROGRESS / IMMEDIATE
 - [ ] **Gesture Recognition Implementation**
-  - Complete `mlService.ts` TFLite model loading
-  - Implement live gesture classification pipeline
-  - Test offline gesture recognition fallback
-  - Validate recognition accuracy with test gestures
+  - [ ] Complete `mlService.ts` TFLite model loading
+  - [ ] Implement live gesture classification pipeline
+  - [x] Test offline gesture recognition fallback
+  - [ ] Validate recognition accuracy with test gestures
 
 - [x] **Rich Audio Feedback System**
   - [x] Complete `audioService.ts` implementation using `expo-av`


### PR DESCRIPTION
## Summary
- test mlService's ability to fall back to local classification when remote API fails
- document offline gesture recognition test completion in TODO list

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6892ef6be02083229d0e4b6844d2c7c8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for gesture recognition by verifying offline fallback behavior when remote classification fails.
  * Improved test reliability by resetting service state before each test.

* **Documentation**
  * Updated the TODO list to mark the offline gesture recognition fallback test as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->