### PR TITLE
feat: centralize camera permission handling

### DIFF
--- a/app/src/hooks/useCameraPermissionStatus.ts
+++ b/app/src/hooks/useCameraPermissionStatus.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { useCameraPermission } from 'react-native-vision-camera';
+
+/**
+ * Consistent camera permission handling across screens.
+ * React Native Vision Camera's `useCameraPermission` hook returns a new object
+ * on each call, which can lead to stale values if used in multiple places.
+ * This hook wraps it and provides a stable permission flag that updates when
+ * the underlying permission state changes.
+ */
+export function useCameraPermissionStatus() {
+  const { hasPermission, requestPermission } = useCameraPermission();
+  const [granted, setGranted] = useState(hasPermission);
+
+  useEffect(() => {
+    setGranted(hasPermission);
+  }, [hasPermission]);
+
+  return { hasPermission: granted, requestPermission };
+}

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -13,11 +13,8 @@ import {
   AppState,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import {
-  Camera,
-  useCameraDevices,
-  useCameraPermission,
-} from 'react-native-vision-camera';
+import { Camera, useCameraDevices } from 'react-native-vision-camera';
+import { useCameraPermissionStatus } from '../hooks/useCameraPermissionStatus';
 import { useIsFocused } from '@react-navigation/native';
 import CorrectionPanel from '../components/CorrectionPanel';
 import SymbolVideoPlayer from '../components/SymbolVideoPlayer';
@@ -59,7 +56,7 @@ export default function RecognitionScreen({ navigation }: any) {
   const [weakGesture, setWeakGesture] = useState<GestureDefinition | null>(null);
   const [isCameraActive, setIsCameraActive] = useState(true);
   const [isProcessing, setIsProcessing] = useState(false);
-  const [permissionStatus, setPermissionStatus] = useState(useCameraPermission().hasPermission);
+  const { hasPermission, requestPermission } = useCameraPermissionStatus();
   const [lastDetection, setLastDetection] = useState(0);
   const [now, setNow] = useState(Date.now());
   const [landmarks, setLandmarks] = useState<number[][]>([]);
@@ -68,9 +65,11 @@ export default function RecognitionScreen({ navigation }: any) {
   const fadeAnim = useRef(new Animated.Value(1)).current;
   const symbolScaleAnim = useRef(new Animated.Value(0)).current;
 
-  const { requestPermission } = useCameraPermission();
   const devices = useCameraDevices();
-  const device = devices.find(d => d.position === 'back') ?? devices.find(d => d.position === 'front') ?? devices[0];
+  const device =
+    devices.find((d) => d.position === 'back') ??
+    devices.find((d) => d.position === 'front') ??
+    devices[0];
   const isFocused = useIsFocused();
   const [appState, setAppState] = useState(AppState.currentState);
   useEffect(() => {
@@ -79,13 +78,11 @@ export default function RecognitionScreen({ navigation }: any) {
   }, []);
 
   const canUseCamera =
-    permissionStatus && device != null && isFocused && isCameraActive && appState === 'active';
+    hasPermission && device != null && isFocused && isCameraActive && appState === 'active';
 
   const handleRequestPermission = useCallback(async () => {
     logger.debug('Requesting camera permission...');
-    const result = await requestPermission();
-    logger.debug('Permission result:', result);
-    setPermissionStatus(result);
+    await requestPermission();
   }, [requestPermission]);
 
   useEffect(() => {
@@ -458,7 +455,7 @@ export default function RecognitionScreen({ navigation }: any) {
     },
   });
 
-  if (!permissionStatus) {
+  if (!hasPermission) {
     const gradientColors = highContrast
       ? ([COLORS.highContrastBackground, COLORS.highContrastBackground] as const)
       : ([COLORS.backgroundStart, COLORS.backgroundEnd] as const);

--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -1,11 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { View, Text, Button, StyleSheet, Alert, TextInput, Animated, Easing, SafeAreaView } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import {
-  Camera,
-  useCameraDevices,
-  useCameraPermission,
-} from 'react-native-vision-camera';
+import { Camera, useCameraDevices } from 'react-native-vision-camera';
+import { useCameraPermissionStatus } from '../hooks/useCameraPermissionStatus';
 import { mlService } from '../services/mlService';
 import { audioService } from '../services/audioService';
 import { saveTrainingSample, loadProfile, Profile } from '../storage';
@@ -20,7 +17,7 @@ export default function TeachingScreen({ navigation }: any) {
   const { largeText, highContrast } = useAccessibility();
   const devices = useCameraDevices();
   const device = devices.find(d => d.position === 'back') ?? devices.find(d => d.position === 'front') ?? devices[0];
-  const { hasPermission, requestPermission } = useCameraPermission();
+  const { hasPermission, requestPermission } = useCameraPermissionStatus();
   const camera = useRef<Camera>(null);
   const [gestureLabel, setGestureLabel] = useState('');
   const [isSessionActive, setIsSessionActive] = useState(false);

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -1,11 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, Button, StyleSheet, AppState, SafeAreaView } from 'react-native';
 import { useIsFocused } from '@react-navigation/native';
-import {
-  Camera,
-  useCameraDevice,
-  useCameraPermission,
-} from 'react-native-vision-camera';
+import { Camera, useCameraDevice } from 'react-native-vision-camera';
+import { useCameraPermissionStatus } from '../hooks/useCameraPermissionStatus';
 import Svg, { Circle } from 'react-native-svg';
 import { saveTrainingSample, loadProfile, Profile } from '../storage';
 import { gestureModel } from '../model';
@@ -27,7 +24,7 @@ export default function TrainingScreen({ navigation, route }: any) {
   const backCamera = useCameraDevice('back');
   const frontCamera = useCameraDevice('front');
   const device = backCamera ?? frontCamera;
-  const { hasPermission, requestPermission } = useCameraPermission();
+  const { hasPermission, requestPermission } = useCameraPermissionStatus();
   const [gestureId, setGestureId] = useState<string | null>(gestureLabel || null);
   const [count, setCount] = useState(0);
   const [isRecording, setIsRecording] = useState(false);


### PR DESCRIPTION
## Summary
- add `useCameraPermissionStatus` for stable camera permission state
- integrate new hook into recognition, training, and teaching screens

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689325d9cc948322bebbb7a4f30ff484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved camera permission handling for a more consistent experience across multiple screens.
* **Refactor**
  * Updated camera permission logic in several screens to use a unified approach, enhancing reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->