### PR TITLE
feat: improve onboarding flow

### DIFF
--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -1,8 +1,9 @@
 
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { RootStackParamList } from './types';
+import { loadProfiles } from '../storage';
 
 const lazyScreen = (
   factory: () => Promise<any>,
@@ -36,9 +37,19 @@ const Loading = () => (
 );
 
 const RootNavigator = () => {
+  const [initialRoute, setInitialRoute] = useState<keyof RootStackParamList | undefined>();
+
+  useEffect(() => {
+    loadProfiles().then((profiles) => {
+      setInitialRoute(profiles.length > 0 ? 'ProfileSelect' : 'Onboarding');
+    });
+  }, []);
+
+  if (!initialRoute) return <Loading />;
+
   return (
     <Suspense fallback={<Loading />}>
-      <Stack.Navigator initialRouteName="Onboarding">
+      <Stack.Navigator initialRouteName={initialRoute}>
       <Stack.Screen
         name="Onboarding"
         component={OnboardingScreen}

--- a/app/src/screens/OnboardingScreen.tsx
+++ b/app/src/screens/OnboardingScreen.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { View, Text, Switch, Button, StyleSheet, SafeAreaView, TextInput } from 'react-native';
+import {
+  View,
+  Text,
+  Switch,
+  Button,
+  StyleSheet,
+  SafeAreaView,
+  TextInput,
+} from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { createProfile } from '../storage';
 import {
@@ -50,6 +58,12 @@ export default function OnboardingScreen({ navigation }: any) {
     },
     heart: { fontSize: largeText ? 80 : 64, textAlign: 'center', marginBottom: SPACING.lg, color: highContrast ? COLORS.highContrastText : COLORS.text },
     title: { fontSize: largeText ? 32 : 24, textAlign: 'center', marginBottom: SPACING.lg, color: highContrast ? COLORS.highContrastText : COLORS.text },
+    privacy: {
+      fontSize: largeText ? 18 : 14,
+      textAlign: 'center',
+      marginBottom: SPACING.lg,
+      color: highContrast ? COLORS.highContrastText : COLORS.text,
+    },
     toggleRow: {
       width: '100%',
       flexDirection: 'row',
@@ -70,6 +84,13 @@ export default function OnboardingScreen({ navigation }: any) {
     <SafeAreaView style={styles.container}>
       <Text style={styles.heart}>❤️</Text>
       <Text style={styles.title}>Welcome to Amy's Echo</Text>
+      <Text
+        style={styles.privacy}
+        accessibilityLabel="Datenschutzhinweis"
+      >
+        Your child's data stays on this device unless you allow uploads. Uploading
+        anonymized data helps improve recognition.
+      </Text>
       <TextInput
         style={styles.input}
         placeholder="Name"

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -37,10 +37,10 @@ The project has a stable foundation after a major refactor. The database, naviga
 
 ### Core HIP (Human Interaction Protocol) Implementation
 - [ ] **HIP 1: Onboarding Flow**
-  - Complete consent and first-use setup
-  - Add privacy explanation for caregivers
-  - Implement gesture recognition tutorial
-  - Test with non-technical users
+  - [x] Complete consent and first-use setup
+  - [x] Add privacy explanation for caregivers
+  - [ ] Implement gesture recognition tutorial
+  - [ ] Test with non-technical users
 
 - [ ] **HIP 3: Correction Mode ("Help Me" Flow)**
   - Implement gesture correction interface


### PR DESCRIPTION
## Summary
- show onboarding only on first launch by checking for existing profiles
- explain data privacy to caregivers during onboarding
- mark onboarding tasks complete in docs

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6893298a2b108322a052220939bd4593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now dynamically chooses the starting screen based on stored profile data, ensuring users are directed to the appropriate screen on launch.
  * A privacy notice has been added to the onboarding screen, clearly explaining data handling and privacy practices.

* **Documentation**
  * Updated the onboarding flow checklist to reflect completed tasks related to consent setup and privacy explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->