### PR TITLE
feat: add gesture tutorial screen

### DIFF
--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -13,6 +13,9 @@ const lazyScreen = (
   );
 
 const OnboardingScreen = lazyScreen(() => import('../screens/OnboardingScreen.js'));
+const GestureTutorialScreen = lazyScreen(
+  () => import('../screens/GestureTutorialScreen.js'),
+);
 const ProfileSelectScreen = lazyScreen(() => import('../screens/ProfileSelectScreen.js'));
 const RecognitionScreen = lazyScreen(() => import('../screens/RecognitionScreen.js'));
 const CorrectionScreen = lazyScreen(() => import('../screens/CorrectionScreen.js'));
@@ -53,6 +56,11 @@ const RootNavigator = () => {
       <Stack.Screen
         name="Onboarding"
         component={OnboardingScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="Tutorial"
+        component={GestureTutorialScreen}
         options={{ headerShown: false }}
       />
       <Stack.Screen

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -1,5 +1,6 @@
 export type RootStackParamList = {
   Onboarding: undefined;
+  Tutorial: undefined;
   ProfileSelect: undefined;
   Recognition: { profileId: string; simulateLowConfidence?: boolean };
   Correction: { gesture: string; suggestions: string[] };

--- a/app/src/screens/GestureTutorialScreen.tsx
+++ b/app/src/screens/GestureTutorialScreen.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button, SafeAreaView } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useAccessibility } from '../components/AccessibilityContext';
+import { COLORS, SPACING } from '../constants/ui';
+
+export default function GestureTutorialScreen({ navigation }: any) {
+  const { largeText, highContrast } = useAccessibility();
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: SPACING.lg,
+      backgroundColor: 'transparent',
+    },
+    title: {
+      fontSize: largeText ? 32 : 24,
+      textAlign: 'center',
+      marginBottom: SPACING.lg,
+      color: highContrast ? COLORS.highContrastText : COLORS.text,
+    },
+    text: {
+      fontSize: largeText ? 22 : 16,
+      textAlign: 'center',
+      marginBottom: SPACING.md,
+      color: highContrast ? COLORS.highContrastText : COLORS.text,
+    },
+    button: {
+      marginTop: SPACING.lg,
+    },
+  });
+
+  const gradientColors = highContrast
+    ? ([COLORS.highContrastBackground, COLORS.highContrastBackground] as const)
+    : ([COLORS.backgroundStart, COLORS.backgroundEnd] as const);
+
+  return (
+    <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.title}>How to use gestures</Text>
+        <Text style={styles.text}>1. Make sure your hand is visible to the camera.</Text>
+        <Text style={styles.text}>2. Hold your hand steady while making the sign.</Text>
+        <Text style={styles.text}>3. Wait for the sound to confirm recognition.</Text>
+        <View style={styles.button}>
+          <Button
+            title="Start"
+            onPress={() => navigation.replace('ProfileSelect')}
+            accessibilityLabel="Tutorial beenden"
+            color={COLORS.primaryAccent}
+          />
+        </View>
+      </SafeAreaView>
+    </LinearGradient>
+  );
+}
+

--- a/app/src/screens/OnboardingScreen.tsx
+++ b/app/src/screens/OnboardingScreen.tsx
@@ -37,7 +37,7 @@ export default function OnboardingScreen({ navigation }: any) {
     });
     setActiveVocabularySet(vocabSet);
     update({ largeText, highContrast });
-    navigation.replace('ProfileSelect');
+    navigation.replace('Tutorial');
   };
 
   const styles = StyleSheet.create({

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -39,7 +39,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [ ] **HIP 1: Onboarding Flow**
   - [x] Complete consent and first-use setup
   - [x] Add privacy explanation for caregivers
-  - [ ] Implement gesture recognition tutorial
+  - [x] Implement gesture recognition tutorial
   - [ ] Test with non-technical users
 
 - [ ] **HIP 3: Correction Mode ("Help Me" Flow)**


### PR DESCRIPTION
## Summary
- add GestureTutorialScreen for onboarding
- wire into navigation and onboarding flow
- mark gesture tutorial todo complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68932bb26bc48322ae9b99a0d875529b