### PR TITLE
feat: log corrections for adaptive learning

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -18,7 +18,7 @@ import { useCameraPermissionStatus } from '../hooks/useCameraPermissionStatus';
 import { useIsFocused } from '@react-navigation/native';
 import CorrectionPanel from '../components/CorrectionPanel';
 import SymbolVideoPlayer from '../components/SymbolVideoPlayer';
-import { loadProfile, Profile } from '../storage';
+import { loadProfile, Profile, logCorrection } from '../storage';
 import { audioService } from '../services';
 import { adaptiveLearningService } from '../services/adaptiveLearningService';
 import { database } from '../../db';
@@ -235,6 +235,8 @@ export default function RecognitionScreen({ navigation }: any) {
           r.isSynced = false;
         });
       });
+
+      await logCorrection(choiceId);
 
       const entry =
         gestureModel.gestures.find((g) => g.id === choiceId) || {

--- a/app/test/correctionStorage.test.ts
+++ b/app/test/correctionStorage.test.ts
@@ -1,0 +1,43 @@
+const store: Record<string, string> = {};
+const stubAsync = {
+  async getItem(key: string) {
+    return store[key] ?? null;
+  },
+  async setItem(key: string, value: string) {
+    store[key] = value;
+  },
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => stubAsync);
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: async () => null,
+  setItemAsync: async () => {},
+}));
+jest.mock('../db', () => ({ database: {} }));
+jest.mock('../db/models', () => ({}));
+
+import { logCorrection } from '../src/storage';
+
+describe('logCorrection', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+  });
+
+  it('stores correction samples and logs', async () => {
+    await logCorrection('gesture1');
+
+    const trainingRaw = store['gestureTrainingData'];
+    expect(trainingRaw).toBeTruthy();
+    const training = JSON.parse(trainingRaw as string);
+    expect(training).toHaveLength(1);
+    expect(training[0].gestureDefinitionId).toBe('gesture1');
+    expect(training[0].source).toBe('HIP_3');
+
+    const logsRaw = store['interactionLogs'];
+    expect(logsRaw).toBeTruthy();
+    const logs = JSON.parse(logsRaw as string);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].gestureDefinitionId).toBe('gesture1');
+    expect(logs[0].wasSuccessful).toBe(true);
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -45,7 +45,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [ ] **HIP 3: Correction Mode ("Help Me" Flow)**
   - Implement gesture correction interface
   - Add "Help Me" repair workflow
-  - Store corrections for model improvement
+  - [x] Store corrections for model improvement
   - Test correction feedback loop
 
 - [ ] **HIP 2: Teach Mode (Training Interface)**


### PR DESCRIPTION
## Summary
- log caregiver-selected corrections during recognition to feed adaptive learning
- add test ensuring correction logging persists training data and interaction logs
- mark TODO for storing corrections as complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm run type-check --prefix server`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68932f044ec48322b93d752cc2ee64f0