### PR TITLE
feat: add dialog memory for LLM suggestions

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -47,6 +47,7 @@ export default function RecognitionScreen({ navigation }: any) {
     nextWords: [],
     caregiverPhrases: [],
   });
+  const [dialogContext, setDialogContext] = useState<string[]>([]);
   const [useDgs, setUseDgs] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [correctionOptions, setCorrectionOptions] = useState<{ id: string; label: string }[]>([]);
@@ -180,11 +181,15 @@ export default function RecognitionScreen({ navigation }: any) {
       try {
         const adv = await dialogEngine.getLLMSuggestions({
           input: recognizedSymbolLabel,
-          context: [],
+          context: dialogContext,
           language: 'de',
           age: 4,
         });
         setSuggestions(adv);
+        setDialogContext((ctx) => {
+          const next = [...ctx, recognizedSymbolLabel];
+          return next.slice(-5);
+        });
       } catch (error) {
         logger.warn('Failed to get LLM suggestions:', error);
       }
@@ -274,11 +279,15 @@ export default function RecognitionScreen({ navigation }: any) {
       try {
         const adv = await dialogEngine.getLLMSuggestions({
           input: entry.label,
-          context: [],
+          context: dialogContext,
           language: 'de',
           age: 4,
         });
         setSuggestions(adv);
+        setDialogContext((ctx) => {
+          const next = [...ctx, entry.label];
+          return next.slice(-5);
+        });
       } catch (error) {
         logger.warn('Failed to get LLM suggestions:', error);
       }

--- a/app/src/services/dialogEngine.ts
+++ b/app/src/services/dialogEngine.ts
@@ -12,6 +12,15 @@ export type LLMSuggestionResponse = {
 };
 
 class DialogEngine {
+  private history: { role: 'user' | 'assistant'; content: string }[] = [];
+
+  /**
+   * Reset the stored conversation history. Useful for new sessions
+   * or when switching profiles.
+   */
+  public resetHistory() {
+    this.history = [];
+  }
   /**
    * Return adaptive suggestions based on last selected symbol.
    * Currently a simple placeholder using local vocabulary order.
@@ -70,7 +79,7 @@ class DialogEngine {
         },
         body: JSON.stringify({
           model: MODEL,
-          messages: [{ role: 'user', content: prompt }],
+          messages: [...this.history, { role: 'user', content: prompt }],
           response_format: { type: 'json_object' },
           temperature: 0.7,
         }),
@@ -82,7 +91,16 @@ class DialogEngine {
       }
 
       const data = await response.json();
-      const content = JSON.parse(data.choices?.[0]?.message?.content || '{}');
+      const messageContent = data.choices?.[0]?.message?.content || '{}';
+
+      // Update conversation history with the latest exchange
+      this.history.push({ role: 'user', content: prompt });
+      this.history.push({ role: 'assistant', content: messageContent });
+      if (this.history.length > 10) {
+        this.history = this.history.slice(-10);
+      }
+
+      const content = JSON.parse(messageContent);
       return {
         nextWords: content.nextWords || [],
         caregiverPhrases: content.caregiverPhrases || [],

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -62,9 +62,9 @@ The project has a stable foundation after a major refactor. The database, naviga
 
 ### Enhanced Intelligence Features
 - [ ] **Live LLM Dialog Engine**
-  - Complete `dialogEngine.ts` OpenAI API integration
-  - Implement context-aware suggestions
-  - Add conversation memory for better responses
+  - [x] Complete `dialogEngine.ts` OpenAI API integration
+  - [x] Implement context-aware suggestions
+  - [x] Add conversation memory for better responses
   - Test suggestion quality and relevance
 
 - [ ] **DGS Video Playback System**


### PR DESCRIPTION
## Summary
- add conversation memory support in dialog engine
- pass prior recognized gestures as context for LLM suggestions
- update TODOs for LLM dialog engine progress

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68933205da5083228427c0c371c4dc1a