### PR TITLE
feat(training): add gesture validation feedback

### DIFF
--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -99,10 +99,15 @@ export default function TrainingScreen({ navigation, route }: any) {
 
   const stopRecording = async () => {
     setIsRecording(false);
-    if (!gestureId || recordedLandmarks.length < 10) return;
+    if (!gestureId) return;
+    if (recordedLandmarks.length < 10) {
+      setError('Recording too short. Please record again with clear hand movement.');
+      return;
+    }
     try {
       await saveTrainingSample(gestureId, recordedLandmarks);
       setCount((c) => c + 1);
+      setError(null);
     } catch (e) {
       logger.error('Failed to save training sample', e);
       setError('Failed to save training sample');

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -51,7 +51,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [ ] **HIP 2: Teach Mode (Training Interface)**
   - Build caregiver training interface for new signs
   - Implement gesture recording workflow
-  - Add gesture validation feedback
+  - [x] Add gesture validation feedback
   - Create training progress tracking
 
 - [ ] **HIP 4: Maintenance Mode**


### PR DESCRIPTION
## Summary
- provide user feedback when a training recording is too short
- document validation feedback completion in TODO list

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68933f45d0f8832283a89234b85c4030