### PR TITLE
feat: add practice session logging

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -316,7 +316,7 @@ export default function RecognitionScreen({ navigation }: any) {
 
   const handleWeakGestureBannerPress = () => {
     if (weakGesture) {
-      navigation.navigate('Training', { gestureLabel: weakGesture.name });
+      navigation.navigate('Training', { gestureLabel: weakGesture.name, isPractice: true });
       setWeakGesture(null);
     }
   };

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -19,7 +19,7 @@ import { logger } from '../utils/logger';
 export default function TrainingScreen({ navigation, route }: any) {
   const { largeText, highContrast } = useAccessibility();
   const PREVIEW_SIZE = 200;
-  const { gestureLabel } = route.params || {};
+  const { gestureLabel, isPractice } = route.params || {};
   // Prefer the back camera but fall back to front if unavailable
   const backCamera = useCameraDevice('back');
   const frontCamera = useCameraDevice('front');
@@ -105,7 +105,7 @@ export default function TrainingScreen({ navigation, route }: any) {
       return;
     }
     try {
-      await saveTrainingSample(gestureId, recordedLandmarks);
+      await saveTrainingSample(gestureId, recordedLandmarks, isPractice ? 'HIP_4' : 'HIP_2');
       setCount((c) => c + 1);
       setError(null);
     } catch (e) {
@@ -181,7 +181,13 @@ export default function TrainingScreen({ navigation, route }: any) {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
-        <Text style={styles.title}>Training {gestureId ? `for ${gestureId}` : 'Mode'}</Text>
+        <Text style={styles.title}>
+          {isPractice
+            ? gestureId
+              ? `Practice ${gestureId}`
+              : 'Practice Mode'
+            : `Training ${gestureId ? `for ${gestureId}` : 'Mode'}`}
+        </Text>
         {!gestureId ? (
           gestureModel.gestures.map((g) => (
             <Button

--- a/app/src/storage.ts
+++ b/app/src/storage.ts
@@ -21,7 +21,7 @@ export interface TrainingSample {
   id: string;
   gestureDefinitionId: string;
   landmarkData: unknown;
-  source: 'HIP_2' | 'HIP_3';
+  source: 'HIP_2' | 'HIP_3' | 'HIP_4';
   syncStatus: 'pending' | 'synced';
 }
 
@@ -114,6 +114,7 @@ export async function logCorrection(correctId: string): Promise<void> {
 export async function saveTrainingSample(
   gestureDefinitionId: string,
   landmarkData: unknown,
+  source: 'HIP_2' | 'HIP_4' = 'HIP_2',
 ): Promise<void> {
   const raw = await AsyncStorage.getItem(TRAINING_KEY);
   const data: TrainingSample[] = raw ? JSON.parse(raw) : [];
@@ -121,7 +122,7 @@ export async function saveTrainingSample(
     id: genId(),
     gestureDefinitionId,
     landmarkData,
-    source: 'HIP_2',
+    source,
     syncStatus: 'pending',
   });
   await AsyncStorage.setItem(TRAINING_KEY, JSON.stringify(data));
@@ -131,7 +132,7 @@ export async function saveTrainingSample(
     await collection.create((record) => {
       record.gestureDefinition.id = gestureDefinitionId;
       record.landmarkData = JSON.stringify(landmarkData);
-      record.source = 'HIP_2';
+      record.source = source;
       record.qualityScore = 1;
       record.frameMetadata = '';
       record.createdAt = new Date();

--- a/app/test/practiceStorage.test.ts
+++ b/app/test/practiceStorage.test.ts
@@ -1,0 +1,55 @@
+const store: Record<string, string> = {};
+const stubAsync = {
+  async getItem(key: string) {
+    return store[key] ?? null;
+  },
+  async setItem(key: string, value: string) {
+    store[key] = value;
+  },
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => stubAsync);
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: async () => null,
+  setItemAsync: async () => {},
+}));
+
+const mockCreate = jest.fn(async (fn: any) => {
+  await fn({ gestureDefinition: { id: '' } });
+});
+const mockGet = jest.fn(() => ({ create: mockCreate }));
+const mockWrite = jest.fn(async (fn: any) => { await fn(); });
+
+jest.mock('../db', () => ({
+  database: {
+    get: mockGet,
+    write: mockWrite,
+  },
+}));
+
+jest.mock('../db/models', () => ({}));
+
+import { saveTrainingSample } from '../src/storage';
+
+describe('saveTrainingSample', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+    mockCreate.mockClear();
+  });
+
+  it('stores samples with default HIP_2 source', async () => {
+    await saveTrainingSample('gesture1', []);
+    const raw = store['gestureTrainingData'];
+    expect(raw).toBeTruthy();
+    const data = JSON.parse(raw as string);
+    expect(data[0].source).toBe('HIP_2');
+  });
+
+  it('stores samples with HIP_4 source when specified', async () => {
+    await saveTrainingSample('gesture1', [], 'HIP_4');
+    const raw = store['gestureTrainingData'];
+    expect(raw).toBeTruthy();
+    const data = JSON.parse(raw as string);
+    expect(data[0].source).toBe('HIP_4');
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -55,8 +55,8 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Create training progress tracking
 
 - [ ] **HIP 4: Maintenance Mode**
-  - Implement "Let's practice this again" feature
-  - Add gesture practice sessions
+  - [x] Implement "Let's practice this again" feature
+  - [x] Add gesture practice sessions
   - Create progress tracking dashboard
   - Implement gentle encouragement system
 


### PR DESCRIPTION
## Summary
- mark and log HIP 4 practice sessions in training data
- pass practice flag from recognition screen and update training screen UI
- document completion of Maintenance Mode practice tasks

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689351d4f6648322869c7fe50cd4cfa0