### PR TITLE
docs: add troubleshooting guide

### DIFF
--- a/docs/CaregiverQuickStartGuide.md
+++ b/docs/CaregiverQuickStartGuide.md
@@ -43,5 +43,8 @@ This guide helps caregivers get Amy's Echo running and begin supporting a child'
 1. In the **Admin Panel**, enter the OpenAI API key and backend token if required.
 2. Tap **Save** for each field. Tokens are stored securely on the device.
 
+## 7. Need Help?
+If you run into problems during setup or usage, consult the [Troubleshooting Guide](Troubleshooting.md) for common fixes.
+
 ---
 With these steps, caregivers can immediately begin using Amy's Echo to translate gestures into speech and track learning progress.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -183,7 +183,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 ### Documentation & Support
 - [ ] **User Documentation**
   - [x] Create caregiver quick start guide
-  - Add troubleshooting documentation
+  - [x] Add troubleshooting documentation
   - Create video tutorials for setup
   - Translate documentation to German
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,0 +1,31 @@
+# Troubleshooting Guide
+
+This guide lists common issues encountered when setting up or running **Amy's Echo** and how to resolve them.
+
+## App fails to start
+- Ensure all dependencies are installed:
+  ```bash
+  npm install
+  npm install --prefix app
+  npm install --prefix server
+  ```
+- If the metro bundler does not start, run `npm start --prefix app` manually.
+
+## Models fail to download
+- Run the model download script again:
+  ```bash
+  npm run build --prefix server
+  node server/dist/tools/downloadModels.js
+  ```
+- Confirm that the device has enough storage space.
+
+## Camera or microphone not working
+- Verify that permissions are granted in the device settings.
+- Close other apps that might be using the camera or microphone.
+
+## Gesture not recognized
+- Make sure there is adequate lighting and the hand is fully within the camera frame.
+- Re-run the gesture teaching flow from the **Admin Panel** to add more samples.
+
+If problems persist, please open an issue in the repository with logs or screenshots so the team can assist.
+


### PR DESCRIPTION
## Summary
- add troubleshooting guide for common setup and runtime issues
- link troubleshooting guide from caregiver quick start guide
- mark troubleshooting docs task as complete in project TODO

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689365640e748322af656ee2b6b455e2