### PR TITLE
feat: add progress tracking dashboard

### DIFF
--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -30,6 +30,7 @@ const ParentalGateScreen = lazyScreen(
 const AdminScreen = lazyScreen(() => import('../screens/AdminScreen.js'));
 const DashboardScreen = lazyScreen(() => import('../screens/DashboardScreen.js'));
 const HelpScreen = lazyScreen(() => import('../screens/HelpScreen.js'));
+const ProgressScreen = lazyScreen(() => import('../screens/ProgressScreen.js'));
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -107,6 +108,11 @@ const RootNavigator = () => {
         name="Dashboard"
         component={DashboardScreen}
         options={{ title: 'Analytics' }}
+      />
+      <Stack.Screen
+        name="Progress"
+        component={ProgressScreen}
+        options={{ title: 'Progress' }}
       />
       <Stack.Screen
         name="Help"

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -10,5 +10,6 @@ export type RootStackParamList = {
   ParentalGate: { target: string };
   Admin: undefined;
   Dashboard: undefined;
+  Progress: undefined;
   Help: undefined;
 };

--- a/app/src/screens/ParentScreen.tsx
+++ b/app/src/screens/ParentScreen.tsx
@@ -69,6 +69,11 @@ export default function ParentScreen({ navigation }: any) {
         accessibilityLabel="View analytics"
       />
       <Button
+        title="Progress"
+        onPress={() => navigation.navigate('Progress')}
+        accessibilityLabel="View progress"
+      />
+      <Button
         title="Help"
         onPress={() => navigation.navigate('Help')}
         accessibilityLabel="Get help"

--- a/app/src/screens/ProgressScreen.tsx
+++ b/app/src/screens/ProgressScreen.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, Button, StyleSheet } from 'react-native';
+import { loadUsageStats } from '../services/usageTracker';
+import { loadProfile, Profile } from '../storage';
+import { gestureModel } from '../model';
+import { useAccessibility } from '../components/AccessibilityContext';
+import { COLORS, SPACING } from '../constants/ui';
+
+export default function ProgressScreen({ navigation }: any) {
+  const { largeText, highContrast } = useAccessibility();
+  const [stats, setStats] = useState<Record<string, number>>({});
+  const [profile, setProfile] = useState<Profile | null>(null);
+
+  useEffect(() => {
+    loadProfile().then((p) => {
+      setProfile(p);
+      if (p) {
+        loadUsageStats(p.id).then(setStats);
+      }
+    });
+  }, []);
+
+  const entries = gestureModel.gestures
+    .map((g) => ({ ...g, count: stats[g.id] || 0 }))
+    .filter((e) => e.count > 0);
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      padding: SPACING.lg,
+      backgroundColor: highContrast ? COLORS.highContrastBackground : COLORS.surface,
+    },
+    title: {
+      fontSize: largeText ? 24 : 20,
+      marginBottom: SPACING.md,
+      color: highContrast ? COLORS.highContrastText : COLORS.text,
+    },
+    item: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginBottom: SPACING.sm,
+    },
+    label: {
+      fontSize: largeText ? 20 : 16,
+      color: highContrast ? COLORS.highContrastText : COLORS.text,
+    },
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Progress</Text>
+      <FlatList
+        data={entries}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <Text style={styles.label}>{item.label}</Text>
+            <Text style={styles.label}>{item.count}</Text>
+          </View>
+        )}
+        ListEmptyComponent={<Text style={styles.label}>No usage yet</Text>}
+      />
+      <Button title="Back" onPress={() => navigation.goBack()} accessibilityLabel="Zurück" />
+    </View>
+  );
+}

--- a/app/test/progressScreen.test.tsx
+++ b/app/test/progressScreen.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock('react-native', () => {
+  const React = require('react');
+  return {
+    View: (props: any) => React.createElement('View', props, props.children),
+    Text: (props: any) => React.createElement('Text', props, props.children),
+    Button: (props: any) => React.createElement('Button', props, props.children),
+    FlatList: ({ data, renderItem, ListEmptyComponent }: any) =>
+      React.createElement(
+        'FlatList',
+        null,
+        data && data.length
+          ? data.map((item: any, index: number) => renderItem({ item, index }))
+          : ListEmptyComponent || null,
+      ),
+    StyleSheet: { create: () => ({}) },
+  };
+});
+
+jest.mock('../src/services/usageTracker', () => ({
+  loadUsageStats: jest.fn(() => Promise.resolve({ hello: 3 })),
+}));
+
+jest.mock('../src/storage', () => ({
+  loadProfile: jest.fn(() =>
+    Promise.resolve({
+      id: 'p1',
+      name: 'Test',
+      consentDataUpload: true,
+      consentHelpMeGetSmarter: true,
+      vocabularySetId: 'basic',
+    }),
+  ),
+}));
+
+jest.mock('../src/components/AccessibilityContext', () => ({
+  useAccessibility: () => ({ largeText: false, highContrast: false }),
+}));
+
+import ProgressScreen from '../src/screens/ProgressScreen';
+
+describe('ProgressScreen', () => {
+  it('renders usage statistics', async () => {
+    let component: renderer.ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<ProgressScreen navigation={{ goBack: jest.fn() }} />);
+    });
+    const textNodes = (component as renderer.ReactTestRenderer).root.findAll((node) => node.type === 'Text');
+    const contents = textNodes.map((n) => n.props.children);
+    expect(contents).toContain('👋 Hallo');
+    expect(contents).toContain(3);
+  });
+});
+

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -57,7 +57,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [ ] **HIP 4: Maintenance Mode**
   - [x] Implement "Let's practice this again" feature
   - [x] Add gesture practice sessions
-  - Create progress tracking dashboard
+  - [x] Create progress tracking dashboard
   - Implement gentle encouragement system
 
 ### Enhanced Intelligence Features


### PR DESCRIPTION
## Summary
- introduce Progress screen showing per-gesture usage stats
- wire progress screen into navigation and parent menu
- document completion of progress tracking dashboard in TODOs

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689375a466d08322a1e4622cd9f5325c