### PR TITLE
feat: encourage practice

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -91,6 +91,13 @@ export default function RecognitionScreen({ navigation }: any) {
     const fetchWeakGesture = async () => {
       const gesture = await adaptiveLearningService.getWeakGesture();
       setWeakGesture(gesture);
+      if (gesture) {
+        try {
+          await audioService.playEncouragement(gesture.name);
+        } catch (error) {
+          logger.warn('Encouragement audio failed:', error);
+        }
+      }
     };
     fetchWeakGesture();
   }, []);

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -7,7 +7,7 @@ import Svg, { Circle } from 'react-native-svg';
 import { saveTrainingSample, loadProfile, Profile } from '../storage';
 import { gestureModel } from '../model';
 import { useAccessibility } from '../components/AccessibilityContext';
-import { useRecordingProcessor } from '../services';
+import { useRecordingProcessor, audioService } from '../services';
 import { useTensorflowModel } from '../hooks/useTensorflowModel';
 import { HAND_LANDMARKER_MODEL } from '../constants/modelPaths';
 import { setHandLandmarkModel } from '../services/landmarkExtractor';
@@ -108,6 +108,9 @@ export default function TrainingScreen({ navigation, route }: any) {
       await saveTrainingSample(gestureId, recordedLandmarks, isPractice ? 'HIP_4' : 'HIP_2');
       setCount((c) => c + 1);
       setError(null);
+      if (isPractice) {
+        await audioService.playEncouragement(gestureId);
+      }
     } catch (e) {
       logger.error('Failed to save training sample', e);
       setError('Failed to save training sample');

--- a/app/src/services/audioService.ts
+++ b/app/src/services/audioService.ts
@@ -285,6 +285,27 @@ export class AudioService {
   }
 
   /**
+   * Speak a gentle encouragement message.
+   * When a gesture name is provided, it will be referenced in the message.
+   */
+  async playEncouragement(gesture?: string): Promise<void> {
+    const phrases = gesture
+      ? [
+          `Möchtest du das Zeichen ${gesture} nochmal üben?`,
+          `Lass uns ${gesture} nochmal versuchen!`,
+          `Wie wäre es mit etwas Übung für ${gesture}?`,
+        ]
+      : [
+          'Weiter so!',
+          'Du machst das toll!',
+          'Prima, weiter üben!'
+        ];
+
+    const phrase = phrases[Math.floor(Math.random() * phrases.length)];
+    await this.speak(phrase, { pitch: 1.1, rate: 0.9 });
+  }
+
+  /**
    * Start audio recording for custom cues
    */
   async startRecording(): Promise<void> {

--- a/app/test/audioFeedback.test.ts
+++ b/app/test/audioFeedback.test.ts
@@ -88,5 +88,15 @@ describe('audioService feedback', () => {
     expect(Speech.speak).toHaveBeenCalled();
     expect(Haptics.notificationAsync).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Error);
   });
+
+  it('speaks gentle encouragement for a gesture', async () => {
+    await audioService.playEncouragement('Winken');
+    const phrase = (Speech.speak as jest.Mock).mock.calls[0][0];
+    expect([
+      'Möchtest du das Zeichen Winken nochmal üben?',
+      'Lass uns Winken nochmal versuchen!',
+      'Wie wäre es mit etwas Übung für Winken?',
+    ]).toContain(phrase);
+  });
 });
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -54,11 +54,11 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Add gesture validation feedback
   - [x] Create training progress tracking
 
-- [ ] **HIP 4: Maintenance Mode**
+- [x] **HIP 4: Maintenance Mode**
   - [x] Implement "Let's practice this again" feature
   - [x] Add gesture practice sessions
   - [x] Create progress tracking dashboard
-  - Implement gentle encouragement system
+  - [x] Implement gentle encouragement system
 
 ### Enhanced Intelligence Features
 - [ ] **Live LLM Dialog Engine**


### PR DESCRIPTION
## Summary
- add audio-based encouragement helper
- encourage practice mode and weak gesture banner
- track gentle encouragement as complete in TODO docs

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689378bd521c8322937e9c2b17399be6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio encouragement feedback when practicing gestures or after fetching a weak gesture, providing personalized or generic motivational phrases.
* **Tests**
  * Introduced new tests to verify the correct playback of encouragement phrases.
* **Documentation**
  * Updated documentation to reflect the completion of the gentle encouragement system task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->