### PR TITLE
Add gentle encouragement system

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -19,7 +19,7 @@ import { useIsFocused } from '@react-navigation/native';
 import CorrectionPanel from '../components/CorrectionPanel';
 import SymbolVideoPlayer from '../components/SymbolVideoPlayer';
 import { loadProfile, Profile, logCorrection } from '../storage';
-import { audioService } from '../services';
+import { audioService, getEncouragementMessage } from '../services';
 import { adaptiveLearningService } from '../services/adaptiveLearningService';
 import { database } from '../../db';
 import { Correction, GestureDefinition } from '../../db/models';
@@ -55,6 +55,7 @@ export default function RecognitionScreen({ navigation }: any) {
   const [lastRecognizedGesture, setLastRecognizedGesture] = useState<GestureModelEntry | null>(null);
   const [showVideoPlayer, setShowVideoPlayer] = useState(false);
   const [weakGesture, setWeakGesture] = useState<GestureDefinition | null>(null);
+  const [encouragementMsg, setEncouragementMsg] = useState<string | null>(null);
   const [isCameraActive, setIsCameraActive] = useState(true);
   const [isProcessing, setIsProcessing] = useState(false);
   const { hasPermission, requestPermission } = useCameraPermissionStatus();
@@ -91,6 +92,9 @@ export default function RecognitionScreen({ navigation }: any) {
     const fetchWeakGesture = async () => {
       const gesture = await adaptiveLearningService.getWeakGesture();
       setWeakGesture(gesture);
+      if (gesture) {
+        setEncouragementMsg(getEncouragementMessage(gesture.name));
+      }
     };
     fetchWeakGesture();
   }, []);
@@ -318,6 +322,7 @@ export default function RecognitionScreen({ navigation }: any) {
     if (weakGesture) {
       navigation.navigate('Training', { gestureLabel: weakGesture.name, isPractice: true });
       setWeakGesture(null);
+      setEncouragementMsg(null);
     }
   };
 
@@ -505,16 +510,14 @@ export default function RecognitionScreen({ navigation }: any) {
   return (
     <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
       <SafeAreaView style={styles.container}>
-      {weakGesture && (
+      {weakGesture && encouragementMsg && (
         <Pressable
           onPress={handleWeakGestureBannerPress}
           style={styles.weakGestureBanner}
           accessibilityRole="button"
           accessibilityLabel="Practice weak gesture again"
         >
-          <Text style={styles.weakGestureBannerText}>
-            Let's try this one again: {weakGesture.name}
-          </Text>
+          <Text style={styles.weakGestureBannerText}>{encouragementMsg}</Text>
         </Pressable>
       )}
 

--- a/app/src/services/encouragementService.ts
+++ b/app/src/services/encouragementService.ts
@@ -1,0 +1,10 @@
+export const encouragementMessages = [
+  "Great job! Let's practice {gesture} again.",
+  "You're doing great—want to try {gesture} once more?",
+  "Let's give {gesture} another go together.",
+];
+
+export function getEncouragementMessage(gesture: string): string {
+  const msg = encouragementMessages[Math.floor(Math.random() * encouragementMessages.length)];
+  return msg.replace('{gesture}', gesture);
+}

--- a/app/src/services/index.ts
+++ b/app/src/services/index.ts
@@ -10,3 +10,4 @@ export { extractLandmarksFromImages } from './landmarkExtractor';
 export * from "./trainingSync";
 export * from "./modelUpdate";
 export * from "./syncService";
+export * from './encouragementService';

--- a/app/test/encouragementService.test.ts
+++ b/app/test/encouragementService.test.ts
@@ -1,0 +1,8 @@
+import { getEncouragementMessage } from '../src/services/encouragementService';
+
+describe('encouragementService', () => {
+  it('includes gesture name in message', () => {
+    const msg = getEncouragementMessage('Winken');
+    expect(msg).toMatch(/Winken/);
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -58,7 +58,7 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Implement "Let's practice this again" feature
   - [x] Add gesture practice sessions
   - [x] Create progress tracking dashboard
-  - Implement gentle encouragement system
+  - [x] Implement gentle encouragement system
 
 ### Enhanced Intelligence Features
 - [ ] **Live LLM Dialog Engine**


### PR DESCRIPTION
## Summary
- add encouragement service that generates friendly practice messages
- wire encouragement banner into recognition screen and mark doc TODO as complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689378c6b31883228c5e8fe3fac29dc5