### PR TITLE
feat: add dashboard access from admin panel

### DIFF
--- a/app/src/screens/AdminScreen.tsx
+++ b/app/src/screens/AdminScreen.tsx
@@ -317,6 +317,11 @@ export default function AdminScreen({ navigation }: any) {
         onPress={() => navigation.navigate('Correction', { gesture: '' , suggestions: []})}
         accessibilityLabel="Korrekturmodus öffnen"
       />
+      <Button
+        title="Dashboard"
+        onPress={() => navigation.navigate('Dashboard')}
+        accessibilityLabel="Analytics-Dashboard öffnen"
+      />
       <Button title="Back" onPress={() => navigation.goBack()} accessibilityLabel="Zurück" />
 
       <Modal visible={modalVisible} animationType="slide">

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -73,11 +73,11 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Implement video playback controls
   - [x] Test video loading and playback performance
 
-- [ ] **Admin Panel Enhancement**
-  - [x] Complete CRUD functionality in `AdminScreen.tsx`
-  - [x] Add symbol and vocabulary management
-  - [x] Implement data export/import features
-  - Add analytics dashboard for caregivers
+  - [x] **Admin Panel Enhancement**
+    - [x] Complete CRUD functionality in `AdminScreen.tsx`
+    - [x] Add symbol and vocabulary management
+    - [x] Implement data export/import features
+    - [x] Add analytics dashboard for caregivers
 
 ---
 


### PR DESCRIPTION
## Summary
- expose caregiver analytics via new Dashboard button in Admin panel
- document completion of analytics dashboard TODO

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68938429bd3c83229fae7355f3c02886