### PR TITLE
feat(models): add versioning and validation

### DIFF
--- a/app/assets/models/versions.json
+++ b/app/assets/models/versions.json
@@ -1,0 +1,4 @@
+{
+  "hand_landmarker.tflite": "1.0.0",
+  "gesture_classifier.tflite": "1.0.0"
+}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -86,8 +86,8 @@ The project has a stable foundation after a major refactor. The database, naviga
 ### Model Management & Training
 - [ ] **Pre-trained Model Integration**
   - [x] Download and bundle MediaPipe models via `src/tools/downloadModels.ts`
-  - Implement model versioning system
-  - Add model validation checks
+  - [x] Implement model versioning system
+  - [x] Add model validation checks
   - Test model loading performance
 
 - [ ] **Two-Stage Frame Processor**

--- a/server/src/constants/modelPaths.ts
+++ b/server/src/constants/modelPaths.ts
@@ -4,3 +4,4 @@ export const HAND_LANDMARKER_MODEL_PATH = path.join(__dirname, '../../../app/ass
 export const GESTURE_CLASSIFIER_MODEL_PATH = path.join(__dirname, '../../../app/assets/models/gesture_classifier.tflite');
 export const TRAINED_MODEL_PATH = path.join(process.cwd(), 'trained_model.tflite');
 export const GESTURE_LABELS_PATH = path.join(__dirname, '../../../app/assets/models/gesture_labels.json');
+export const MODEL_VERSIONS_PATH = path.join(__dirname, '../../../app/assets/models/versions.json');

--- a/server/src/tools/downloadModels.ts
+++ b/server/src/tools/downloadModels.ts
@@ -8,12 +8,21 @@ import { pipeline } from 'stream';
 import {
   HAND_LANDMARKER_MODEL_PATH,
   GESTURE_CLASSIFIER_MODEL_PATH,
+  MODEL_VERSIONS_PATH,
 } from '../constants/modelPaths';
 
 interface ModelSpec {
   url: string;
   extract: (downloadedPath: string, destPath: string) => Promise<void>;
   dest: string;
+  version: string;
+}
+
+let versionManifest: Record<string, string> = {};
+try {
+  versionManifest = JSON.parse(fs.readFileSync(MODEL_VERSIONS_PATH, 'utf8'));
+} catch {
+  versionManifest = {};
 }
 
 async function downloadFile(url: string, dest: string): Promise<void> {
@@ -67,24 +76,41 @@ const models: ModelSpec[] = [
     url: 'https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/latest/hand_landmarker.task',
     dest: HAND_LANDMARKER_MODEL_PATH,
     extract: extractHandLandmarker,
+    version: '1.0.0',
   },
   {
     url: 'https://storage.googleapis.com/mediapipe-models/gesture_recognizer/gesture_recognizer/float16/latest/gesture_recognizer.task',
     dest: GESTURE_CLASSIFIER_MODEL_PATH,
     extract: extractGestureClassifier,
+    version: '1.0.0',
   },
 ];
 
+async function validateModel(file: string) {
+  const stats = await fs.promises.stat(file);
+  if (stats.size === 0) throw new Error('Model file is empty');
+  const fd = await fs.promises.open(file, 'r');
+  const buffer = Buffer.alloc(4);
+  await fd.read(buffer, 0, 4, 0);
+  await fd.close();
+  if (buffer.toString() !== 'TFL3') {
+    throw new Error('Invalid TFLite model file');
+  }
+}
+
 async function ensureModel(model: ModelSpec) {
-  if (fs.existsSync(model.dest)) {
-    console.log(`${path.basename(model.dest)} already exists, skipping`);
+  const name = path.basename(model.dest);
+  if (fs.existsSync(model.dest) && versionManifest[name] === model.version) {
+    console.log(`${name} v${model.version} already present, skipping`);
     return;
   }
   const tmpFile = path.join(os.tmpdir(), path.basename(model.url));
   console.log(`Downloading ${model.url}...`);
   await downloadFile(model.url, tmpFile);
   await model.extract(tmpFile, model.dest);
+  await validateModel(model.dest);
   await fs.promises.unlink(tmpFile).catch(() => {});
+  versionManifest[name] = model.version;
   console.log(`Saved to ${model.dest}`);
 }
 
@@ -96,4 +122,8 @@ async function ensureModel(model: ModelSpec) {
       console.error(`Failed to process ${path.basename(m.dest)}:`, err);
     }
   }
+  await fs.promises.writeFile(
+    MODEL_VERSIONS_PATH,
+    JSON.stringify(versionManifest, null, 2)
+  );
 })();


### PR DESCRIPTION
## Summary
- track model versions with versions.json
- validate downloaded TFLite models before saving
- document completed model management tasks

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689391ac19e083228ed364caa1aca180