### PR TITLE
docs: add contribution and deployment guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to Amy's Echo
+
+Thanks for your interest in improving Amy's Echo! This project supports one child, so every contribution must be made with care.
+
+## Getting Started
+- Read `AGENTS.md` for workflow and `spec/AmysEcho.md` for the project requirements.
+- Run `npm install` in the repo root to install shared tools.
+- Each package has its own dependencies; run `npm install` inside `app/` and `server/` when working there.
+
+## Development Workflow
+1. Create your changes on top of `main` and keep commits focused.
+2. Run the full test suite before submitting:
+   ```bash
+   npm run type-check --prefix app
+   npm test --prefix app
+   pip install -r server/requirements.txt
+   npm test --prefix server
+   npm test --prefix integration
+   ```
+   Or run `./scripts/full-check.sh` from the repo root to execute all of the above.
+3. Update `docs/TODO.md` when completing a task from the action plan.
+4. Submit a pull request with a clear description of the change and its motivation.
+
+## Code Style
+- TypeScript uses strict mode; keep types explicit.
+- Prefer functional components in React Native.
+- Write tests for new functionality or regression fixes.
+
+## Commit Guidelines
+- Use present tense, e.g., `Add onboarding test`.
+- Reference relevant tasks or issues when possible.
+- Avoid committing generated files or local environment changes.
+
+Thank you for helping turn Amy's gestures into understanding.

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -1,0 +1,49 @@
+# Deployment Guide
+
+This guide explains how to deploy both the mobile app and the backend server.
+
+## Mobile App (EAS Build)
+1. Install dependencies:
+   ```bash
+   npm install
+   npm install --prefix app
+   ```
+2. Configure Expo Application Services:
+   - Ensure you are logged in: `npx eas login`
+   - Update `app.json` or `app.config.js` with your bundle identifiers and splash assets.
+3. Kick off a build:
+   ```bash
+   npm run build:android   # or: npm run build:ios
+   ```
+   The command triggers an [EAS build](https://docs.expo.dev/build/introduction/). The terminal prints a URL where you can monitor progress.
+4. After completion, download the artifact from the provided link and distribute it to testers or the app stores.
+
+## Backend Server
+1. Install dependencies and build:
+   ```bash
+   npm install --prefix server
+   pip install -r server/requirements.txt
+   npm run build --prefix server
+   ```
+2. Set an authentication token and start the server:
+   ```bash
+   API_TOKEN=<secret> node server/dist/server.js
+   ```
+3. Reverse proxy or containerize the service as needed for your environment.
+4. Use the `downloadModels` tool to provision gesture models:
+   ```bash
+   node server/dist/tools/downloadModels.js
+   ```
+   The models are placed in `app/assets/models/` for the mobile app.
+
+## Updating Models and Analytics
+- Retrain the offline model with new gesture data:
+  ```bash
+  node server/dist/tools/retrainOfflineModel.js <path/to/db.json> dist/offlineModel.json
+  ```
+- Update caregiver analytics stored in the database:
+  ```bash
+  node server/dist/tools/updateAnalytics.js <path/to/db.json>
+  ```
+
+With these steps the app and server are ready for production deployment.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -189,8 +189,8 @@ The project has a stable foundation after a major refactor. The database, naviga
 
 - [ ] **Technical Documentation**
   - Complete API documentation
-  - Add deployment guides
-  - Create contribution guidelines
+  - [x] Add deployment guides
+  - [x] Create contribution guidelines
   - Document architecture decisions
 
 ---


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with workflow, style, and test requirements
- document app and server deployment steps
- check off completed tasks in docs/TODO

## Testing
- `npm test --prefix app`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6893a429ccb483228eec65adddf81867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a CONTRIBUTING guide outlining contribution, development, and code style guidelines.
  * Introduced a comprehensive deployment guide for both the mobile app and backend server.
  * Updated the technical documentation checklist to mark deployment and contribution guides as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->