### PR TITLE
feat: classify gestures within frame processor

### DIFF
--- a/app/src/services/gestureClassifier.ts
+++ b/app/src/services/gestureClassifier.ts
@@ -1,0 +1,22 @@
+import { TensorflowModel } from 'react-native-fast-tflite';
+import { logger } from '../utils/logger';
+
+let gestureModel: TensorflowModel | null = null;
+
+export function setGestureModel(model: TensorflowModel | null): void {
+  gestureModel = model;
+}
+
+export function classifyGesture(input: number[]): number[] | null {
+  'worklet';
+  if (!gestureModel) return null;
+  try {
+    const tensor = new Float32Array(input);
+    const result = gestureModel.runSync([tensor]) as any[];
+    const predictions = result[0] as number[] | undefined;
+    return predictions ?? null;
+  } catch (e) {
+    logger.error('Gesture classification failed', e);
+    return null;
+  }
+}

--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -21,7 +21,14 @@ try {
 } catch (e) {
   logger.warn('Worklets not available, using fallback:', e);
 }
-import { extractHandLandmarks, setHandLandmarkModel } from './landmarkExtractor';
+import {
+  extractHandLandmarks,
+  setHandLandmarkModel,
+} from './landmarkExtractor';
+import {
+  classifyGesture,
+  setGestureModel,
+} from './gestureClassifier';
 import { DetailedGestureResult, ProcessedFrame, MLServiceConfig } from '../types/ml';
 import { API_TOKEN, API_URL, CONFIDENCE_THRESHOLD } from '../constants';
 import { database } from '../../db';
@@ -105,6 +112,7 @@ class MachineLearningService {
       this.gestureModel?.close?.();
       this.gestureModel = null;
       setHandLandmarkModel?.(null);
+      setGestureModel(null);
 
       logger.info('Loading custom models...');
 
@@ -137,21 +145,23 @@ class MachineLearningService {
         logger.info(`Loading model from: ${modelPath}`);
         try {
           this.gestureModel = await loadTensorflowModel({ url: modelPath });
-        } catch (e) {
-          logger.error('Failed to load gesture model:', e);
-          throw e; // Re-throw to ensure isReady becomes false
-        }
-      } else if (typeof gesture === 'object' && gesture.url && loadTensorflowModel) {
-        logger.info(`Loading gesture model from: ${gesture.url}`);
-        try {
-          this.gestureModel = await loadTensorflowModel({ url: gesture.url });
-        } catch (e) {
-          logger.error('Failed to load gesture model:', e);
-          throw e; // Re-throw to ensure isReady becomes false
-        }
-      } else {
-        this.gestureModel = gesture;
+      } catch (e) {
+        logger.error('Failed to load gesture model:', e);
+        throw e; // Re-throw to ensure isReady becomes false
       }
+    } else if (typeof gesture === 'object' && gesture.url && loadTensorflowModel) {
+      logger.info(`Loading gesture model from: ${gesture.url}`);
+      try {
+        this.gestureModel = await loadTensorflowModel({ url: gesture.url });
+      } catch (e) {
+        logger.error('Failed to load gesture model:', e);
+        throw e; // Re-throw to ensure isReady becomes false
+      }
+    } else {
+      this.gestureModel = gesture;
+    }
+
+      setGestureModel(this.gestureModel);
 
       if (config?.confidenceThreshold) {
         this.confidenceThreshold = config.confidenceThreshold;
@@ -182,6 +192,7 @@ class MachineLearningService {
     this.gestureModel?.close?.();
     this.gestureModel = null;
     setHandLandmarkModel?.(null);
+    setGestureModel(null);
     this.isReady = false;
   }
 
@@ -208,7 +219,26 @@ class MachineLearningService {
   ): Promise<void> {
     let result: DetailedGestureResult | null = null;
 
-    if (this.shouldUseRemote()) {
+    if (processed.predictions) {
+      try {
+        const { gesture, confidence } = this.processModelOutput(processed.predictions);
+        const suggestions = this.getTopPredictions(processed.predictions, 3);
+
+        result = {
+          label: gesture,
+          confidence,
+          isLocal: true,
+          timestamp: Date.now(),
+          suggestions,
+          requiresConfirmation: confidence < this.confidenceThreshold,
+        };
+      } catch (error) {
+        logger.error('Local gesture classification failed:', error);
+        result = this.createUncertainResult('Local inference error');
+      }
+    }
+
+    if (!result && this.shouldUseRemote()) {
       try {
         result = await Promise.race([
           this.classifyRemotely(processed),
@@ -525,11 +555,15 @@ export const useGestureClassifier = (
           return;
         }
 
+        const flat = landmarks.flat();
+        const predictions = classifyGesture(flat);
+
         const processed: ProcessedFrame = {
           landmarks,
           width: frame.width,
           height: frame.height,
           timestamp: Date.now(),
+          predictions: predictions || undefined,
         };
 
         runOnJS(enqueueFrame)(processed);

--- a/app/src/types/ml.ts
+++ b/app/src/types/ml.ts
@@ -3,6 +3,7 @@ export interface ProcessedFrame {
   width: number;
   height: number;
   timestamp: number;
+  predictions?: number[];
 }
 
 export interface DetailedGestureResult {

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -91,8 +91,8 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Test model loading performance
 
 - [ ] **Two-Stage Frame Processor**
-  - Implement landmark detection in `useFrameProcessor` worklet
-  - Add gesture classification pipeline
+  - [x] Implement landmark detection in `useFrameProcessor` worklet
+  - [x] Add gesture classification pipeline
   - Optimize processing performance
   - Test real-time processing accuracy
 


### PR DESCRIPTION
## Summary
- classify gestures synchronously within the frame processor via new `gestureClassifier`
- extend ML service to accept in-worklet predictions
- check off two-stage frame processor milestone in docs

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689444700c548322ae083be204597e96