### PR TITLE
docs: document architecture decisions

### DIFF
--- a/docs/ArchitectureDecisions.md
+++ b/docs/ArchitectureDecisions.md
@@ -1,0 +1,29 @@
+# Architecture Decisions
+
+This document records the major architectural choices made for Amy's Echo.
+
+## Hybrid-First Recognition
+- **Decision**: Use a hybrid online/offline gesture recognition pipeline.
+- **Rationale**: Online services provide higher accuracy and faster iteration, while an on-device TensorFlow Lite model guarantees functionality without network access.
+- **Consequences**: The app must seamlessly switch between modes within 400 ms and always maintain an offline fallback to protect the user experience.
+
+## Technology Stack
+- **Decision**: Build the mobile app with React Native and TypeScript.
+- **Rationale**: React Native offers native performance and access to required modules (camera, database, ML) while TypeScript adds type safety.
+- **Consequences**: All app code follows strict TypeScript rules and leverages the React Native ecosystem.
+
+## Data Storage
+- **Decision**: Store local data with WatermelonDB backed by SQLite.
+- **Rationale**: WatermelonDB provides an encrypted, offline-first database that synchronizes efficiently when connectivity is available.
+- **Consequences**: Database schema and interactions must be defined in WatermelonDB models and kept reactive for UI updates.
+
+## Audio and Video Feedback
+- **Decision**: Use Expo modules (`expo-av`, `expo-speech`, `expo-video`) for media playback and synthesis.
+- **Rationale**: Expo libraries provide cross-platform support and a consistent API for audio prompts and DGS video demonstrations.
+- **Consequences**: Media features rely on Expo's runtime; additional native modules must be evaluated carefully for compatibility.
+
+## Error Handling Philosophy
+- **Decision**: Prioritize graceful degradation and user trust over raw accuracy.
+- **Rationale**: The system must remain supportive even when recognition fails, especially for a young child.
+- **Consequences**: Every failure state requires a recovery path (e.g., "Help Me" flow) rather than exposing technical errors.
+

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -191,7 +191,7 @@ The project has a stable foundation after a major refactor. The database, naviga
   - Complete API documentation
   - [x] Add deployment guides
   - [x] Create contribution guidelines
-  - Document architecture decisions
+  - [x] Document architecture decisions
 
 ---
 


### PR DESCRIPTION
## Summary
- add ArchitectureDecisions document outlining major technical choices
- check off architecture decision item in TODO

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689455c68f008322b4e03b54927fe4f3