### PR TITLE
feat: add dual trigger feedback

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -19,7 +19,7 @@ import { useIsFocused } from '@react-navigation/native';
 import CorrectionPanel from '../components/CorrectionPanel';
 import SymbolVideoPlayer from '../components/SymbolVideoPlayer';
 import { loadProfile, Profile, logCorrection } from '../storage';
-import { audioService } from '../services';
+import { audioService, triggerSpeakAndShow } from '../services';
 import { adaptiveLearningService } from '../services/adaptiveLearningService';
 import { database } from '../../db';
 import { Correction, GestureDefinition } from '../../db/models';
@@ -219,17 +219,19 @@ export default function RecognitionScreen({ navigation }: any) {
       setLastRecognizedGesture(entry);
       setStatus(recognizedSymbolLabel);
       startFeedbackAnimation();
-      audioService
-        .playSuccessFeedback(recognizedSymbolLabel, result.confidence)
-        .catch((error) => {
-          logger.warn('Audio feedback failed:', error);
-        });
-
-      if (useDgs && entry.dgsVideoUri) {
-        setShowVideoPlayer(true);
-      } else if (entry.videoUri) {
-        setShowVideoPlayer(true);
-      }
+      triggerSpeakAndShow(
+        recognizedSymbolLabel,
+        result.confidence,
+        () => {
+          if (useDgs && entry.dgsVideoUri) {
+            setShowVideoPlayer(true);
+          } else if (entry.videoUri) {
+            setShowVideoPlayer(true);
+          }
+        },
+      ).catch((error) => {
+        logger.warn('Feedback failed:', error);
+      });
 
       if (profile) {
         try {

--- a/app/src/services/feedbackService.ts
+++ b/app/src/services/feedbackService.ts
@@ -1,0 +1,33 @@
+import * as Haptics from 'expo-haptics';
+import { audioService } from './audioService';
+import { logger } from '../utils/logger';
+
+/**
+ * Trigger speech, symbol display and haptic feedback in parallel.
+ * Failures in any individual channel should not prevent the others
+ * from executing.
+ */
+export async function triggerSpeakAndShow(
+  text: string,
+  confidence: number,
+  showSymbol: () => void,
+): Promise<void> {
+  const tasks: Promise<unknown>[] = [
+    audioService.playSuccessFeedback(text, confidence),
+    (async () => {
+      try {
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      } catch (error) {
+        logger.warn('Haptics feedback failed:', error);
+      }
+    })(),
+    (async () => {
+      try {
+        showSymbol();
+      } catch (error) {
+        logger.warn('Visual feedback failed:', error);
+      }
+    })(),
+  ];
+  await Promise.allSettled(tasks);
+}

--- a/app/src/services/index.ts
+++ b/app/src/services/index.ts
@@ -10,3 +10,4 @@ export { extractLandmarksFromImages } from './landmarkExtractor';
 export * from "./trainingSync";
 export * from "./modelUpdate";
 export * from "./syncService";
+export * from './feedbackService';

--- a/app/test/speakShow.test.tsx
+++ b/app/test/speakShow.test.tsx
@@ -1,0 +1,35 @@
+jest.mock('expo-haptics', () => ({
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+  NotificationFeedbackType: { Success: 'success' },
+}));
+
+jest.mock('../src/services/audioService', () => ({
+  audioService: { playSuccessFeedback: jest.fn() },
+}));
+
+import { triggerSpeakAndShow } from '../src/services/feedbackService';
+import { audioService } from '../src/services/audioService';
+import * as Haptics from 'expo-haptics';
+
+describe('triggerSpeakAndShow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('triggers speech, haptics, and visual callback', async () => {
+    (audioService.playSuccessFeedback as jest.Mock).mockResolvedValue(undefined);
+    const show = jest.fn();
+    await triggerSpeakAndShow('Hallo', 1, show);
+    expect(audioService.playSuccessFeedback).toHaveBeenCalledWith('Hallo', 1);
+    expect(Haptics.notificationAsync).toHaveBeenCalled();
+    expect(show).toHaveBeenCalled();
+  });
+
+  it('still shows symbol when speech fails', async () => {
+    (audioService.playSuccessFeedback as jest.Mock).mockRejectedValue(new Error('fail'));
+    const show = jest.fn();
+    await triggerSpeakAndShow('Hallo', 1, show);
+    expect(show).toHaveBeenCalled();
+    expect(Haptics.notificationAsync).toHaveBeenCalled();
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -36,7 +36,7 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Add success/error sound effects
   - [x] Implement speech synthesis for recognized gestures
   - [x] Test audio output quality and timing
-- [ ] **Speak + Show dual-trigger** _(see `app/test/speakShow.test.tsx`)_
+- [x] **Speak + Show dual-trigger** _(see `app/test/speakShow.test.tsx`)_
   - Guarantee that recognition fires both speech and symbol display together with fallback handling.
   - Add haptic and visual confirmation so one failure does not block the other.
 


### PR DESCRIPTION
## Summary
- ensure speech, haptic and symbol feedback trigger together using new `triggerSpeakAndShow`
- wire recognition screen to use the dual-trigger feedback helper
- document completion of speak+show feature

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68953b55bc8083228bea1fe844e1230f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced combined audio, haptic, and visual feedback when a symbol is recognized.
* **Bug Fixes**
  * Improved error handling to ensure all feedback types are attempted, even if one fails.
* **Tests**
  * Added tests to verify the new feedback mechanism works correctly and handles errors gracefully.
* **Documentation**
  * Updated documentation to reflect the completion of the "Speak + Show dual-trigger" feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->