### PR TITLE
feat: add API retry manager

### DIFF
--- a/app/src/services/APIRetryManager.ts
+++ b/app/src/services/APIRetryManager.ts
@@ -1,0 +1,33 @@
+import { logger } from '../utils/logger';
+
+export class APIRetryManager {
+  private readonly maxRetries: number;
+  private readonly baseDelay: number;
+
+  constructor(maxRetries = 3, baseDelay = 1000) {
+    this.maxRetries = maxRetries;
+    this.baseDelay = baseDelay;
+  }
+
+  async executeWithRetry<T>(operation: () => Promise<T>, context: string): Promise<T> {
+    let lastError: Error | undefined;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        return await operation();
+      } catch (error: any) {
+        lastError = error;
+        if (attempt < this.maxRetries) {
+          const delay = this.baseDelay * Math.pow(2, attempt);
+          logger.warn(
+            `${context} failed (attempt ${attempt + 1}/${this.maxRetries + 1}), retrying in ${delay}ms`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+      }
+    }
+    logger.error(`API failure in ${context}:`, lastError);
+    throw lastError;
+  }
+}
+
+export default APIRetryManager;

--- a/app/src/services/dialogEngine.ts
+++ b/app/src/services/dialogEngine.ts
@@ -1,33 +1,7 @@
 import { Symbol } from '../../db/models';
 import { loadOpenAIApiKey } from '../storage';
 import { logger } from '../utils/logger';
-
-class APIRetryManager {
-  private readonly maxRetries = 3;
-  private readonly baseDelay = 1000;
-
-  async executeWithRetry<T>(operation: () => Promise<T>, context: string): Promise<T> {
-    let lastError: Error | undefined;
-    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      try {
-        return await operation();
-      } catch (error: any) {
-        lastError = error;
-        if (attempt < this.maxRetries) {
-          const delay = this.baseDelay * Math.pow(2, attempt);
-          logger.warn(`${context} failed (attempt ${attempt + 1}/${this.maxRetries + 1}), retrying in ${delay}ms`);
-          await new Promise((resolve) => setTimeout(resolve, delay));
-        }
-      }
-    }
-    this.handleAPIFailure(context, lastError!);
-    throw lastError!;
-  }
-
-  private handleAPIFailure(context: string, error: Error): void {
-    logger.error(`API failure in ${context}:`, error);
-  }
-}
+import { APIRetryManager } from './APIRetryManager';
 
 const OPENAI_URL = 'https://api.openai.com/v1/chat/completions';
 const MODEL = 'gpt-4-turbo';

--- a/app/test/apiRetry.test.ts
+++ b/app/test/apiRetry.test.ts
@@ -1,0 +1,51 @@
+import { APIRetryManager } from '../src/services/APIRetryManager';
+
+jest.useFakeTimers();
+
+describe('APIRetryManager', () => {
+  it('retries failed operations with exponential backoff', async () => {
+    const operation = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('fail1'))
+      .mockRejectedValueOnce(new Error('fail2'))
+      .mockResolvedValue('success');
+    const retry = new APIRetryManager();
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+    const promise = retry.executeWithRetry(operation, 'test');
+
+    await Promise.resolve();
+    expect(operation).toHaveBeenCalledTimes(1);
+
+    await jest.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+    expect(operation).toHaveBeenCalledTimes(2);
+
+    await jest.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+    expect(operation).toHaveBeenCalledTimes(3);
+
+    await expect(promise).resolves.toBe('success');
+
+    expect(setTimeoutSpy).toHaveBeenNthCalledWith(1, expect.any(Function), 1000);
+    expect(setTimeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), 2000);
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('throws after exceeding max retries', async () => {
+    const operation = jest.fn().mockImplementation(() => Promise.reject(new Error('boom')));
+    const retry = new APIRetryManager();
+
+    const promise = retry.executeWithRetry(operation, 'test');
+    const expectation = expect(promise).rejects.toThrow('boom');
+
+    for (let i = 0; i < 3; i++) {
+      await Promise.resolve();
+      await jest.runOnlyPendingTimersAsync();
+    }
+
+    await expectation;
+    expect(operation).toHaveBeenCalledTimes(4);
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -90,7 +90,7 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Implement context-aware suggestions
   - [x] Add conversation memory for better responses
   - [x] Test suggestion quality and relevance
-  - [ ] Add `APIRetryManager` with exponential backoff for failed requests _(add `app/src/services/APIRetryManager.ts`; see `app/test/apiRetry.test.ts`)_
+  - [x] Add `APIRetryManager` with exponential backoff for failed requests _(add `app/src/services/APIRetryManager.ts`; see `app/test/apiRetry.test.ts`)_
     - Example:
       ```ts
       const retry = new APIRetryManager();


### PR DESCRIPTION
## Summary
- extract API retry logic into dedicated APIRetryManager service
- reuse APIRetryManager in dialogEngine
- document and test exponential backoff behavior

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6895cbc79d988322b4dbd7f2ed2d5cc6