### PR TITLE
Queue corrections for training on server

### DIFF
--- a/app/src/services/correctionService.ts
+++ b/app/src/services/correctionService.ts
@@ -1,9 +1,9 @@
 export const correctionService = {
-  async logCorrection(correction: string) {
+  async logCorrection(gesture: string) {
     await fetch('/api/corrections', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ correction }),
+      body: JSON.stringify({ gesture }),
     });
   },
 };

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,7 +5,7 @@ import { promises as fs } from 'fs';
 import rateLimit from 'express-rate-limit';
 import { TRAINED_MODEL_PATH } from './constants/modelPaths';
 import { DB_FILE_PATH } from './constants/dbPaths';
-import { setupDatabase, loadDatabase, saveDatabase, Database } from './db';
+import { setupDatabase, loadDatabase, saveDatabase, Database, logCorrection } from './db';
 import auth from './middleware/auth';
 import { mlService } from './services/mlService';
 import { Correction, UsageStat, LearningAnalytics, Profile, SymbolRecord } from './types';
@@ -36,6 +36,10 @@ app.get('/portal', (_req: Request, res: Response) => {
 });
 
 let dbInstance: Database; // Declare a variable to hold the database instance
+
+// Utility to generate lightweight unique ids
+const genId = () =>
+  Date.now().toString(36) + Math.random().toString(36).slice(2);
 
 // Ensure the database file exists with default content and load it
 setupDatabase(DB_FILE_PATH)
@@ -186,6 +190,30 @@ app.get('/api/analytics/export', auth, async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Error exporting data:', error);
     res.status(500).json({ error: 'Failed to export data' });
+  }
+});
+
+app.post('/api/corrections', auth, async (req: Request, res: Response) => {
+  const { gesture } = req.body || {};
+  if (typeof gesture !== 'string') {
+    return res.status(400).json({ error: 'Invalid correction' });
+  }
+  try {
+    logCorrection(dbInstance, 'unknown', gesture, null);
+    const record: Correction = {
+      id: genId(),
+      predictedGesture: 'unknown',
+      actualGesture: gesture,
+      confidence: 0,
+      timestamp: Date.now(),
+      isSynced: false,
+    };
+    dbInstance.corrections.push(record);
+    await saveDatabase(dbInstance, DB_FILE_PATH);
+    res.status(202).json({ status: 'queued' });
+  } catch (error) {
+    console.error('Error logging correction:', error);
+    res.status(500).json({ error: 'Failed to log correction' });
   }
 });
 

--- a/server/test/test_training_queue.py
+++ b/server/test/test_training_queue.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+import time
+import json
+import urllib.request
+import urllib.error
+
+SERVER_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+PORT = "5055"
+DB_PATH = os.path.join(SERVER_DIR, 'db.json')
+
+
+def start_server():
+    env = os.environ.copy()
+    env.setdefault('API_TOKEN', 'testtoken')
+    env.setdefault('PORT', PORT)
+    proc = subprocess.Popen(
+        ['npx', 'ts-node', 'src/server.ts'],
+        cwd=SERVER_DIR,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    for _ in range(20):
+        try:
+            urllib.request.urlopen(f'http://localhost:{PORT}/')
+            break
+        except Exception:
+            time.sleep(0.5)
+    return proc
+
+
+def stop_server(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def post_correction():
+    url = f'http://localhost:{PORT}/api/corrections'
+    payload = json.dumps({"gesture": "wave"}).encode('utf-8')
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer testtoken',
+    }
+    req = urllib.request.Request(url, data=payload, headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        return resp.getcode()
+
+
+def load_training_count():
+    with open(DB_PATH) as f:
+        data = json.load(f)
+    return len(data.get('gestureTrainingData', []))
+
+
+def test_training_queue_increment():
+    original = open(DB_PATH).read()
+    proc = start_server()
+    try:
+        status = post_correction()
+        assert status == 202
+        # Ensure the correction was logged
+        count = load_training_count()
+        assert count >= 1
+    finally:
+        stop_server(proc)
+        with open(DB_PATH, 'w') as f:
+            f.write(original)
+


### PR DESCRIPTION
## Summary
- send correction gestures from the app using `gesture` payload
- add `/api/corrections` endpoint that logs corrections to the training queue and persists to the database
- cover correction logging with a server-side test

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6895daa2b1288322a37f911cc5d07a61