### PR TITLE
refactor: use color constants and logger

### DIFF
--- a/app/src/components/CorrectionPanel.tsx
+++ b/app/src/components/CorrectionPanel.tsx
@@ -16,7 +16,7 @@ export default function CorrectionPanel({ onSelect, onAddNew, onCancel, suggesti
   const styles = StyleSheet.create({
     modal: {
       flex: 1,
-      backgroundColor: 'rgba(0, 0, 0, 0.8)',
+      backgroundColor: `${COLORS.highContrastBackground}CC`,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/app/src/components/DgsVideoPlayer.tsx
+++ b/app/src/components/DgsVideoPlayer.tsx
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
   },
   loadingOverlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.5)',
+    backgroundColor: `${COLORS.highContrastBackground}80`,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/app/src/components/ErrorMessage.tsx
+++ b/app/src/components/ErrorMessage.tsx
@@ -23,7 +23,7 @@ const styles = StyleSheet.create({
     bottom: SPACING.md,
     left: SPACING.md,
     right: SPACING.md,
-    backgroundColor: 'rgba(255, 0, 0, 0.7)',
+    backgroundColor: `${COLORS.warning}B3`,
     padding: SPACING.sm,
     borderRadius: RADIUS,
   },

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -93,7 +93,7 @@ export default function RecognitionScreen({ navigation }: any) {
 
   const handleCameraError = useCallback(
     (error: CameraRuntimeError) => {
-      console.error('Camera error:', error);
+      logger.error('Camera error:', error);
       const code = (error.code as string) || '';
       switch (code) {
         case 'device/camera-not-available':
@@ -124,7 +124,7 @@ export default function RecognitionScreen({ navigation }: any) {
           }
         }
       } catch (error) {
-        console.warn('Camera health check failed:', error);
+        logger.warn('Camera health check failed:', error);
       }
     }, 5000);
     return () => clearInterval(healthCheck);
@@ -412,7 +412,7 @@ export default function RecognitionScreen({ navigation }: any) {
       bottom: 0,
       justifyContent: 'center',
       alignItems: 'center',
-      backgroundColor: 'rgba(0, 0, 0, 0.3)',
+      backgroundColor: `${COLORS.highContrastBackground}4D`,
     },
     detectionIndicator: {
       position: 'absolute',
@@ -437,14 +437,14 @@ export default function RecognitionScreen({ navigation }: any) {
       marginBottom: SPACING.lg,
       textAlign: 'center',
       color: COLORS.highContrastText,
-      textShadowColor: 'rgba(0, 0, 0, 0.8)',
+      textShadowColor: `${COLORS.highContrastBackground}CC`,
       textShadowOffset: { width: 2, height: 2 },
       textShadowRadius: 4,
     },
     symbolDisplay: {
       fontSize: largeText ? 120 : 100,
       marginBottom: SPACING.lg,
-      textShadowColor: 'rgba(0, 0, 0, 0.8)',
+      textShadowColor: `${COLORS.highContrastBackground}CC`,
       textShadowOffset: { width: 2, height: 2 },
       textShadowRadius: 4,
     },
@@ -453,7 +453,7 @@ export default function RecognitionScreen({ navigation }: any) {
       bottom: 96,
       left: SPACING.md,
       right: SPACING.md,
-      backgroundColor: 'rgba(255, 255, 255, 0.9)',
+      backgroundColor: `${COLORS.surface}E6`,
       borderRadius: RADIUS * 2,
       padding: SPACING.md,
     },
@@ -630,20 +630,20 @@ export default function RecognitionScreen({ navigation }: any) {
                       y1={start[1] * height}
                       x2={end[0] * width}
                       y2={end[1] * height}
-                      stroke="yellow"
+                      stroke={COLORS.warning}
                       strokeWidth={3}
                     />
                   );
                 })}
                 {landmarks.map((l, idx) => (
-                  <Circle key={`point-${idx}`} cx={l[0] * width} cy={l[1] * height} r={5} fill="yellow" />
+                  <Circle key={`point-${idx}`} cx={l[0] * width} cy={l[1] * height} r={5} fill={COLORS.warning} />
                 ))}
               </Svg>
             )}
             <ErrorMessage message={processingError} />
             <View style={styles.detectionIndicator}>
               <View
-                style={[styles.dot, { backgroundColor: detectionActive ? 'lime' : 'red' }]}
+                style={[styles.dot, { backgroundColor: detectionActive ? COLORS.success : COLORS.warning }]}
               />
               <Text style={styles.detectionText}>
                 {detectionActive ? 'Hand detected' : 'No hand'}

--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -244,7 +244,7 @@ const createStyles = (largeText: boolean, highContrast: boolean) =>
     sampleIndicator: {
       position: 'absolute',
       top: 100,
-      backgroundColor: 'rgba(0,255,0,0.7)',
+      backgroundColor: `${COLORS.success}B3`,
       padding: SPACING.sm,
       borderRadius: RADIUS,
     },

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -217,15 +217,15 @@ export default function TrainingScreen({ navigation, route }: any) {
                     viewBox={`0 0 ${PREVIEW_SIZE} ${PREVIEW_SIZE}`}
                     pointerEvents="none"
                   >
-                    {landmarks.map((l, idx) => (
-                      <Circle key={idx} cx={l[0] * PREVIEW_SIZE} cy={l[1] * PREVIEW_SIZE} r={3} fill="yellow" />
-                    ))}
-                  </Svg>
-                )}
-                <View style={styles.detectionIndicator}>
-                  <View
-                    style={[styles.dot, { backgroundColor: detectionActive ? 'lime' : 'red' }]}
-                  />
+                {landmarks.map((l, idx) => (
+                      <Circle key={idx} cx={l[0] * PREVIEW_SIZE} cy={l[1] * PREVIEW_SIZE} r={3} fill={COLORS.warning} />
+                  ))}
+                </Svg>
+              )}
+              <View style={styles.detectionIndicator}>
+                <View
+                    style={[styles.dot, { backgroundColor: detectionActive ? COLORS.success : COLORS.warning }]}
+                />
                   <Text style={styles.detectionText}>
                     {isRecording
                       ? detectionActive


### PR DESCRIPTION
## Summary
- replace inline RGBA colors with entries from `COLORS` palette
- route camera errors and health checks through shared logger
- standardize detection indicator colors

## Testing
- `./scripts/full-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895ddfe89c08322bdebf7223f4cf0e3