### PR TITLE
Log corrections to server training queue

### DIFF
--- a/app/src/services/correctionService.ts
+++ b/app/src/services/correctionService.ts
@@ -1,10 +1,16 @@
+import { API_URL, API_TOKEN } from '../constants';
+
 export const correctionService = {
-  async logCorrection(gesture: string) {
-    await fetch('/api/corrections', {
+  async logCorrection(gesture: string): Promise<void> {
+    await fetch(`${API_URL}/api/corrections`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_TOKEN}`,
+      },
       body: JSON.stringify({ gesture }),
     });
   },
 };
+
 export default correctionService;

--- a/app/test/correctionService.test.ts
+++ b/app/test/correctionService.test.ts
@@ -1,0 +1,20 @@
+import { correctionService } from '../src/services/correctionService';
+import { API_URL, API_TOKEN } from '../src/constants';
+
+describe('correctionService', () => {
+  it('sends correction with auth header', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true }) as any;
+    (global as any).fetch = mockFetch;
+
+    await correctionService.logCorrection('wave');
+
+    expect(mockFetch).toHaveBeenCalledWith(`${API_URL}/api/corrections`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_TOKEN}`,
+      },
+      body: JSON.stringify({ gesture: 'wave' }),
+    });
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -65,7 +65,7 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Add "Help Me" repair workflow
   - [x] Store corrections for model improvement
   - [x] Test correction feedback loop
-  - [ ] Log corrections to server training queue _(update `app/src/services/correctionService.ts`; see `server/test/test_training_queue.py`)_
+  - [x] Log corrections to server training queue _(update `app/src/services/correctionService.ts`; see `server/test/test_training_queue.py`)_
 
 - [ ] **HIP 2: Teach Mode (Training Interface)**
   - [x] Build caregiver training interface for new signs


### PR DESCRIPTION
## Summary
- send corrections to backend training queue with auth headers
- document completion of logging corrections task
- test correctionService posts to server with bearer token

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm run type-check --prefix server`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6895eea5e8d083228475f61f8452a482