### PR TITLE
feat: manage child attention sessions

### DIFF
--- a/app/src/services/childSessionManager.ts
+++ b/app/src/services/childSessionManager.ts
@@ -1,0 +1,58 @@
+export type SessionCallbacks = {
+  onEncouragement: () => void;
+  onBreak: () => void;
+};
+
+export class ChildSessionManager {
+  private encouragementInterval: number;
+  private breakInterval: number;
+  private encouragementTimer?: NodeJS.Timeout;
+  private breakTimer?: NodeJS.Timeout;
+  private callbacks: SessionCallbacks;
+
+  constructor(
+    callbacks: SessionCallbacks,
+    encouragementInterval = 5 * 60 * 1000,
+    breakInterval = 20 * 60 * 1000,
+  ) {
+    this.callbacks = callbacks;
+    this.encouragementInterval = encouragementInterval;
+    this.breakInterval = breakInterval;
+  }
+
+  startSession(): void {
+    this.clearTimers();
+    this.scheduleEncouragement();
+    this.scheduleBreak();
+  }
+
+  recordActivity(): void {
+    this.scheduleEncouragement();
+  }
+
+  endSession(): void {
+    this.clearTimers();
+  }
+
+  private scheduleEncouragement(): void {
+    if (this.encouragementTimer) clearTimeout(this.encouragementTimer);
+    this.encouragementTimer = setTimeout(() => {
+      this.callbacks.onEncouragement();
+      this.scheduleEncouragement();
+    }, this.encouragementInterval);
+  }
+
+  private scheduleBreak(): void {
+    if (this.breakTimer) clearTimeout(this.breakTimer);
+    this.breakTimer = setTimeout(() => {
+      this.callbacks.onBreak();
+    }, this.breakInterval);
+  }
+
+  private clearTimers(): void {
+    if (this.encouragementTimer) clearTimeout(this.encouragementTimer);
+    if (this.breakTimer) clearTimeout(this.breakTimer);
+  }
+}
+
+export default ChildSessionManager;

--- a/app/src/services/index.ts
+++ b/app/src/services/index.ts
@@ -12,3 +12,4 @@ export * from "./trainingSync";
 export * from "./modelUpdate";
 export * from "./syncService";
 export * from './feedbackService';
+export * from './childSessionManager';

--- a/app/test/childSessionManager.test.ts
+++ b/app/test/childSessionManager.test.ts
@@ -1,0 +1,41 @@
+import { ChildSessionManager } from '../src/services/childSessionManager';
+
+jest.useFakeTimers();
+
+describe('ChildSessionManager', () => {
+  it('triggers encouragement and break callbacks', () => {
+    const encourage = jest.fn();
+    const takeBreak = jest.fn();
+    const manager = new ChildSessionManager(
+      { onEncouragement: encourage, onBreak: takeBreak },
+      1000,
+      3000,
+    );
+
+    manager.startSession();
+
+    jest.advanceTimersByTime(1000);
+    expect(encourage).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(2000);
+    expect(takeBreak).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets encouragement timer on activity', () => {
+    const encourage = jest.fn();
+    const takeBreak = jest.fn();
+    const manager = new ChildSessionManager(
+      { onEncouragement: encourage, onBreak: takeBreak },
+      1000,
+      5000,
+    );
+
+    manager.startSession();
+    jest.advanceTimersByTime(800);
+    manager.recordActivity();
+    jest.advanceTimersByTime(800);
+    expect(encourage).toHaveBeenCalledTimes(0);
+    jest.advanceTimersByTime(200);
+    expect(encourage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -201,7 +201,7 @@ The project has a stable foundation after a major refactor. The database, naviga
       <Pressable style={childFriendlyStyles.primaryButton} onPress={childHaptic} />
       ```
   - Test with child users
-  - [ ] Add session management for attention span
+  - [x] Add session management for attention span
     - Hint: implement `ChildSessionManager` to schedule encouragements and suggest breaks.
 
 ### Quality Assurance


### PR DESCRIPTION
## Summary
- add ChildSessionManager to schedule encouragements and breaks
- cover session manager with unit tests
- mark attention session management as complete in TODO docs

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68960eff53708322aeac64cdb6c6c562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced session management for timed encouragement and break reminders.
* **Tests**
  * Added tests to verify session timing and callback behavior.
* **Documentation**
  * Updated checklist to reflect completion of session management for attention span.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->