### PR TITLE
feat: add caregiver portal training data approval

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -77,7 +77,7 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Implement gentle encouragement system
   - [x] Add dedicated practice screen for rehearsal _(update `app/src/screens/PracticeScreen.tsx`; see `integration/test/practiceMode.test.js`)_
 
-- [ ] **Caregiver portal completion** _(implement routes in `server/src/portal`; see `integration/test/portal.test.js`)_
+- [x] **Caregiver portal completion** _(implement routes in `server/src/portal`; see `integration/test/portal.test.js`)_
   - Review, approve, and export recorded samples for training.
 
 ### Enhanced Intelligence Features

--- a/integration/package.json
+++ b/integration/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "pretest": "npm ci --include=dev && npm run build --prefix ../server",
-    "test": "tsx --test offlineFallback.spec.ts offlineBoot.spec.ts teachMode.spec.ts test/api.test.js test/practiceMode.test.js"
+    "test": "tsx --test offlineFallback.spec.ts offlineBoot.spec.ts teachMode.spec.ts test/api.test.js test/practiceMode.test.js test/portal.test.js"
   },
   "devDependencies": {
     "tsx": "^4.20.3"

--- a/integration/test/portal.test.js
+++ b/integration/test/portal.test.js
@@ -1,0 +1,66 @@
+import { spawn } from 'child_process';
+import { once } from 'events';
+import assert from 'node:assert';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { test, before, after } from 'node:test';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverDir = join(__dirname, '..', '..', 'server');
+const PORT = 5050;
+let proc;
+
+async function startServer() {
+  proc = spawn('node', ['dist/server.js'], {
+    cwd: serverDir,
+    env: { ...process.env, PORT: PORT.toString(), API_TOKEN: 'testtoken' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('server start timeout')), 5000);
+    proc.stdout.on('data', (data) => {
+      if (data.toString().includes('Server is running')) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    proc.on('error', reject);
+    proc.on('exit', (code) => reject(new Error(`server exited ${code}`)));
+  });
+}
+
+async function stopServer() {
+  if (proc) {
+    proc.kill();
+    await once(proc, 'exit').catch(() => {});
+  }
+}
+
+before(startServer);
+after(stopServer);
+
+test('approve and export training data', async () => {
+  const payload = { gestureDefinitionId: 'hello', landmarkData: [1, 2, 3] };
+  const postRes = await fetch(`http://localhost:${PORT}/portal/training-data`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  assert.strictEqual(postRes.status, 200);
+  const { id } = await postRes.json();
+  assert.ok(id);
+
+  const approveRes = await fetch(`http://localhost:${PORT}/portal/training-data/${id}/approve`, {
+    method: 'POST',
+  });
+  assert.strictEqual(approveRes.status, 200);
+
+  const exportRes = await fetch(`http://localhost:${PORT}/portal/training-data/export`);
+  assert.strictEqual(exportRes.status, 200);
+  const data = await exportRes.json();
+  assert.ok(Array.isArray(data));
+  assert.strictEqual(data.length, 1);
+  assert.strictEqual(data[0].id, id);
+  assert.strictEqual(data[0].approved, true);
+});

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -282,6 +282,7 @@ export const logCorrection = (
     landmarkData,
     source: 'HIP_3',
     syncStatus: 'pending',
+    approved: false,
   };
   addGestureTrainingData(db, training);
 

--- a/server/src/portal/index.ts
+++ b/server/src/portal/index.ts
@@ -8,6 +8,8 @@ import {
   saveDatabase,
   addGestureTrainingData,
   removeGestureTrainingData,
+  getGestureTrainingDataById,
+  updateGestureTrainingData,
 } from '../db';
 import { promises as fs } from 'fs';
 
@@ -66,6 +68,7 @@ router.post('/training-data', limiter, async (req, res) => {
     landmarkData,
     source: 'HIP_2',
     syncStatus: 'pending',
+    approved: false,
   });
   await saveDatabase(db, DB_FILE_PATH);
   res.json({ id });
@@ -77,6 +80,27 @@ router.delete('/training-data/:id', limiter, async (req, res) => {
   removeGestureTrainingData(db, id);
   await saveDatabase(db, DB_FILE_PATH);
   res.json({ status: 'deleted' });
+});
+
+router.post('/training-data/:id/approve', limiter, async (req, res) => {
+  const { id } = req.params;
+  const db = await loadDatabase(DB_FILE_PATH);
+  const record = getGestureTrainingDataById(db, id);
+  if (!record) {
+    res.status(404).send('Not found');
+    return;
+  }
+  record.approved = true;
+  updateGestureTrainingData(db, record);
+  await saveDatabase(db, DB_FILE_PATH);
+  res.json({ status: 'approved' });
+});
+
+router.get('/training-data/export', limiter, async (_req, res) => {
+  const db = await loadDatabase(DB_FILE_PATH);
+  const approved = db.gestureTrainingData.filter((d) => d.approved);
+  res.setHeader('Content-Disposition', 'attachment; filename="training-data.json"');
+  res.json(approved);
 });
 
 export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15,6 +15,7 @@ import {
   loadAnalyticsFromFile,
 } from './services/analyticsService';
 import { getLLMSuggestions, LLMRequest } from './services/dialogEngine';
+import portalRouter from './portal';
 
 const app = express();
 app.use(express.json());
@@ -34,6 +35,9 @@ app.use('/portal', express.static(path.join(__dirname, 'portal')));
 app.get('/portal', (_req: Request, res: Response) => {
   res.sendFile(path.join(__dirname, 'portal', 'index.html'));
 });
+
+// API routes for caregiver portal
+app.use('/portal', portalRouter);
 
 let dbInstance: Database; // Declare a variable to hold the database instance
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -28,6 +28,7 @@ export interface GestureTrainingData {
   landmarkData: unknown;
   source: TrainingSource;
   syncStatus: SyncStatus;
+  approved: boolean;
 }
 
 export type ProcessedBy = 'local' | 'cloud';


### PR DESCRIPTION
## Summary
- enable caregivers to approve and export training data via new portal routes
- track approval status on training data records
- cover portal workflow with integration test

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68962b0e33d4832293fbf7ccbc868065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an approval mechanism for gesture training data, including the ability to approve records and export only approved data through the portal.
  * Introduced endpoints to approve training data and export approved records as a downloadable JSON file.

* **Bug Fixes**
  * None.

* **Tests**
  * Added integration tests to verify training data approval and export functionality.

* **Documentation**
  * Updated task list to mark caregiver portal as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->