### PR TITLE
feat: add child-friendly touch targets

### DIFF
--- a/app/src/components/SymbolButton.tsx
+++ b/app/src/components/SymbolButton.tsx
@@ -3,6 +3,8 @@ import { Pressable, Text, StyleSheet } from 'react-native';
 import { Symbol } from '../../db/models';
 import { useAccessibility } from './AccessibilityContext';
 import { COLORS, SPACING, RADIUS } from '../constants/ui';
+import { childFriendlyStyles } from '../styles/touchTargets';
+import { childHaptic } from '../services/feedbackService';
 
 interface Props {
   symbol: Symbol;
@@ -13,8 +15,11 @@ export const SymbolButton = ({ symbol, onPress }: Props) => {
   const { largeText, highContrast } = useAccessibility();
   return (
     <Pressable
-      style={[styles.button, highContrast && styles.buttonHC]}
-      onPress={() => onPress(symbol)}
+      style={[childFriendlyStyles.minTouchTarget, styles.button, highContrast && styles.buttonHC]}
+      onPress={() => {
+        void childHaptic();
+        onPress(symbol);
+      }}
       accessibilityRole="button"
       accessibilityLabel={symbol.name}
     >

--- a/app/src/services/feedbackService.ts
+++ b/app/src/services/feedbackService.ts
@@ -31,3 +31,14 @@ export async function triggerSpeakAndShow(
   ];
   await Promise.allSettled(tasks);
 }
+
+/**
+ * Gentle haptic feedback for child-friendly touch targets.
+ */
+export async function childHaptic(): Promise<void> {
+  try {
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  } catch (error) {
+    logger.warn('Child haptic feedback failed:', error);
+  }
+}

--- a/app/src/styles/touchTargets.ts
+++ b/app/src/styles/touchTargets.ts
@@ -1,0 +1,19 @@
+import { StyleSheet, ViewStyle } from 'react-native';
+import { COLORS, RADIUS } from '../constants/ui';
+
+const base: ViewStyle = {
+  minWidth: 60,
+  minHeight: 60,
+  padding: 12,
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+export const childFriendlyStyles = StyleSheet.create({
+  minTouchTarget: base,
+  primaryButton: {
+    ...base,
+    backgroundColor: COLORS.primaryAccent,
+    borderRadius: RADIUS,
+  },
+});

--- a/app/test/symbolButton.test.tsx
+++ b/app/test/symbolButton.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock('react-native', () => {
+  const React = require('react');
+  return {
+    Pressable: (props: any) => React.createElement('Pressable', props, props.children),
+    Text: (props: any) => React.createElement('Text', props, props.children),
+    StyleSheet: { create: () => ({}) },
+  };
+});
+
+jest.mock('../src/components/AccessibilityContext', () => ({
+  useAccessibility: () => ({ largeText: false, highContrast: false }),
+}));
+
+const childHaptic = jest.fn();
+
+jest.mock('../src/services/feedbackService', () => ({
+  childHaptic: jest.fn(),
+}));
+
+import { SymbolButton } from '../src/components/SymbolButton';
+
+describe('SymbolButton', () => {
+  it('triggers haptic feedback on press', () => {
+    const symbol: any = { id: '1', name: 'Hello', emoji: '👋' };
+    const onPress = jest.fn();
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <SymbolButton symbol={symbol} onPress={onPress} />,
+      );
+    });
+    const pressable = (component as renderer.ReactTestRenderer).root.findByType('Pressable');
+    const { childHaptic: mockHaptic } = require('../src/services/feedbackService');
+    act(() => {
+      pressable.props.onPress();
+    });
+    expect(mockHaptic).toHaveBeenCalled();
+    expect(onPress).toHaveBeenCalledWith(symbol);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable child-friendly touch target styles
- trigger gentle haptic feedback when pressing SymbolButton
- cover SymbolButton with unit test

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6896c90011608322be0283de8d804003