### PR TITLE
feat: add accessible press feedback

### DIFF
--- a/app/src/components/SymbolButton.tsx
+++ b/app/src/components/SymbolButton.tsx
@@ -15,7 +15,12 @@ export const SymbolButton = ({ symbol, onPress }: Props) => {
   const { largeText, highContrast } = useAccessibility();
   return (
     <Pressable
-      style={[childFriendlyStyles.minTouchTarget, styles.button, highContrast && styles.buttonHC]}
+      style={({ pressed }) => [
+        childFriendlyStyles.minTouchTarget,
+        styles.button,
+        highContrast && styles.buttonHC,
+        pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+      ]}
       onPress={() => {
         void childHaptic();
         onPress(symbol);
@@ -48,6 +53,8 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.highContrastBackground,
     borderColor: COLORS.highContrastText,
   },
+  buttonPressed: { backgroundColor: COLORS.pressed },
+  buttonPressedHC: { backgroundColor: COLORS.highContrastPressed },
   text: { fontSize: 16, color: COLORS.text },
   textLarge: { fontSize: 20 },
   textHC: { color: COLORS.highContrastText },

--- a/app/test/symbolButton.test.tsx
+++ b/app/test/symbolButton.test.tsx
@@ -6,7 +6,7 @@ jest.mock('react-native', () => {
   return {
     Pressable: (props: any) => React.createElement('Pressable', props, props.children),
     Text: (props: any) => React.createElement('Text', props, props.children),
-    StyleSheet: { create: () => ({}) },
+    StyleSheet: { create: (styles: any) => styles },
   };
 });
 
@@ -21,6 +21,7 @@ jest.mock('../src/services/feedbackService', () => ({
 }));
 
 import { SymbolButton } from '../src/components/SymbolButton';
+import { COLORS } from '../src/constants/ui';
 
 describe('SymbolButton', () => {
   it('triggers haptic feedback on press', () => {
@@ -39,5 +40,21 @@ describe('SymbolButton', () => {
     });
     expect(mockHaptic).toHaveBeenCalled();
     expect(onPress).toHaveBeenCalledWith(symbol);
+  });
+
+  it('applies pressed visual style', () => {
+    const symbol: any = { id: '1', name: 'Hello', emoji: '👋' };
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <SymbolButton symbol={symbol} onPress={() => {}} />,
+      );
+    });
+    const pressable = (component as renderer.ReactTestRenderer).root.findByType('Pressable');
+    const styleFn = pressable.props.style as (args: { pressed: boolean }) => any;
+    const pressedStyle = styleFn({ pressed: true });
+    expect(pressedStyle).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: COLORS.pressed })]),
+    );
   });
 });

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -236,8 +236,8 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [ ] **Animation & Feedback**
   - Implement RN Animated API for smooth transitions
   - Add Skia-based animations (optional)
-  - Create gentle haptic feedback system
-  - Add visual highlight during confirmation for accessibility
+  - [x] Create gentle haptic feedback system
+  - [x] Add visual highlight during confirmation for accessibility
   - Test animation performance on older devices
 
 - [ ] **Child-Friendly Interface**


### PR DESCRIPTION
## Summary
- add pressed visual styles to SymbolButton for accessibility
- mark docs TODOs for haptic feedback and visual highlight as done
- cover SymbolButton pressed style with tests

## Testing
- `./scripts/full-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896cb483774832287fd6bbd1005a857