### PR TITLE
feat: add neutral fail-safe feedback

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -19,7 +19,7 @@ import { useIsFocused } from '@react-navigation/native';
 import CorrectionPanel from '../components/CorrectionPanel';
 import SymbolVideoPlayer from '../components/SymbolVideoPlayer';
 import { loadProfile, Profile, logCorrection } from '../storage';
-import { audioService, triggerSpeakAndShow } from '../services';
+import { audioService, triggerSpeakAndShow, correctionService } from '../services';
 import { assessOcclusion } from '../services/GestureOcclusion';
 import { adaptiveLearningService } from '../services/adaptiveLearningService';
 import { database } from '../../db';
@@ -37,7 +37,8 @@ import { HAND_CONNECTIONS } from '../constants/hand';
 import ErrorMessage from '../components/ErrorMessage';
 import { logger } from '../utils/logger';
 import { ModelPerformanceMonitor } from '../services/ModelPerformanceMonitor';
-import { dump as dumpTelemetry } from '../telemetry/recorder';
+import { telemetry } from '../telemetry/recorder';
+import * as Haptics from 'expo-haptics';
 
 const { width, height } = Dimensions.get('window');
 
@@ -71,6 +72,7 @@ export default function RecognitionScreen({ navigation }: any) {
   const [occlusionHints, setOcclusionHints] = useState<string[] | null>(null);
   const neutralCooldownRef = useRef<number>(0);
   const [lastResultAt, setLastResultAt] = useState<number>(0);
+  const [showNeutralHint, setShowNeutralHint] = useState(false);
   const perfMonitorRef = useRef(new ModelPerformanceMonitor(60));
   const [showPerfBanner, setShowPerfBanner] = useState(false);
   const [showDebug, setShowDebug] = useState(false);
@@ -179,16 +181,16 @@ export default function RecognitionScreen({ navigation }: any) {
     if (!showDebug) return;
     const id = setInterval(() => {
       try {
-        const data = dumpTelemetry();
+        const data = telemetry.dump() as any[];
         if (data.length === 0) {
           setDebugStats({ medianLatency: 0, offlineRatio: 0, cloudRatio: 0 });
           return;
         }
-        const lat = data.map((d) => d.latencyMs).sort((a, b) => a - b);
+        const lat = data.map((d: any) => d.latencyMs).sort((a: number, b: number) => a - b);
         const mid = Math.floor(lat.length / 2);
         const median = lat.length % 2 ? lat[mid] : (lat[mid - 1] + lat[mid]) / 2;
-        const offline = data.filter((d) => d.path === 'offline').length;
-        const cloud = data.filter((d) => d.path === 'cloud').length;
+        const offline = data.filter((d: any) => d.path === 'offline').length;
+        const cloud = data.filter((d: any) => d.path === 'cloud').length;
         const total = data.length;
         setDebugStats({
           medianLatency: Math.round(median),
@@ -359,6 +361,11 @@ export default function RecognitionScreen({ navigation }: any) {
       if (canUseCamera && !isProcessing && (noFrames || noResults) && ts >= neutralCooldownRef.current) {
         try {
           await audioService.speak('Ich bin hier und höre zu.');
+          try {
+            await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+          } catch {}
+          setShowNeutralHint(true);
+          setTimeout(() => setShowNeutralHint(false), 2000);
         } catch {}
         neutralCooldownRef.current = ts + 7000;
       }
@@ -801,6 +808,13 @@ export default function RecognitionScreen({ navigation }: any) {
               </View>
             )}
 
+            {showNeutralHint && !lastRecognizedGesture && (
+              <Animated.Text
+                style={[styles.symbolDisplay, { transform: [{ scale: symbolScaleAnim }] }]}
+              >
+                {'🤔'}
+              </Animated.Text>
+            )}
             {lastRecognizedGesture && lastRecognizedGesture.label !== 'uncertain' && (
               <Animated.Text
                 style={[styles.symbolDisplay, { transform: [{ scale: symbolScaleAnim }] }]}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -55,9 +55,9 @@ The project has a stable foundation after a major refactor. The database, naviga
    - Enforce `401` as the default for unauthorized access and add rate limiting.
    - Dashboard should display: correction rate, uncertainty ratio, median latency, top misclassifications.
 
-9. **Audio & UX Fail-safes**
-   - Never leave the app silent: in uncertain cases, output a neutral voice line plus visual symbol and haptic feedback.
-   - Add a UI timer to detect "no frame / no result" situations and degrade gracefully instead of freezing.
+9. [x] **Audio & UX Fail-safes**
+  - [x] Never leave the app silent: in uncertain cases, output a neutral voice line plus visual symbol and haptic feedback.
+  - [x] Add a UI timer to detect "no frame / no result" situations and degrade gracefully instead of freezing.
 
 10. **Documentation & Roadmap Cleanup**
     - Keep `README.md` as a short landing page, move deeper technical documentation to `docs/*`.


### PR DESCRIPTION
## Summary
- add haptic and visual neutral feedback when camera has no results
- document completion of Audio & UX fail-safes

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `npm test --prefix server` *(fails: Connection refused)*
- `npm test --prefix integration` *(fails: Cannot find name 'NegativeSample')*


------
https://chatgpt.com/codex/tasks/task_e_6896f20a134c83228cbd82bf8eab40a1