### PR TITLE
feat: add child-friendly bottom nav buttons

### DIFF
--- a/app/src/components/BottomNav.tsx
+++ b/app/src/components/BottomNav.tsx
@@ -5,6 +5,8 @@ import { Hand, BookOpen, Settings } from 'lucide-react-native';
 import type { RootStackParamList } from '../navigation/types';
 import { COLORS, SPACING } from '../constants/ui';
 import { useAccessibility } from './AccessibilityContext';
+import { childFriendlyStyles } from '../styles/touchTargets';
+import { childHaptic } from '../services/feedbackService';
 
 interface Props {
   active: 'recognition' | 'training' | 'parent';
@@ -17,8 +19,15 @@ export default function BottomNav({ active, profileId }: Props) {
   return (
     <View style={[styles.container, highContrast && styles.containerHC]}>
       <Pressable
-        onPress={() => navigation.navigate('Recognition', { profileId })}
-        style={styles.item}
+        onPress={() => {
+          void childHaptic();
+          navigation.navigate('Recognition', { profileId });
+        }}
+        style={({ pressed }) => [
+          childFriendlyStyles.minTouchTarget,
+          styles.item,
+          pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+        ]}
         accessibilityLabel="Listen"
         accessibilityRole="button"
         accessibilityHint="Start gesture recognition"
@@ -47,8 +56,15 @@ export default function BottomNav({ active, profileId }: Props) {
         </Text>
       </Pressable>
       <Pressable
-        onPress={() => navigation.navigate('Training', { gestureLabel: undefined })}
-        style={styles.item}
+        onPress={() => {
+          void childHaptic();
+          navigation.navigate('Training', { gestureLabel: undefined });
+        }}
+        style={({ pressed }) => [
+          childFriendlyStyles.minTouchTarget,
+          styles.item,
+          pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+        ]}
         accessibilityLabel="Learn"
         accessibilityRole="button"
         accessibilityHint="Record or practice gestures"
@@ -77,8 +93,15 @@ export default function BottomNav({ active, profileId }: Props) {
         </Text>
       </Pressable>
       <Pressable
-        onPress={() => navigation.navigate('ProfileSelect')}
-        style={styles.item}
+        onPress={() => {
+          void childHaptic();
+          navigation.navigate('ProfileSelect');
+        }}
+        style={({ pressed }) => [
+          childFriendlyStyles.minTouchTarget,
+          styles.item,
+          pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+        ]}
         accessibilityLabel="Menu"
         accessibilityRole="button"
         accessibilityHint="Open profile and settings menu"
@@ -127,6 +150,8 @@ const styles = StyleSheet.create({
   item: {
     alignItems: 'center',
   },
+  buttonPressed: { backgroundColor: COLORS.pressed },
+  buttonPressedHC: { backgroundColor: COLORS.highContrastPressed },
   icon: {
     marginBottom: SPACING.xs,
   },

--- a/app/test/bottomNav.test.tsx
+++ b/app/test/bottomNav.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock('react-native', () => {
+  const React = require('react');
+  return {
+    View: (props: any) => React.createElement('View', props, props.children),
+    Pressable: (props: any) => React.createElement('Pressable', props, props.children),
+    Text: (props: any) => React.createElement('Text', props, props.children),
+    StyleSheet: { create: (styles: any) => styles },
+  };
+});
+
+const navigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate }),
+}));
+
+jest.mock('lucide-react-native', () => {
+  const React = require('react');
+  return {
+    Hand: (props: any) => React.createElement('Hand', props, props.children),
+    BookOpen: (props: any) => React.createElement('BookOpen', props, props.children),
+    Settings: (props: any) => React.createElement('Settings', props, props.children),
+  };
+});
+
+jest.mock('../src/components/AccessibilityContext', () => ({
+  useAccessibility: () => ({ highContrast: false }),
+}));
+
+jest.mock('../src/services/feedbackService', () => ({
+  childHaptic: jest.fn(),
+}));
+
+import BottomNav from '../src/components/BottomNav';
+import { COLORS } from '../src/constants/ui';
+
+describe('BottomNav', () => {
+  it('uses large touch targets with haptic feedback', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<BottomNav active="recognition" profileId="123" />);
+    });
+    const pressable = (component as renderer.ReactTestRenderer).root.findAllByType('Pressable')[0];
+    const styleFn = pressable.props.style as (args: { pressed: boolean }) => any;
+    const pressedStyle = styleFn({ pressed: true });
+    expect(pressedStyle).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ minWidth: 60, minHeight: 60 }),
+        expect.objectContaining({ backgroundColor: COLORS.pressed }),
+      ]),
+    );
+    const { childHaptic } = require('../src/services/feedbackService');
+    act(() => {
+      pressable.props.onPress();
+    });
+    expect(childHaptic).toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('Recognition', { profileId: '123' });
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -251,7 +251,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [ ] **Child-Friendly Interface**
   - Optimize UI for 4-year-old usability
   - Add colorful, engaging visual elements
-  - Implement large touch targets
+  - [x] Implement large touch targets
     - Hint: use `childFriendlyStyles.minTouchTarget` (60x60, padding 12) and add haptic feedback.
     - Example:
       ```ts


### PR DESCRIPTION
## Summary
- add haptic feedback and 60x60 touch targets to bottom navigation buttons
- test bottom navigation for child-friendly behavior
- mark touch-target TODO complete in docs

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server` (fails: URLError Connection refused)
- `npm test --prefix integration` (fails: Cannot find name 'NegativeSample')

------
https://chatgpt.com/codex/tasks/task_e_68972299f5248322953418adbe08631d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added haptic feedback when pressing navigation buttons in the bottom navigation bar.
  * Improved accessibility by increasing the touch target size for navigation buttons.
  * Enhanced visual feedback for pressed states, including support for high contrast mode.

* **Tests**
  * Introduced tests to verify touch target size, pressed state styling, haptic feedback, and navigation behavior in the bottom navigation bar.

* **Documentation**
  * Marked the "Implement large touch targets" task as completed in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->