### PR TITLE
feat: add accessibility announcements for gesture recognition

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -19,7 +19,13 @@ import { useIsFocused } from '@react-navigation/native';
 import CorrectionPanel from '../components/CorrectionPanel';
 import SymbolVideoPlayer from '../components/SymbolVideoPlayer';
 import { loadProfile, Profile, logCorrection } from '../storage';
-import { audioService, triggerSpeakAndShow, correctionService } from '../services';
+import {
+  audioService,
+  triggerSpeakAndShow,
+  correctionService,
+  announceGestureRecognition,
+  createGestureAccessibilityLabel,
+} from '../services';
 import { assessOcclusion } from '../services/GestureOcclusion';
 import { adaptiveLearningService } from '../services/adaptiveLearningService';
 import { database } from '../../db';
@@ -46,6 +52,11 @@ export default function RecognitionScreen({ navigation }: any) {
   const { largeText, highContrast } = useAccessibility();
   const [profile, setProfile] = useState<Profile | null>(null);
   const [status, setStatus] = useState("I'm listening...");
+  const [statusA11y, setStatusA11y] = useState("I'm listening...");
+  const updateStatus = useCallback((msg: string, a11yMsg?: string) => {
+    setStatus(msg);
+    setStatusA11y(a11yMsg ?? msg);
+  }, []);
   const [showCorrection, setShowCorrection] = useState(false);
   const [suggestions, setSuggestions] = useState<LLMSuggestionResponse>({
     nextWords: [],
@@ -233,7 +244,7 @@ export default function RecognitionScreen({ navigation }: any) {
     setShowCorrection(false);
     setShowHelp(false);
     setIsProcessing(false);
-    setStatus("I'm listening...");
+    updateStatus("I'm listening...");
   };
 
   const onGestureResult = useCallback(async (result: any, detectedLandmarks: number[][]) => {
@@ -279,7 +290,11 @@ export default function RecognitionScreen({ navigation }: any) {
         };
 
       setLastRecognizedGesture(entry);
-      setStatus(recognizedSymbolLabel);
+      updateStatus(
+        recognizedSymbolLabel,
+        createGestureAccessibilityLabel(recognizedSymbolLabel, result.confidence),
+      );
+      announceGestureRecognition(recognizedSymbolLabel, result.confidence);
       startFeedbackAnimation();
       triggerSpeakAndShow(
         recognizedSymbolLabel,
@@ -321,7 +336,7 @@ export default function RecognitionScreen({ navigation }: any) {
 
       setTimeout(() => {
         setIsProcessing(false);
-        setStatus("I'm listening...");
+        updateStatus("I'm listening...");
       }, 3000);
     } else if (result && result.requiresConfirmation) {
       setIsProcessing(true);
@@ -336,14 +351,14 @@ export default function RecognitionScreen({ navigation }: any) {
       }));
       setCorrectionOptions(mapped);
       setLastRecognizedGesture(null);
-      setStatus("Can you help me?");
+      updateStatus("Can you help me?");
       setShowHelp(true);
       startFeedbackAnimation();
       audioService.playErrorFeedback().catch((error) => {
         logger.warn('Error feedback failed:', error);
       });
     }
-  }, [isProcessing, useDgs, profile, startFeedbackAnimation]);
+  }, [isProcessing, useDgs, profile, startFeedbackAnimation, updateStatus]);
 
   const frameProcessor = useGestureClassifier(onGestureResult, isProcessing, setProcessingError);
   const detectionActive = now - lastDetection < 1000;
@@ -400,7 +415,8 @@ export default function RecognitionScreen({ navigation }: any) {
       setShowCorrection(false);
       setShowHelp(false);
       setLastRecognizedGesture(entry);
-      setStatus(entry.label);
+      updateStatus(entry.label, createGestureAccessibilityLabel(entry.label, 1));
+      announceGestureRecognition(entry.label, 1);
       startFeedbackAnimation();
       audioService
         .playSuccessFeedback(entry.label, 1)
@@ -441,7 +457,7 @@ export default function RecognitionScreen({ navigation }: any) {
       setPendingGesture(null);
       setTimeout(() => {
         setIsProcessing(false);
-        setStatus("I'm listening...");
+        updateStatus("I'm listening...");
         navigation.navigate('Training', { gestureLabel: pendingGesture, isPractice: true });
       }, 3000);
     } catch (error) {
@@ -797,6 +813,7 @@ export default function RecognitionScreen({ navigation }: any) {
             <Animated.Text
               onLongPress={() => setShowDebug((v) => !v)}
               style={[styles.status]}
+              accessibilityLabel={statusA11y}
             >
               {status}
             </Animated.Text>

--- a/app/src/services/accessibilityService.ts
+++ b/app/src/services/accessibilityService.ts
@@ -1,0 +1,35 @@
+import { AccessibilityInfo } from 'react-native';
+
+/**
+ * Announces a recognized gesture for screen readers.
+ * @param name Gesture name to announce
+ * @param confidence Confidence value between 0 and 1
+ */
+export function announceGestureRecognition(name: string, confidence: number): void {
+  const percent = Math.round(confidence * 100);
+  const message = `${name} erkannt, ${percent} Prozent sicher`;
+  try {
+    AccessibilityInfo.announceForAccessibility(message);
+  } catch {
+    // ignore errors to avoid breaking gesture flow
+  }
+}
+
+/**
+ * Builds a descriptive accessibility label for a gesture.
+ * @param gesture Gesture name
+ * @param confidence Confidence value between 0 and 1
+ * @param context Optional additional context to append
+ */
+export function createGestureAccessibilityLabel(
+  gesture: string,
+  confidence: number,
+  context?: string,
+): string {
+  const percent = Math.round(confidence * 100);
+  let label = `${gesture}, ${percent} Prozent sicher`;
+  if (context && context.length > 0) {
+    label += `. ${context}`;
+  }
+  return label;
+}

--- a/app/src/services/index.ts
+++ b/app/src/services/index.ts
@@ -13,3 +13,4 @@ export * from "./modelUpdate";
 export * from "./syncService";
 export * from './feedbackService';
 export * from './childSessionManager';
+export * from './accessibilityService';

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -232,7 +232,7 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Add screen reader support for bottom navigation
   - [x] Implement high contrast mode
   - Test with accessibility tools
-  - [ ] Add rich gesture descriptions and live announcements
+  - [x] Add rich gesture descriptions and live announcements
     - Example:
       ```ts
       announceGestureRecognition(name, confidence);


### PR DESCRIPTION
## Summary
- add accessibility service with functions to describe and announce gestures
- announce recognized gestures and expose accessibility label in `RecognitionScreen`
- mark accessibility docs todo as complete

## Testing
- `./scripts/full-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6897c8f872948322b7180ac416570b1b