### PR TITLE
feat: secure gesture data and API key

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18,6 +18,7 @@
         "@react-navigation/stack": "6.4.1",
         "@shopify/react-native-skia": "2.2.2",
         "better-sqlite3": "12.2.0",
+        "crypto-js": "4.2.0",
         "expo": "53.0.20",
         "expo-audio": "0.4.8",
         "expo-camera": "16.1.11",
@@ -47,6 +48,7 @@
         "@babel/preset-flow": "7.27.1",
         "@babel/preset-typescript": "7.27.1",
         "@react-native-community/cli": "latest",
+        "@types/crypto-js": "4.2.1",
         "@types/jest": "30.0.0",
         "@types/react": "19.0.10",
         "babel-jest": "30.0.5",
@@ -5913,6 +5915,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.1.tgz",
+      "integrity": "sha512-FSPGd9+OcSok3RsM0UZ/9fcvMOXJ1ENE/ZbLfOPlBWj7BgXtEAM8VYfTtT760GiLbQIMoVozwVuisjvsVwqYWw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -7531,6 +7540,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,7 @@
     "expo-secure-store": "14.2.3",
     "expo-speech": "13.1.7",
     "expo-video": "2.2.2",
+    "crypto-js": "4.2.0",
     "@shopify/react-native-skia": "2.2.2",
     "lucide-react-native": "0.535.0",
     "react": "19.0.0",
@@ -69,6 +70,7 @@
     "metro-config": "0.82.3",
     "metro-runtime": "0.82.3",
     "metro-source-map": "0.82.3",
+    "@types/crypto-js": "4.2.1",
     "ts-jest": "29.4.0",
     "ts-node": "10.9.2",
     "typescript": "5.8.3"

--- a/app/src/services/dataProtection.ts
+++ b/app/src/services/dataProtection.ts
@@ -1,4 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import CryptoJS from 'crypto-js';
 
 export interface GestureData {
   gestureClass: string;
@@ -14,29 +16,33 @@ interface AnonymizedGestureData {
   sessionId: string;
 }
 
-function simpleHash(text: string): string {
-  let hash = 0;
-  for (let i = 0; i < text.length; i++) {
-    hash = (hash << 5) - hash + text.charCodeAt(i);
-    hash |= 0;
-  }
-  return hash.toString();
-}
-
 class GestureDataProtector {
-  private encryptionKey: string;
+  private encryptionKey: string | null = null;
+  private keyPromise: Promise<string>;
 
   constructor() {
-    this.encryptionKey = this.getOrCreateEncryptionKey();
+    this.keyPromise = this.getOrCreateEncryptionKey();
   }
 
-  private getOrCreateEncryptionKey(): string {
-    // In a real implementation this would be device specific
-    return 'amys-echo-gesture-key';
+  private async getOrCreateEncryptionKey(): Promise<string> {
+    let key = await SecureStore.getItemAsync('gestureEncryptionKey');
+    if (!key) {
+      key = CryptoJS.lib.WordArray.random(32).toString();
+      await SecureStore.setItemAsync('gestureEncryptionKey', key);
+    }
+    this.encryptionKey = key;
+    return key as string;
+  }
+
+  private async getKey(): Promise<string> {
+    if (!this.encryptionKey) {
+      this.encryptionKey = await this.keyPromise;
+    }
+    return this.encryptionKey;
   }
 
   private hashSessionId(sessionId: string): string {
-    return sessionId.split('').reverse().join('');
+    return CryptoJS.SHA256(sessionId).toString();
   }
 
   private anonymizeGestureData(data: GestureData): AnonymizedGestureData {
@@ -49,8 +55,14 @@ class GestureDataProtector {
   }
 
   private async encrypt(data: any): Promise<string> {
-    const json = JSON.stringify(data) + this.encryptionKey;
-    return simpleHash(json);
+    const key = await this.getKey();
+    return CryptoJS.AES.encrypt(JSON.stringify(data), key).toString();
+  }
+
+  private async decrypt(cipher: string): Promise<AnonymizedGestureData> {
+    const key = await this.getKey();
+    const bytes = CryptoJS.AES.decrypt(cipher, key);
+    return JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
   }
 
   private async storeWithRetention(data: string, days: number): Promise<void> {
@@ -64,6 +76,11 @@ class GestureDataProtector {
     const anonymized = this.anonymizeGestureData(gestureData);
     const encrypted = await this.encrypt(anonymized);
     await this.storeWithRetention(encrypted, 30);
+  }
+
+  // Exposed for testing to verify anonymization
+  async decryptGesture(cipher: string): Promise<AnonymizedGestureData> {
+    return this.decrypt(cipher);
   }
 }
 

--- a/app/src/services/secureConfig.ts
+++ b/app/src/services/secureConfig.ts
@@ -26,8 +26,10 @@ class SecureConfigManager {
   }
 
   async setAPIKey(key: string): Promise<void> {
-    this.apiKeyHash = this.hashKey(key);
+    const hash = this.hashKey(key);
+    this.apiKeyHash = hash;
     await SecureStore.setItemAsync('amys-echo-api-key', key);
+    await SecureStore.setItemAsync('amys-echo-api-key-hash', hash);
     setTimeout(() => {
       key = '';
     }, 1000);
@@ -35,15 +37,23 @@ class SecureConfigManager {
 
   async getAPIKey(): Promise<string | null> {
     try {
-      return await SecureStore.getItemAsync('amys-echo-api-key');
+      const key = await SecureStore.getItemAsync('amys-echo-api-key');
+      const storedHash = await SecureStore.getItemAsync('amys-echo-api-key-hash');
+      if (key && storedHash && this.hashKey(key) === storedHash) {
+        return key;
+      }
+      logger.error('API key integrity check failed');
+      return null;
     } catch (error) {
       logger.error('Failed to retrieve API key:', error);
       return process.env.OPENAI_API_KEY || null;
     }
   }
 
-  validateKeyIntegrity(): boolean {
-    return this.apiKeyHash.length > 0;
+  async validateKeyIntegrity(): Promise<boolean> {
+    const key = await SecureStore.getItemAsync('amys-echo-api-key');
+    const hash = await SecureStore.getItemAsync('amys-echo-api-key-hash');
+    return !!(key && hash && this.hashKey(key) === hash);
   }
 }
 

--- a/app/test/dataProtection.test.ts
+++ b/app/test/dataProtection.test.ts
@@ -1,0 +1,50 @@
+jest.mock('@react-native-async-storage/async-storage');
+jest.mock('expo-secure-store', () => {
+  const store: Record<string, string> = { gestureEncryptionKey: 'test-key' };
+  return {
+    getItemAsync: jest.fn(async (key: string) => store[key] ?? null),
+    setItemAsync: jest.fn(async (key: string, value: string) => {
+      store[key] = value;
+    }),
+  };
+});
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import CryptoJS from 'crypto-js';
+import { gestureDataProtector, GestureData } from '../src/services/dataProtection';
+
+describe('GestureDataProtector', () => {
+  beforeEach(() => {
+    (AsyncStorage.setItem as jest.Mock).mockReset();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('anonymizes and encrypts gesture data', async () => {
+    const sample: GestureData = {
+      gestureClass: 'wave',
+      confidence: 0.9,
+      timestamp: Date.now(),
+      sessionId: 'session123',
+    };
+
+    await gestureDataProtector.storeGesture(sample);
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'protectedGestures',
+      expect.any(String)
+    );
+
+    const stored = (AsyncStorage.setItem as jest.Mock).mock.calls[0][1];
+    const records = JSON.parse(stored);
+    const cipher = records[0].data;
+    expect(cipher).not.toContain(sample.sessionId);
+
+    const key = 'test-key';
+    const bytes = CryptoJS.AES.decrypt(cipher, key);
+    const decrypted = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
+    expect(decrypted.sessionId).toBe(CryptoJS.SHA256(sample.sessionId).toString());
+    expect(decrypted.timestamp).toBe(
+      Math.floor(sample.timestamp / (24 * 60 * 60 * 1000))
+    );
+  });
+});

--- a/app/test/secureConfig.test.ts
+++ b/app/test/secureConfig.test.ts
@@ -1,0 +1,30 @@
+jest.mock('expo-secure-store', () => {
+  const store: Record<string, string> = {};
+  return {
+    getItemAsync: jest.fn(async (key: string) => store[key] ?? null),
+    setItemAsync: jest.fn(async (key: string, value: string) => {
+      store[key] = value;
+    }),
+  };
+});
+
+import * as SecureStore from 'expo-secure-store';
+import { secureConfigManager } from '../src/services/secureConfig';
+
+describe('SecureConfigManager', () => {
+  beforeEach(() => {
+    (SecureStore.getItemAsync as jest.Mock).mockClear();
+    (SecureStore.setItemAsync as jest.Mock).mockClear();
+  });
+
+  it('stores key with hash and validates integrity', async () => {
+    await secureConfigManager.setAPIKey('abc123');
+    const key = await secureConfigManager.getAPIKey();
+    expect(key).toBe('abc123');
+
+    // Tamper stored key
+    await (SecureStore.setItemAsync as jest.Mock)('amys-echo-api-key', 'bad');
+    const tampered = await secureConfigManager.getAPIKey();
+    expect(tampered).toBeNull();
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -293,10 +293,10 @@ The project has a stable foundation after a major refactor. The database, naviga
   - Add GDPR compliance features
   - Create data export functionality
   - Test data migration scenarios
-  - [ ] Protect gesture data
-    - Hint: implement `GestureDataProtector` for anonymization and AES encryption.
-  - [ ] Enhance API key security
-    - Hint: use `SecureConfigManager` with device keystore and hash validation.
+  - [x] Protect gesture data
+    - Implement `GestureDataProtector` for anonymization and AES encryption.
+  - [x] Enhance API key security
+    - Added hash validation and secure storage in `SecureConfigManager`.
 
 - [ ] **Offline Capability**
   - Ensure full offline functionality


### PR DESCRIPTION
## Summary
- add AES encryption and SHA-256 session anonymization to gesture data storage
- harden API key storage with hash validation via SecureStore
- document completed data protection and key security tasks

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6897d2692c0883228b22305cbdd4c0cd