### PR TITLE
Add end-to-end integration specs

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -266,7 +266,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [ ] **Testing Suite**
   - [x] Implement unit tests for core services
   - [x] Add integration tests for HIP workflows
-  - Create end-to-end testing scenarios
+  - [x] Create end-to-end testing scenarios
   - Set up automated testing pipeline
 
 - [ ] **Performance Optimization**

--- a/integration/package.json
+++ b/integration/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "pretest": "npm ci --include=dev && npm run build --prefix ../server",
-    "test": "tsx --test offlineFallback.spec.ts offlineBoot.spec.ts teachMode.spec.ts onboardingFlow.spec.ts test/api.test.js test/practiceMode.test.js test/portal.test.js"
+    "test": "tsx --test offlineFallback.spec.ts offlineBoot.spec.ts teachMode.spec.ts onboardingFlow.spec.ts correctionFlow.spec.ts navigationConsistency.spec.ts practiceMode.spec.ts test/api.test.js test/practiceMode.test.js test/portal.test.js"
   },
   "devDependencies": {
     "tsx": "^4.20.3"


### PR DESCRIPTION
## Summary
- integrate correction, navigation, and practice specs into integration test suite
- mark E2E scenarios as done in project TODO

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68982fedd64083229644cb1f44405888