### PR TITLE
docs: add server API documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,122 @@
+# API Documentation
+
+This document describes the backend server endpoints used by Amy's Echo. All endpoints require an `Authorization` header in the form `Bearer <API_TOKEN>`.
+
+## Rate Limiting
+
+Two rate limiters are applied:
+- **/dialog**: Limited by `DIALOG_LIMIT` (default `60` requests per minute).
+- **/api/* and other endpoints**: Limited by `API_LIMIT` (default `120` requests per minute).
+
+## Endpoints
+
+### GET /api/analytics/profiles
+Return the list of gesture profiles available.
+
+**Response**
+```json
+[
+  { "id": "profile1", "name": "Child" }
+]
+```
+
+### GET /api/analytics/corrections
+Retrieve correction events. Optional query parameter `profileId` filters by profile.
+
+**Response**
+```json
+[
+  {
+    "predictedGesture": "wave",
+    "actualGesture": "clap",
+    "confidence": 0.42,
+    "timestamp": 1700000000000
+  }
+]
+```
+
+### POST /dialog
+Ask the dialog engine for caregiver suggestions.
+
+**Body**
+```json
+{
+  "input": "hello",
+  "context": ["previous", "messages"]
+}
+```
+
+**Response**
+```json
+{
+  "nextWords": ["friend"],
+  "caregiverPhrases": ["Good job!"]
+}
+```
+
+### POST /train-model
+Upload hand landmarks and trigger model training.
+
+**Body**
+```json
+{ "landmarks": [...] }
+```
+
+**Response**
+```json
+{ "status": "ok" }
+```
+
+### GET /model-version
+Fetch the current model version and path information.
+
+**Response**
+```json
+{ "version": "1.0.0", "modelPath": "latest-model" }
+```
+
+### GET /latest-model
+Download the latest trained gesture model file.
+
+### POST /analytics
+Store high level analytics.
+
+**Body**
+```json
+{ "successRate7d": 0.9, "improvementTrend": 0.2 }
+```
+
+**Response**
+```json
+{ "status": "ok" }
+```
+
+### GET /analytics
+Retrieve stored analytics summary.
+
+**Response**
+```json
+{
+  "id": "default",
+  "gestureDefinitionId": "default",
+  "successRate24h": 0,
+  "successRate7d": 0.9,
+  "avgConfidenceScore": 0,
+  "improvementTrend": 0.2,
+  "lastCalculated": 1700000000000
+}
+```
+
+### POST /classify
+Classify a gesture from raw landmarks. Falls back to cloud recognition when the local model is unavailable.
+
+**Body**
+```json
+{ "landmarks": [...] }
+```
+
+**Response**
+```json
+{ "label": "wave", "confidence": 0.92 }
+```
+

--- a/docs/API.md
+++ b/docs/API.md
@@ -66,7 +66,7 @@ Return learning analytics for gesture training progress.
 Export analytics data as CSV. Query parameter `type` selects `corrections`, `usage`, or `training`. Optional `profileId` filters by profile.
 
 ### GET /api/analytics/summary
-Return aggregated metrics such as correction rate, uncertainty ratio, median latency, and top misclassifications.
+Return aggregated metrics such as correction rate, uncertainty ratio, median latency, and top misclassifications. `medianLatencyMs` is `null` when no telemetry data is available, and `topMisclassifications` is an array of objects describing the most common errors.
 
 **Response**
 ```json
@@ -74,12 +74,14 @@ Return aggregated metrics such as correction rate, uncertainty ratio, median lat
   "correctionRate": 0.1,
   "uncertaintyRatio": 0.05,
   "medianLatencyMs": 120,
-  "topMisclassifications": ["wave -> clap"]
+  "topMisclassifications": [
+    { "predicted": "wave", "actual": "clap", "count": 3 }
+  ]
 }
 ```
 
 ### POST /api/telemetry
-Submit telemetry events recording gesture classification latency.
+Submit telemetry events recording gesture classification latency. Accepts a single event object or an array of events. Returns `202 Accepted`.
 
 **Body**
 ```json
@@ -94,7 +96,7 @@ Submit telemetry events recording gesture classification latency.
 ```
 
 ### POST /api/corrections
-Log a caregiver correction when the system misclassifies a gesture.
+Log a caregiver correction when the system misclassifies a gesture. Returns `202 Accepted`.
 
 **Body**
 ```json
@@ -107,7 +109,7 @@ Log a caregiver correction when the system misclassifies a gesture.
 ```
 
 ### POST /api/negative-samples
-Record a negative sample for future model training.
+Record a negative sample for future model training. Returns `202 Accepted`.
 
 **Body**
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -35,6 +35,90 @@ Retrieve correction events. Optional query parameter `profileId` filters by prof
 ]
 ```
 
+### GET /api/analytics/usage-rates
+Retrieve symbol usage counts. Optional query parameter `profileId` filters by profile.
+
+**Response**
+```json
+[
+  { "symbolId": "hello", "usageCount": 42 }
+]
+```
+
+### GET /api/analytics/training-trends
+Return learning analytics for gesture training progress.
+
+**Response**
+```json
+[
+  {
+    "gestureDefinitionId": "wave",
+    "successRate24h": 0.85,
+    "successRate7d": 0.92,
+    "avgConfidenceScore": 0.88,
+    "improvementTrend": 0.03,
+    "lastCalculated": 1700000000000
+  }
+]
+```
+
+### GET /api/analytics/export
+Export analytics data as CSV. Query parameter `type` selects `corrections`, `usage`, or `training`. Optional `profileId` filters by profile.
+
+### GET /api/analytics/summary
+Return aggregated metrics such as correction rate, uncertainty ratio, median latency, and top misclassifications.
+
+**Response**
+```json
+{
+  "correctionRate": 0.1,
+  "uncertaintyRatio": 0.05,
+  "medianLatencyMs": 120,
+  "topMisclassifications": ["wave -> clap"]
+}
+```
+
+### POST /api/telemetry
+Submit telemetry events recording gesture classification latency.
+
+**Body**
+```json
+[
+  { "latencyMs": 120, "timestamp": 1700000000000 }
+]
+```
+
+**Response**
+```json
+{ "status": "ok" }
+```
+
+### POST /api/corrections
+Log a caregiver correction when the system misclassifies a gesture.
+
+**Body**
+```json
+{ "gesture": "wave" }
+```
+
+**Response**
+```json
+{ "status": "queued" }
+```
+
+### POST /api/negative-samples
+Record a negative sample for future model training.
+
+**Body**
+```json
+{ "gesture": "random" }
+```
+
+**Response**
+```json
+{ "status": "queued" }
+```
+
 ### POST /dialog
 Ask the dialog engine for caregiver suggestions.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -311,11 +311,11 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Create video tutorials for setup
   - [x] Translate documentation to German
 
-- [ ] **Technical Documentation**
-  - Complete API documentation
-  - [x] Add deployment guides
-  - [x] Create contribution guidelines
-  - [x] Document architecture decisions
+  - [x] **Technical Documentation**
+    - [x] Complete API documentation
+    - [x] Add deployment guides
+    - [x] Create contribution guidelines
+    - [x] Document architecture decisions
 
 ---
 


### PR DESCRIPTION
## Summary
- Document backend API endpoints and rate limits
- Mark API docs task as complete in TODO list

## Testing
- `./scripts/full-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6898457dc5d48322a28c0ec32cf26ae7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API documentation detailing backend endpoints, authentication, rate limits, and example requests/responses.
  * Updated the project TODO list to mark technical documentation tasks as completed and improved checklist formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->