### PR TITLE
Optimize gesture frame processing buffer

### DIFF
--- a/app/src/services/gestureClassifier.ts
+++ b/app/src/services/gestureClassifier.ts
@@ -3,17 +3,21 @@ import { runOnJS } from 'react-native-reanimated';
 import { logger } from '../utils/logger';
 
 let gestureModel: TensorflowModel | null = null;
+let inputBuffer: Float32Array | null = null;
 
 export function setGestureModel(model: TensorflowModel | null): void {
   gestureModel = model;
 }
 
-export function classifyGesture(input: number[]): number[] | null {
+export function classifyGesture(input: Float32Array): number[] | null {
   'worklet';
   if (!gestureModel) return null;
   try {
-    const tensor = new Float32Array(input);
-    const result = gestureModel.runSync([tensor]) as any[];
+    if (!inputBuffer || inputBuffer.length !== input.length) {
+      inputBuffer = new Float32Array(input.length);
+    }
+    inputBuffer.set(input);
+    const result = gestureModel.runSync([inputBuffer]) as any[];
     const predictions = result[0] as number[] | undefined;
     return predictions ?? null;
   } catch (e) {

--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -629,6 +629,7 @@ export const useGestureClassifier = (
   const enqueueFrameJS = Worklets.createRunOnJS(enqueueFrame);
   const logErrorJS = Worklets.createRunOnJS(logger.error);
   const onErrorJS = Worklets.createRunOnJS((message: string) => onErrorRef.current?.(message));
+  let flatBuffer = new Float32Array(0);
 
   const frameProcessor = useFrameProcessor(
     (frame: Frame) => {
@@ -651,8 +652,16 @@ export const useGestureClassifier = (
           return;
         }
 
-        const flat = landmarks.flat();
-        const predictions = classifyGesture(flat);
+        const count = landmarks.length * landmarks[0].length;
+        if (flatBuffer.length !== count) {
+          flatBuffer = new Float32Array(count);
+        }
+        let offset = 0;
+        for (let i = 0; i < landmarks.length; i++) {
+          flatBuffer.set(landmarks[i], offset);
+          offset += landmarks[i].length;
+        }
+        const predictions = classifyGesture(flatBuffer);
 
         const processed: ProcessedFrame = {
           landmarks,

--- a/app/test/gestureClassifierBuffer.test.ts
+++ b/app/test/gestureClassifierBuffer.test.ts
@@ -1,0 +1,29 @@
+jest.mock('react-native-reanimated', () => ({
+  runOnJS: (fn: any) => fn,
+}));
+
+import { classifyGesture, setGestureModel } from '../src/services/gestureClassifier';
+
+describe('classifyGesture buffer reuse', () => {
+  afterEach(() => {
+    setGestureModel(null as any);
+  });
+
+  it('reuses the same input buffer across invocations', () => {
+    const seen: any[] = [];
+    const mockModel = {
+      runSync: (args: any[]) => {
+        seen.push(args[0]);
+        return [[0.1, 0.2]];
+      },
+    };
+    setGestureModel(mockModel as any);
+
+    const sample = new Float32Array([1, 2, 3, 4]);
+    classifyGesture(sample);
+    classifyGesture(sample);
+
+    expect(seen.length).toBe(2);
+    expect(seen[0]).toBe(seen[1]);
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -177,7 +177,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [ ] **Two-Stage Frame Processor**
   - [x] Implement landmark detection in `useFrameProcessor` worklet
   - [x] Add gesture classification pipeline
-  - Optimize processing performance
+  - [x] Optimize processing performance
   - Test real-time processing accuracy
 
 - [ ] **Training Interface**


### PR DESCRIPTION
## Summary
- Reuse a preallocated Float32Array for gesture classification to avoid per-frame allocations.
- Flatten hand landmarks into a shared buffer in the frame processor for better performance.
- Add unit test to ensure the classifier reuses its input buffer and mark the optimization step complete in docs.

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6898639a618c8322bfaae5d6c8e3f632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced gesture classification performance by reusing internal data buffers, reducing unnecessary memory allocations.

* **Tests**
  * Added new tests to verify buffer reuse in gesture classification.

* **Documentation**
  * Updated documentation to reflect completion of gesture processing performance optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->