### PR TITLE
feat: add practice screen fade animation

### DIFF
--- a/app/src/screens/PracticeScreen.tsx
+++ b/app/src/screens/PracticeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   View,
   Button,
@@ -6,6 +6,7 @@ import {
   SafeAreaView,
   Text,
   FlatList,
+  Animated,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useAccessibility } from '../components/AccessibilityContext';
@@ -17,12 +18,21 @@ import { loadProfile, Profile } from '../storage';
 export default function PracticeScreen({ navigation }: any) {
   const { largeText, highContrast } = useAccessibility();
   const [profile, setProfile] = useState<Profile | null>(null);
+  const fadeAnim = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     loadProfile()
       .then(setProfile)
       .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  }, [fadeAnim]);
 
   const styles = createStyles(largeText, highContrast);
   const gradientColors = highContrast
@@ -47,16 +57,18 @@ export default function PracticeScreen({ navigation }: any) {
 
   return (
     <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
-      <SafeAreaView style={styles.container}>
-        <Text style={styles.title}>Practice Gestures</Text>
-        <FlatList
-          data={gestureModel.gestures}
-          keyExtractor={(item) => item.id}
-          renderItem={renderItem}
-          contentContainerStyle={styles.list}
-          ListEmptyComponent={<Text style={styles.empty}>No gestures available</Text>}
-        />
-      </SafeAreaView>
+      <Animated.View style={{ flex: 1, opacity: fadeAnim }}>
+        <SafeAreaView style={styles.container}>
+          <Text style={styles.title}>Practice Gestures</Text>
+          <FlatList
+            data={gestureModel.gestures}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+            contentContainerStyle={styles.list}
+            ListEmptyComponent={<Text style={styles.empty}>No gestures available</Text>}
+          />
+        </SafeAreaView>
+      </Animated.View>
       {profile && <BottomNav active="training" profileId={profile.id} />}
     </LinearGradient>
   );

--- a/app/tests/PracticeScreen.test.tsx
+++ b/app/tests/PracticeScreen.test.tsx
@@ -11,6 +11,14 @@ jest.mock('react-native', () => {
       React.createElement('FlatList', null, data.map((item: any, index: number) => renderItem({ item, index }))),
     StyleSheet: { create: () => ({}) },
     SafeAreaView: (props: any) => React.createElement('SafeAreaView', props, props.children),
+    Animated: {
+      View: ({ children, ...props }: any) => React.createElement('View', props, children),
+      Value: function (v: number) {
+        this.__value = v;
+        return this;
+      },
+      timing: () => ({ start: () => {} }),
+    },
   };
 });
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -242,7 +242,7 @@ The project has a stable foundation after a major refactor. The database, naviga
     - Hint: load `i18n/de.json` via `LanguageManager` and update gesture translations.
 
 - [ ] **Animation & Feedback**
-  - Implement RN Animated API for smooth transitions
+  - [x] Implement RN Animated API for smooth transitions
   - [x] Add Skia-based animations (optional)
   - [x] Create gentle haptic feedback system
   - [x] Add visual highlight during confirmation for accessibility


### PR DESCRIPTION
## Summary
- use React Native Animated API to fade in PracticeScreen content
- mark animation task complete in TODO docs

## Testing
- `./scripts/full-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6898735674348322b8bf2561468f9cef