### PR TITLE
feat: track user engagement sessions

### DIFF
--- a/app/src/screens/ProgressScreen.tsx
+++ b/app/src/screens/ProgressScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, Button, StyleSheet } from 'react-native';
 import { loadUsageStats } from '../services/usageTracker';
+import { loadEngagementStats } from '../services/engagementTracker';
 import { loadProfile, Profile } from '../storage';
 import { gestureModel } from '../model';
 import { useAccessibility } from '../components/AccessibilityContext';
@@ -10,12 +11,14 @@ export default function ProgressScreen({ navigation }: any) {
   const { largeText, highContrast } = useAccessibility();
   const [stats, setStats] = useState<Record<string, number>>({});
   const [profile, setProfile] = useState<Profile | null>(null);
+  const [engagement, setEngagement] = useState<{ totalSessions: number; averageDurationMs: number }>({ totalSessions: 0, averageDurationMs: 0 });
 
   useEffect(() => {
     loadProfile().then((p) => {
       setProfile(p);
       if (p) {
         loadUsageStats(p.id).then(setStats);
+        loadEngagementStats(p.id).then(setEngagement);
       }
     });
   }, []);
@@ -35,6 +38,11 @@ export default function ProgressScreen({ navigation }: any) {
       marginBottom: SPACING.md,
       color: highContrast ? COLORS.highContrastText : COLORS.text,
     },
+    summaryItem: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginBottom: SPACING.sm,
+    },
     item: {
       flexDirection: 'row',
       justifyContent: 'space-between',
@@ -49,6 +57,14 @@ export default function ProgressScreen({ navigation }: any) {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Progress</Text>
+      <View style={styles.summaryItem}>
+        <Text style={styles.label}>Sessions</Text>
+        <Text style={styles.label}>{engagement.totalSessions}</Text>
+      </View>
+      <View style={styles.summaryItem}>
+        <Text style={styles.label}>Avg Session (s)</Text>
+        <Text style={styles.label}>{Math.round(engagement.averageDurationMs / 1000)}</Text>
+      </View>
       <FlatList
         data={entries}
         keyExtractor={(item) => item.id}

--- a/app/src/services/childSessionManager.ts
+++ b/app/src/services/childSessionManager.ts
@@ -1,3 +1,5 @@
+import { startSession as startEngagement, endSession as endEngagement } from './engagementTracker';
+
 export type SessionCallbacks = {
   onEncouragement: () => void;
   onBreak: () => void;
@@ -9,19 +11,23 @@ export class ChildSessionManager {
   private encouragementTimer?: NodeJS.Timeout;
   private breakTimer?: NodeJS.Timeout;
   private callbacks: SessionCallbacks;
+  private profileId: string;
 
   constructor(
     callbacks: SessionCallbacks,
+    profileId: string,
     encouragementInterval = 5 * 60 * 1000,
     breakInterval = 20 * 60 * 1000,
   ) {
     this.callbacks = callbacks;
+    this.profileId = profileId;
     this.encouragementInterval = encouragementInterval;
     this.breakInterval = breakInterval;
   }
 
   startSession(): void {
     this.clearTimers();
+    void startEngagement();
     this.scheduleEncouragement();
     this.scheduleBreak();
   }
@@ -32,6 +38,7 @@ export class ChildSessionManager {
 
   endSession(): void {
     this.clearTimers();
+    void endEngagement(this.profileId);
   }
 
   private scheduleEncouragement(): void {

--- a/app/src/services/engagementTracker.ts
+++ b/app/src/services/engagementTracker.ts
@@ -1,0 +1,43 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY = 'engagementStats';
+let sessionStart: number | null = null;
+
+interface StoredStats {
+  sessions: number;
+  totalMs: number;
+}
+
+interface EngagementStats {
+  totalSessions: number;
+  totalDurationMs: number;
+  averageDurationMs: number;
+}
+
+export async function startSession(): Promise<void> {
+  sessionStart = Date.now();
+}
+
+export async function endSession(profileId: string): Promise<void> {
+  if (sessionStart === null) return;
+  const duration = Date.now() - sessionStart;
+  sessionStart = null;
+  const raw = await AsyncStorage.getItem(KEY);
+  const data: Record<string, StoredStats> = raw ? JSON.parse(raw) : {};
+  const stats = data[profileId] || { sessions: 0, totalMs: 0 };
+  stats.sessions += 1;
+  stats.totalMs += duration;
+  data[profileId] = stats;
+  await AsyncStorage.setItem(KEY, JSON.stringify(data));
+}
+
+export async function loadEngagementStats(profileId: string): Promise<EngagementStats> {
+  const raw = await AsyncStorage.getItem(KEY);
+  const data: Record<string, StoredStats> = raw ? JSON.parse(raw) : {};
+  const stats = data[profileId] || { sessions: 0, totalMs: 0 };
+  return {
+    totalSessions: stats.sessions,
+    totalDurationMs: stats.totalMs,
+    averageDurationMs: stats.sessions ? stats.totalMs / stats.sessions : 0,
+  };
+}

--- a/app/src/services/index.ts
+++ b/app/src/services/index.ts
@@ -5,6 +5,7 @@ export * from './dialogEngine';
 export * from './videoService';
 export * from './analytics';
 export * from './usageTracker';
+export * from './engagementTracker';
 export { extractLandmarksFromImages } from './landmarkExtractor';
 export * from './correctionService';
 

--- a/app/test/childSessionManager.test.ts
+++ b/app/test/childSessionManager.test.ts
@@ -1,4 +1,8 @@
 import { ChildSessionManager } from '../src/services/childSessionManager';
+jest.mock('../src/services/engagementTracker', () => ({
+  startSession: jest.fn(),
+  endSession: jest.fn(),
+}));
 
 jest.useFakeTimers();
 
@@ -8,6 +12,7 @@ describe('ChildSessionManager', () => {
     const takeBreak = jest.fn();
     const manager = new ChildSessionManager(
       { onEncouragement: encourage, onBreak: takeBreak },
+      'p1',
       1000,
       3000,
     );
@@ -26,6 +31,7 @@ describe('ChildSessionManager', () => {
     const takeBreak = jest.fn();
     const manager = new ChildSessionManager(
       { onEncouragement: encourage, onBreak: takeBreak },
+      'p1',
       1000,
       5000,
     );

--- a/app/test/engagementTracker.test.ts
+++ b/app/test/engagementTracker.test.ts
@@ -1,0 +1,28 @@
+const store: Record<string, string> = {};
+const stub = {
+  async getItem(key: string) { return store[key] ?? null; },
+  async setItem(key: string, value: string) { store[key] = value; },
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => stub);
+
+import { startSession, endSession, loadEngagementStats } from '../src/services/engagementTracker';
+
+describe('EngagementTracker', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+  });
+
+  it('records session durations', async () => {
+    const spy = jest.spyOn(Date, 'now');
+    spy.mockReturnValueOnce(1000); // session start
+    await startSession();
+    spy.mockReturnValueOnce(4000); // session end
+    await endSession('p1');
+    const stats = await loadEngagementStats('p1');
+    expect(stats.totalSessions).toBe(1);
+    expect(stats.totalDurationMs).toBe(3000);
+    expect(stats.averageDurationMs).toBe(3000);
+    spy.mockRestore();
+  });
+});

--- a/app/test/progressScreen.test.tsx
+++ b/app/test/progressScreen.test.tsx
@@ -23,6 +23,12 @@ jest.mock('../src/services/usageTracker', () => ({
   loadUsageStats: jest.fn(() => Promise.resolve({ hello: 3 })),
 }));
 
+jest.mock('../src/services/engagementTracker', () => ({
+  loadEngagementStats: jest.fn(() =>
+    Promise.resolve({ totalSessions: 2, totalDurationMs: 10000, averageDurationMs: 5000 }),
+  ),
+}));
+
 jest.mock('../src/storage', () => ({
   loadProfile: jest.fn(() =>
     Promise.resolve({
@@ -51,6 +57,8 @@ describe('ProgressScreen', () => {
     const contents = textNodes.map((n) => n.props.children);
     expect(contents).toContain('👋 Hallo');
     expect(contents).toContain(3);
+    expect(contents).toContain(2);
+    expect(contents).toContain(5);
   });
 });
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -337,7 +337,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 ### Analytics & Monitoring
 - [ ] **Usage Analytics**
   - [x] Track gesture recognition success rates
-  - Monitor user engagement patterns
+  - [x] Monitor user engagement patterns
   - Analyze correction frequency
   - Generate improvement insights
 


### PR DESCRIPTION
## Summary
- track session start/end and store aggregated durations
- integrate session tracking with child session manager and progress screen
- document usage analytics progress

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68988bad2ee483228831755ab7541312