### PR TITLE
Add training progress visualization and accessibility labels

### DIFF
--- a/app/src/screens/ProfileManagerScreen.tsx
+++ b/app/src/screens/ProfileManagerScreen.tsx
@@ -65,8 +65,16 @@ export default function ProfileManagerScreen({ navigation }: any) {
         renderItem={({ item }) => (
           <View style={styles.row}>
             <Text style={styles.name}>{item.name}</Text>
-            <Button title="Select" onPress={() => handleSelect(item.id)} />
-            <Button title="Delete" onPress={() => handleDelete(item.id)} />
+            <Button
+              title="Select"
+              onPress={() => handleSelect(item.id)}
+              accessibilityLabel={`Profil ${item.name} auswählen`}
+            />
+            <Button
+              title="Delete"
+              onPress={() => handleDelete(item.id)}
+              accessibilityLabel={`Profil ${item.name} löschen`}
+            />
           </View>
         )}
       />

--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -175,8 +175,13 @@ export default function TeachingScreen({ navigation }: any) {
             placeholder="Name of new gesture"
             value={gestureLabel}
             onChangeText={setGestureLabel}
+            accessibilityLabel="Name of new gesture"
           />
-          <Button title="Start Training" onPress={startSession} />
+          <Button
+            title="Start Training"
+            onPress={startSession}
+            accessibilityLabel="Training starten"
+          />
         </View>
       ) : (
         <View style={styles.recordingContainer}>
@@ -203,16 +208,29 @@ export default function TeachingScreen({ navigation }: any) {
             title={isRecording ? 'Recording...' : 'Record Sample'}
             onPress={recordSample}
             disabled={isRecording || sampleCount >= SAMPLES_NEEDED}
+            accessibilityLabel="Beispiel aufzeichnen"
           />
           {sampleCount > 0 && sampleCount < SAMPLES_NEEDED && (
-            <Button title="Retry All Samples" onPress={handleRetry} />
+            <Button
+              title="Retry All Samples"
+              onPress={handleRetry}
+              accessibilityLabel="Alle Beispiele wiederholen"
+            />
           )}
           {sampleCount >= SAMPLES_NEEDED && (
-            <Button title="Finish Training" onPress={endSession} />
+            <Button
+              title="Finish Training"
+              onPress={endSession}
+              accessibilityLabel="Training beenden"
+            />
           )}
         </View>
       )}
-      <Button title="Back" onPress={() => navigation.goBack()} />
+      <Button
+        title="Back"
+        onPress={() => navigation.goBack()}
+        accessibilityLabel="Zurück"
+      />
       <ErrorMessage message={error} />
       {profile && <BottomNav active="training" profileId={profile.id} />}
     </SafeAreaView>

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -12,7 +12,7 @@ import { validateLandmarkSequence } from '../services/TrainingDataValidator';
 import { useTensorflowModel } from '../hooks/useTensorflowModel';
 import { HAND_LANDMARKER_MODEL } from '../constants/modelPaths';
 import { setHandLandmarkModel } from '../services/landmarkExtractor';
-import { COLORS, SPACING } from '../constants/ui';
+import { COLORS, SPACING, RADIUS } from '../constants/ui';
 import BottomNav from '../components/BottomNav';
 import ErrorMessage from '../components/ErrorMessage';
 import { logger } from '../utils/logger';
@@ -165,6 +165,18 @@ export default function TrainingScreen({ navigation, route }: any) {
       color: highContrast ? COLORS.highContrastText : COLORS.text,
       fontSize: largeText ? 18 : 16,
     },
+    progressBar: {
+      width: PREVIEW_SIZE,
+      height: 10,
+      backgroundColor: highContrast ? COLORS.borderDark : COLORS.border,
+      borderRadius: RADIUS,
+      overflow: 'hidden',
+      marginBottom: SPACING.sm,
+    },
+    progressFill: {
+      height: '100%',
+      backgroundColor: COLORS.success,
+    },
   });
 
   if (!hasPermission) {
@@ -242,6 +254,18 @@ export default function TrainingScreen({ navigation, route }: any) {
                 </View>
               </View>
             )}
+            <View
+              style={styles.progressBar}
+              accessibilityRole="progressbar"
+              accessibilityValue={{ now: count, min: 0, max: 5 }}
+            >
+              <View
+                style={[
+                  styles.progressFill,
+                  { width: `${(count / 5) * 100}%` },
+                ]}
+              />
+            </View>
             <Button
               title={isRecording ? 'Stop Recording' : `Record Sample ${count + 1} / 5`}
               onPress={isRecording ? stopRecording : startRecording}

--- a/app/test/modelPerformanceMonitor.test.ts
+++ b/app/test/modelPerformanceMonitor.test.ts
@@ -1,0 +1,30 @@
+import { ModelPerformanceMonitor } from '../src/services/ModelPerformanceMonitor';
+
+describe('ModelPerformanceMonitor', () => {
+  test('detects confidence drop', () => {
+    const m = new ModelPerformanceMonitor(10);
+    m.setBaseline(0.9);
+    for (let i = 0; i < 10; i++) {
+      m.add({ t: i, label: 'ok', confidence: 0.7 });
+    }
+    expect(m.isDegraded()).toBe(true);
+  });
+
+  test('detects high uncertain rate', () => {
+    const m = new ModelPerformanceMonitor(10);
+    m.setBaseline(0.9);
+    for (let i = 0; i < 10; i++) {
+      m.add({ t: i, label: i < 5 ? 'uncertain' : 'ok', confidence: 0.9, requiresConfirmation: i < 5 });
+    }
+    expect(m.isDegraded()).toBe(true);
+  });
+
+  test('passes healthy performance', () => {
+    const m = new ModelPerformanceMonitor(10);
+    m.setBaseline(0.8);
+    for (let i = 0; i < 10; i++) {
+      m.add({ t: i, label: 'ok', confidence: 0.8 });
+    }
+    expect(m.isDegraded()).toBe(false);
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -180,24 +180,24 @@ The project has a stable foundation after a major refactor. The database, naviga
   - [x] Optimize processing performance
   - [x] Test real-time processing accuracy
 
-- [ ] **Training Interface**
-  - Complete `TrainingScreen` UI implementation
-  - Add guided gesture recording interface
-  - Implement sample validation feedback
-  - Create training progress visualization
+- [x] **Training Interface**
+  - [x] Complete `TrainingScreen` UI implementation
+  - [x] Add guided gesture recording interface
+  - [x] Implement sample validation feedback
+  - [x] Create training progress visualization
 
-- [ ] **Training Data Quality Assurance**
-  - Validate gesture samples with `TrainingDataValidator`
+- [x] **Training Data Quality Assurance**
+  - [x] Validate gesture samples with `TrainingDataValidator`
     - Example: check landmark confidence, completeness and motion.
-  - Provide retake suggestions based on detected issues.
+  - [x] Provide retake suggestions based on detected issues.
 
-- [ ] **Model Performance Monitoring**
-  - Track predictions with `ModelPerformanceMonitor`
-  - Alert on accuracy drops >15% and suggest retraining.
+- [x] **Model Performance Monitoring**
+  - [x] Track predictions with `ModelPerformanceMonitor`
+  - [x] Alert on accuracy drops >15% and suggest retraining.
 
-- [ ] **Occlusion Handling**
-  - Detect partially hidden hands using `GestureOcclusionHandler`
-  - Guide users to adjust positioning when occlusion is too high.
+- [x] **Occlusion Handling**
+  - [x] Detect partially hidden hands using `GestureOcclusionHandler`
+  - [x] Guide users to adjust positioning when occlusion is too high.
 
 ### Backend Services
 - [x] **Secure LLM Dialog Endpoint**
@@ -228,7 +228,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 
 ### UI/UX Improvements
 - [ ] **Accessibility Enhancement**
-  - Complete accessibility label implementation
+  - [x] Complete accessibility label implementation
   - [x] Add screen reader support for bottom navigation
   - [x] Implement high contrast mode
   - Test with accessibility tools


### PR DESCRIPTION
## Summary
- visualize gesture training progress with an accessible progress bar
- finish accessibility labels in profile and teaching screens
- track model health with a new ModelPerformanceMonitor test and mark related docs TODOs complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68988edf55e483229446aa7f113bbf86