### PR TITLE
feat: conserve battery by auto-pausing camera

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -384,9 +384,13 @@ export default function RecognitionScreen({ navigation }: any) {
         } catch {}
         neutralCooldownRef.current = ts + 7000;
       }
+      if (isCameraActive && ts - Math.max(lastDetection, lastResultAt) > 30000) {
+        setIsCameraActive(false);
+        updateStatus('Paused to save power', 'Camera paused to save battery');
+      }
     }, 1000);
     return () => clearInterval(id);
-  }, [canUseCamera, isProcessing, lastDetection, lastResultAt]);
+  }, [canUseCamera, isProcessing, lastDetection, lastResultAt, isCameraActive, updateStatus]);
 
   const handleSelect = async (choiceId: string) => {
     try {
@@ -882,6 +886,20 @@ export default function RecognitionScreen({ navigation }: any) {
           testID="btn-correction"
           accessibilityLabel="Open correction screen"
           onPress={() => navigation.navigate('Correction')}
+        />
+      )}
+
+      {!isCameraActive && (
+        <Button
+          title="Resume Camera"
+          accessibilityLabel="Resume camera"
+          onPress={() => {
+            setIsCameraActive(true);
+            updateStatus("I'm listening...");
+            const ts = Date.now();
+            setLastDetection(ts);
+            setLastResultAt(ts);
+          }}
         />
       )}
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -273,7 +273,8 @@ The project has a stable foundation after a major refactor. The database, naviga
 
 - [ ] **Performance Optimization**
   - [x] Profile gesture recognition speed
-  - Minimize battery usage during operation
+  - [x] Minimize battery usage during operation
+    - Camera auto-pauses after inactivity to conserve power.
   - Optimize memory usage for older devices
   - Test performance across device range
   - [x] Implement adaptive processing based on battery & thermal state


### PR DESCRIPTION
## Summary
- pause recognition camera after 30s of inactivity to reduce battery drain
- document battery saver in TODO roadmap

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6898a80e729c832299ba7d84ac34d9d4