### PR TITLE
feat: resize frames with vision camera plugin

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -39,7 +39,8 @@
         "react-native-screens": "4.11.1",
         "react-native-svg": "15.12.1",
         "react-native-vision-camera": "4.7.1",
-        "react-native-worklets-core": "1.6.0"
+        "react-native-worklets-core": "1.6.0",
+        "vision-camera-resize-plugin": "3.2.0"
       },
       "devDependencies": {
         "@babel/core": "7.28.0",
@@ -18150,6 +18151,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vision-camera-resize-plugin": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vision-camera-resize-plugin/-/vision-camera-resize-plugin-3.2.0.tgz",
+      "integrity": "sha512-OR/rU6cwnSoFs3zN8EtAiomwtoXBzQsGnQxfUY5wfQ9WcssLY+Hrcdp/pr2qY3fsHokKtYZHeF43eXNaMyBi6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-vision-camera": ">=4.0.1",
+        "react-native-worklets-core": ">=1.2.0"
       }
     },
     "node_modules/vlq": {

--- a/app/package.json
+++ b/app/package.json
@@ -49,7 +49,8 @@
     "react-native-screens": "4.11.1",
     "react-native-svg": "15.12.1",
     "react-native-vision-camera": "4.7.1",
-    "react-native-worklets-core": "1.6.0"
+    "react-native-worklets-core": "1.6.0",
+    "vision-camera-resize-plugin": "3.2.0"
   },
   "devDependencies": {
     "@babel/core": "7.28.0",

--- a/app/src/ml/tfliteRuntime.ts
+++ b/app/src/ml/tfliteRuntime.ts
@@ -1,5 +1,7 @@
 import { useRef } from 'react';
 import { useTensorflowModel, type TensorflowModel } from 'react-native-fast-tflite';
+import { type Frame } from 'react-native-vision-camera';
+import { useResizePlugin } from 'vision-camera-resize-plugin';
 
 /**
  * One-time model loader; exposes a global infer function for the frame worklet.
@@ -7,18 +9,31 @@ import { useTensorflowModel, type TensorflowModel } from 'react-native-fast-tfli
 export function useAmyGestureModel(modelAsset: number) {
   const modelRef = useRef<TensorflowModel | null>(null);
   const { state, model } = useTensorflowModel(modelAsset);
+  const { resize } = useResizePlugin();
 
   if (state === 'loaded' && model && !modelRef.current) {
     modelRef.current = model;
     // Attach a fast path for the worklet
     // @ts-ignore
-    globalThis.__amy_infer = (frame: any): { label: string; score: number } | null => {
+    globalThis.__amy_infer = (frame: Frame): { label: string; score: number } | null => {
       'worklet';
-      // A resize plugin can convert YUV frames to the model's input tensor
-      // without extra copies. When available, perform the conversion here
-      // and feed the tensor into the model. This placeholder returns null
-      // until proper preprocessing is supplied.
-      return null;
+      if (!modelRef.current) return null;
+
+      // Convert the YUV frame into the model's expected RGB float32 tensor
+      const tensor = resize(frame, {
+        scale: { width: 192, height: 192 },
+        pixelFormat: 'rgb',
+        dataType: 'float32',
+      }) as Float32Array;
+
+      const result = modelRef.current.runSync([tensor]) as Float32Array[] | undefined;
+      if (!result || result.length === 0) return null;
+      const scores = result[0];
+      let best = 0;
+      for (let i = 1; i < scores.length; i++) {
+        if (scores[i] > scores[best]) best = i;
+      }
+      return { label: String(best), score: scores[best] };
     };
   }
   return state;

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11,7 +11,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - ✅ Backpressure: single in-flight inference; JS callbacks only on state change.
 - ✅ One-time TFLite load; no per-frame allocations.
 - ✅ Bounded, PII-free telemetry buffer; perf budget test.
-- ⏭ (Optional) Move resize/convert into a VisionCamera frame processor plugin for zero-copy.
+- ✅ Move resize/convert into a VisionCamera frame processor plugin for zero-copy via `vision-camera-resize-plugin`.
 
 ## 🔁 Enhancements & Extensions
 


### PR DESCRIPTION
## Summary
- add vision-camera-resize-plugin dependency and regenerate lockfile
- use resize plugin in tflite runtime to convert YUV frames before inference
- document resize plugin requirement in TODO list

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app` *(fails: checkForModelUpdate › downloads model when on wifi)*
- `pip install -r server/requirements.txt`
- `npm run type-check --prefix server`
- `npm test --prefix server`
- `npm test --prefix integration`
- `npx expo prebuild`


------
https://chatgpt.com/codex/tasks/task_e_6899205b50d08322bc74980eada3b4b3