### PR TITLE
Configure Metro to bundle model assets

### DIFF
--- a/app/assets/models/dummy.task
+++ b/app/assets/models/dummy.task
@@ -1,0 +1,1 @@
+dummy task file

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -5,6 +5,6 @@ module.exports = {
     "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|react-native-reanimated))"
   ],
   moduleNameMapper: {
-    "\.tflite$": "<rootDir>/test/__mocks__/fileMock.js",
+    "\.(tflite|task)$": "<rootDir>/test/__mocks__/fileMock.js",
   },
 };

--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -2,6 +2,7 @@ const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 
-config.resolver.assetExts.push('tflite');
+// Include TFLite and MediaPipe Task model files in the bundle
+config.resolver.assetExts.push('tflite', 'task');
 
 module.exports = config;

--- a/app/test/modelLoadingPerformance.test.ts
+++ b/app/test/modelLoadingPerformance.test.ts
@@ -13,4 +13,12 @@ describe('model loading performance', () => {
       expect(duration).toBeLessThan(100);
     });
   });
+
+  it('loads gesture model through bundler', () => {
+    expect(() => require('../assets/models/gesture_classifier.tflite')).not.toThrow();
+  });
+
+  it('loads task file through bundler', () => {
+    expect(() => require('../assets/models/dummy.task')).not.toThrow();
+  });
 });

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,6 +12,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - ✅ One-time TFLite load; no per-frame allocations.
 - ✅ Bounded, PII-free telemetry buffer; perf budget test.
 - ✅ Move resize/convert into a VisionCamera frame processor plugin for zero-copy via `vision-camera-resize-plugin`.
+- ✅ Metro bundler configured to load `.tflite` and MediaPipe `.task` model assets via `app/metro.config.js`.
 
 ## 🔁 Enhancements & Extensions
 


### PR DESCRIPTION
## Summary
- scope Metro config to the app and note MediaPipe .task model support
- document bundler setup for `.tflite` and `.task` assets in recognition docs

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app` *(fails: checkForModelUpdate › downloads model when on wifi)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68992298db6c832296509adcf22280c6