### PR TITLE
feat: integrate gesture model inference

### DIFF
--- a/app/src/ml/tfliteRuntime.ts
+++ b/app/src/ml/tfliteRuntime.ts
@@ -14,11 +14,29 @@ export function useAmyGestureModel(modelAsset: number) {
     // @ts-ignore
     globalThis.__amy_infer = (frame: any): { label: string; score: number } | null => {
       'worklet';
-      // A resize plugin can convert YUV frames to the model's input tensor
-      // without extra copies. When available, perform the conversion here
-      // and feed the tensor into the model. This placeholder returns null
-      // until proper preprocessing is supplied.
-      return null;
+      // The VisionCamera resize plugin writes the model-sized float buffer
+      // directly onto the frame object. Reuse that buffer to avoid extra
+      // allocations.
+      const buffer = (frame as any)?.resized ?? frame?.data;
+      if (!buffer || !modelRef.current) {
+        return null;
+      }
+
+      // Create a Float32Array view over the existing ArrayBuffer without
+      // copying. Most resize plugins expose a Float32Array already, so this
+      // will simply reference the same memory.
+      const tensor = buffer instanceof Float32Array ? buffer : new Float32Array(buffer);
+      const output = (modelRef.current.runSync([tensor]) as any[])[0] as number[];
+      if (!output || output.length === 0) {
+        return null;
+      }
+      let bestIdx = 0;
+      for (let i = 1; i < output.length; i++) {
+        if (output[i] > output[bestIdx]) {
+          bestIdx = i;
+        }
+      }
+      return { label: String(bestIdx), score: output[bestIdx] };
     };
   }
   return state;

--- a/app/test/mlService.test.ts
+++ b/app/test/mlService.test.ts
@@ -148,6 +148,40 @@ describe('mlService', () => {
     );
   });
 
+  it('uses provided worklet predictions when available', async () => {
+    const landmarkTflite: any = { runSync: () => [[1, 2, 3]] };
+    const gestureRunSync = jest.fn();
+    const gestureTflite: any = { runSync: gestureRunSync };
+
+    await mlService.loadModels(landmarkTflite, gestureTflite, ['a', 'b'], {
+      enableRemoteClassification: false,
+    });
+
+    const frame = {
+      landmarks: [
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ],
+      width: 1,
+      height: 1,
+      timestamp: Date.now(),
+      predictions: [0.2, 0.8],
+    } as any;
+
+    const onResult = jest.fn();
+
+    // first call warms up smoothing buffer
+    await mlService.processFrameAsync(frame, onResult);
+    await mlService.processFrameAsync(frame, onResult);
+
+    expect(onResult).toHaveBeenLastCalledWith(
+      expect.objectContaining({ label: 'b', confidence: 0.8, isLocal: true }),
+      frame.landmarks,
+    );
+    expect(gestureRunSync).not.toHaveBeenCalled();
+  });
+
   it('requests remote classification when worklet prediction confidence is low', async () => {
     const landmarkTflite: any = { runSync: () => [[1, 2, 3]] };
     const gestureRunSync = jest.fn();

--- a/app/test/modelUpdate.test.ts
+++ b/app/test/modelUpdate.test.ts
@@ -13,6 +13,8 @@ jest.mock('expo-file-system', () => ({
 jest.mock('../src/storage', () => ({
   loadBackendApiToken: jest.fn().mockResolvedValue('token'),
   saveCustomModelUri: jest.fn().mockResolvedValue(undefined),
+  loadCustomModelHash: jest.fn().mockResolvedValue(''),
+  saveCustomModelHash: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../src/constants/modelPaths', () => ({
@@ -45,6 +47,10 @@ describe('checkForModelUpdate', () => {
       isConnected: true,
       isInternetReachable: true,
       type: 'wifi',
+    });
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sha256: 'newhash' }),
     });
 
     const result = await checkForModelUpdate();


### PR DESCRIPTION
## Summary
- convert resized frame buffer into tensor and run gesture model via global worklet path
- exercise prediction flow and worklet output in mlService tests
- mock model update test dependencies to allow successful download path

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6899206082e883228edc8a97d0c5a849