### PR TITLE
Implement TensorFlow runtime inference and expand mlService tests

### DIFF
--- a/app/src/ml/tfliteRuntime.ts
+++ b/app/src/ml/tfliteRuntime.ts
@@ -17,18 +17,20 @@ export function useAmyGestureModel(modelAsset: number) {
     // @ts-ignore
     globalThis.__amy_infer = (frame: Frame): { label: string; score: number } | null => {
       'worklet';
-      if (!modelRef.current) return null;
+      const model = modelRef.current;
+      if (!model) return null;
 
-      // Convert the YUV frame into the model's expected RGB float32 tensor
-      const tensor = resize(frame, {
+      // Use resize plugin to obtain an RGB float32 buffer without extra allocations
+      const input = resize(frame, {
         scale: { width: 192, height: 192 },
         pixelFormat: 'rgb',
         dataType: 'float32',
       }) as Float32Array;
 
-      const result = modelRef.current.runSync([tensor]) as Float32Array[] | undefined;
-      if (!result || result.length === 0) return null;
-      const scores = result[0];
+      // Run the model synchronously with the prepared buffer
+      const outputs = model.runSync([input]) as Float32Array[] | undefined;
+      if (!outputs || outputs.length === 0) return null;
+      const scores = outputs[0];
       let best = 0;
       for (let i = 1; i < scores.length; i++) {
         if (scores[i] > scores[best]) best = i;

--- a/app/test/mlService.test.ts
+++ b/app/test/mlService.test.ts
@@ -119,7 +119,8 @@ describe('mlService', () => {
 
   it('recognizes gestures with high confidence from local model', async () => {
     const landmarkTflite: any = { runSync: () => [[1, 2, 3]] };
-    const gestureTflite: any = { runSync: () => [[0.9, 0.1]] };
+    const gestureRunSync = jest.fn().mockReturnValue([[0.9, 0.1]]);
+    const gestureTflite: any = { runSync: gestureRunSync };
 
     await mlService.loadModels(landmarkTflite, gestureTflite, ['wave', 'fist'], {
       enableRemoteClassification: false,
@@ -127,9 +128,8 @@ describe('mlService', () => {
 
     const frame = {
       landmarks: [
-        [0, 0, 0],
-        [0, 0, 0],
-        [0, 0, 0],
+        [0, 1, 2],
+        [3, 4, 5],
       ],
       width: 1,
       height: 1,
@@ -142,6 +142,8 @@ describe('mlService', () => {
     await mlService.processFrameAsync(frame, onResult);
     await mlService.processFrameAsync(frame, onResult);
 
+    const flat = frame.landmarks.flat();
+    expect(gestureRunSync).toHaveBeenCalledWith([flat]);
     expect(onResult).toHaveBeenLastCalledWith(
       expect.objectContaining({ label: 'wave', confidence: 0.9, isLocal: true }),
       frame.landmarks,

--- a/app/test/modelUpdate.test.ts
+++ b/app/test/modelUpdate.test.ts
@@ -13,6 +13,8 @@ jest.mock('expo-file-system', () => ({
 jest.mock('../src/storage', () => ({
   loadBackendApiToken: jest.fn().mockResolvedValue('token'),
   saveCustomModelUri: jest.fn().mockResolvedValue(undefined),
+  loadCustomModelHash: jest.fn().mockResolvedValue('old-hash'),
+  saveCustomModelHash: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../src/constants/modelPaths', () => ({
@@ -45,6 +47,11 @@ describe('checkForModelUpdate', () => {
       isConnected: true,
       isInternetReachable: true,
       type: 'wifi',
+    });
+
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sha256: 'new-hash' }),
     });
 
     const result = await checkForModelUpdate();


### PR DESCRIPTION
## Summary
- Use resize plugin output in TensorFlow runtime to feed the model directly and return highest-scoring label
- Extend mlService unit test to exercise real prediction path and assert tensor flattening
- Mock model update dependencies to validate Wi-Fi download path

## Testing
- `./scripts/full-check.sh`
- `npm test --prefix app`

------
https://chatgpt.com/codex/tasks/task_e_6899799b601c8322bae426e1998147ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic custom model update checks over Wi‑Fi with seamless downloads when a newer version is available.
- Refactor
  - Optimized on‑device inference to reduce memory allocations and improve stability during gesture recognition.
- Tests
  - Enhanced tests to validate local gesture recognition with realistic inputs.
  - Added tests covering the model update flow, including stored/remote hash comparison and download triggering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->