### PR TITLE
feat: analyze correction frequency

### DIFF
--- a/app/test/analytics.test.ts
+++ b/app/test/analytics.test.ts
@@ -3,8 +3,9 @@ import {
   refreshLearningAnalytics,
   computeLearningAnalytics,
   computeSummaryMetrics,
+  computeAnalyticsInsights,
 } from '../../server/src/services/analyticsService';
-import { InteractionLog } from '../../server/src/types';
+import { InteractionLog, Correction } from '../../server/src/types';
 
 describe('Analytics Service', () => {
   it('should compute analytics correctly', () => {
@@ -129,5 +130,77 @@ describe('Analytics Service', () => {
     });
     const summary = computeSummaryMetrics(db, []);
     expect(summary.successRate).toBe(0.5);
+  });
+
+  it('should analyze correction frequency and recommendations', () => {
+    const db = createDatabase();
+    const now = Date.now();
+
+    db.interactionLogs.push(
+      {
+        id: '1',
+        gestureDefinitionId: 'g1',
+        wasSuccessful: false,
+        confidenceScore: 0.2,
+        timestamp: now,
+        processedBy: 'local',
+      },
+      {
+        id: '2',
+        gestureDefinitionId: 'g2',
+        wasSuccessful: true,
+        confidenceScore: 0.9,
+        timestamp: now + 1,
+        processedBy: 'local',
+      },
+      {
+        id: '3',
+        gestureDefinitionId: 'g1',
+        wasSuccessful: false,
+        confidenceScore: 0.3,
+        timestamp: now + 2,
+        processedBy: 'local',
+      },
+    );
+
+    const corrections: Correction[] = [
+      {
+        id: 'c1',
+        predictedGesture: 'g1',
+        actualGesture: 'g2',
+        confidence: 0.6,
+        timestamp: now,
+        isSynced: false,
+        profileId: 'p',
+      },
+      {
+        id: 'c2',
+        predictedGesture: 'g1',
+        actualGesture: 'g2',
+        confidence: 0.5,
+        timestamp: now + 1,
+        isSynced: false,
+        profileId: 'p',
+      },
+      {
+        id: 'c3',
+        predictedGesture: 'g2',
+        actualGesture: 'g1',
+        confidence: 0.4,
+        timestamp: now + 2,
+        isSynced: false,
+        profileId: 'p',
+      },
+    ];
+    db.corrections.push(...corrections);
+
+    const insights = computeAnalyticsInsights(db);
+    expect(insights.correctionFrequency).toEqual([
+      { gesture: 'g2', count: 2, rate: 0.67 },
+      { gesture: 'g1', count: 1, rate: 0.33 },
+    ]);
+    expect(insights.topConfusingPairs[0]).toEqual({ pair: 'g1→g2', count: 2 });
+    expect(insights.recommendations.length).toBe(2);
+    expect(insights.recommendations[0].gesture).toBe('g2');
   });
 });

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -343,10 +343,10 @@ The project has a stable foundation after a major refactor. The database, naviga
 
 ### Analytics & Monitoring
 - [ ] **Usage Analytics**
-  - [x] Track gesture recognition success rates
-  - [x] Monitor user engagement patterns
-  - Analyze correction frequency
-  - Generate improvement insights
+- [x] Track gesture recognition success rates
+- [x] Monitor user engagement patterns
+  - [x] Analyze correction frequency
+  - [x] Generate improvement insights
 
 ---
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -32,6 +32,7 @@ import {
   loadTelemetry,
   saveTelemetry,
   TelemetryEvent,
+  computeAnalyticsInsights,
 } from './services/analyticsService';
 import { getLLMSuggestions, LLMRequest } from './services/dialogEngine';
 import portalRouter from './portal';
@@ -254,39 +255,8 @@ app.get('/api/analytics/summary', auth, async (_req: Request, res: Response) => 
 // Insights: correction frequency and improvement suggestions
 app.get('/api/analytics/insights', auth, async (_req: Request, res: Response) => {
   try {
-    const corrections = dbInstance.corrections;
-    const totalInteractions = dbInstance.interactionLogs.length || 1; // avoid div by zero
-
-    const byGesture = new Map<string, number>();
-    for (const c of corrections) {
-      byGesture.set(c.actualGesture, (byGesture.get(c.actualGesture) || 0) + 1);
-    }
-    const correctionFrequency = Array.from(byGesture.entries())
-      .map(([gesture, count]) => ({ gesture, count, rate: Number((count / totalInteractions).toFixed(2)) }))
-      .sort((a, b) => b.count - a.count)
-      .slice(0, 10);
-
-    // Identify gestures with high correction rate as candidates for practice or retraining
-    const recommendations = correctionFrequency
-      .filter((g) => g.rate >= 0.1 || g.count >= 3)
-      .map((g) => ({
-        gesture: g.gesture,
-        action: 'practice_and_retrain',
-        reason: 'High correction frequency relative to interactions',
-      }));
-
-    // Top confusing pairs from corrections
-    const pairMap = new Map<string, number>();
-    for (const c of corrections) {
-      const key = `${c.predictedGesture}→${c.actualGesture}`;
-      pairMap.set(key, (pairMap.get(key) || 0) + 1);
-    }
-    const topConfusingPairs = Array.from(pairMap.entries())
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 5)
-      .map(([pair, count]) => ({ pair, count }));
-
-    res.json({ correctionFrequency, recommendations, topConfusingPairs });
+    const insights = computeAnalyticsInsights(dbInstance);
+    res.json(insights);
   } catch (error) {
     console.error('Error computing analytics insights:', error);
     res.status(500).json({ error: 'Failed to compute analytics insights' });

--- a/server/src/services/analyticsService.ts
+++ b/server/src/services/analyticsService.ts
@@ -153,3 +153,59 @@ export function computeSummaryMetrics(
     topMisclassifications,
   };
 }
+
+export interface CorrectionFrequency {
+  gesture: string;
+  count: number;
+  rate: number;
+}
+
+export interface ImprovementRecommendation {
+  gesture: string;
+  action: string;
+  reason: string;
+}
+
+export interface AnalyticsInsights {
+  correctionFrequency: CorrectionFrequency[];
+  recommendations: ImprovementRecommendation[];
+  topConfusingPairs: { pair: string; count: number }[];
+}
+
+export function computeAnalyticsInsights(db: Database): AnalyticsInsights {
+  const totalInteractions = db.interactionLogs.length || 1;
+  const corrections = db.corrections || [];
+
+  const byGesture = new Map<string, number>();
+  for (const c of corrections) {
+    byGesture.set(c.actualGesture, (byGesture.get(c.actualGesture) || 0) + 1);
+  }
+  const correctionFrequency = Array.from(byGesture.entries())
+    .map(([gesture, count]) => ({
+      gesture,
+      count,
+      rate: Number((count / totalInteractions).toFixed(2)),
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
+  const recommendations = correctionFrequency
+    .filter((g) => g.rate >= 0.1 || g.count >= 3)
+    .map((g) => ({
+      gesture: g.gesture,
+      action: 'practice_and_retrain',
+      reason: 'High correction frequency relative to interactions',
+    }));
+
+  const pairMap = new Map<string, number>();
+  for (const c of corrections) {
+    const key = `${c.predictedGesture}→${c.actualGesture}`;
+    pairMap.set(key, (pairMap.get(key) || 0) + 1);
+  }
+  const topConfusingPairs = Array.from(pairMap.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([pair, count]) => ({ pair, count }));
+
+  return { correctionFrequency, recommendations, topConfusingPairs };
+}


### PR DESCRIPTION
## Summary
- add analytics service helper for correction frequency and recommendations
- expose analytics insights via API and cover with tests
- mark usage analytics docs task complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_6899e54efbd883229e91d813d8f7288a