### PR TITLE
feat: add gesture data export capability

### DIFF
--- a/app/src/screens/AdminScreen.tsx
+++ b/app/src/screens/AdminScreen.tsx
@@ -236,6 +236,19 @@ export default function AdminScreen({ navigation }: any) {
     }
   };
 
+  const handleExportGestures = async () => {
+    try {
+      const path = await backupService.exportProtectedGestures();
+      if (path) {
+        Alert.alert('Export complete', `Saved to ${path}`);
+      } else {
+        Alert.alert('No data to export');
+      }
+    } catch (e) {
+      Alert.alert('Export failed', (e as Error).message || 'Unknown error');
+    }
+  };
+
   const handleRestoreGestures = async () => {
     try {
       const ok = await backupService.restoreProtectedGestures();
@@ -332,6 +345,11 @@ export default function AdminScreen({ navigation }: any) {
         title="Import Symbols"
         onPress={handleImportSymbols}
         accessibilityLabel="Symbole importieren"
+      />
+      <Button
+        title="Gesten exportieren"
+        onPress={handleExportGestures}
+        accessibilityLabel="Gesten exportieren"
       />
       <Button
         title="Gesten sichern"

--- a/app/src/services/backupService.ts
+++ b/app/src/services/backupService.ts
@@ -3,8 +3,10 @@ import * as FileSystem from 'expo-file-system';
 import * as SecureStore from 'expo-secure-store';
 import CryptoJS from 'crypto-js';
 import { logger } from '../utils/logger';
+import { gestureDataProtector } from './dataProtection';
 
 const BACKUP_FILE = `${FileSystem.documentDirectory}protectedGesturesBackup.json`;
+const EXPORT_FILE = `${FileSystem.documentDirectory}protectedGesturesExport.json`;
 const PROTECTED_GESTURES_KEY = 'protectedGestures';
 const BACKUP_KEY_ID = 'protectedGesturesBackupKey';
 
@@ -98,6 +100,52 @@ export const backupService = {
       return false;
     }
   },
+
+  async exportProtectedGestures(): Promise<string | null> {
+    try {
+      const raw = await AsyncStorage.getItem(PROTECTED_GESTURES_KEY);
+      if (!raw) {
+        logger.info('No protected gesture data to export.');
+        return null;
+      }
+
+      let records: unknown;
+      try {
+        records = JSON.parse(raw);
+      } catch (parseError) {
+        logger.error('Invalid JSON data found, cannot export', parseError);
+        throw new Error('Cannot export corrupted data');
+      }
+      if (!Array.isArray(records)) {
+        logger.error('Invalid data structure for export');
+        throw new Error('Cannot export corrupted data');
+      }
+
+      const decrypted: any[] = [];
+      for (const r of records as any[]) {
+        if (typeof r.data === 'string') {
+          try {
+            const g = await gestureDataProtector.decryptGesture(r.data);
+            decrypted.push(g);
+          } catch (err) {
+            logger.error('Failed to decrypt gesture for export', err);
+          }
+        }
+      }
+
+      await FileSystem.writeAsStringAsync(
+        EXPORT_FILE,
+        JSON.stringify(decrypted, null, 2),
+        { encoding: FileSystem.EncodingType.UTF8 },
+      );
+      logger.info(`Export created at ${EXPORT_FILE}`);
+      return EXPORT_FILE;
+    } catch (error) {
+      logger.error('Error exporting gestures', error);
+      throw error;
+    }
+  },
 };
 
 export const BACKUP_FILE_PATH = BACKUP_FILE;
+export const EXPORT_FILE_PATH = EXPORT_FILE;

--- a/app/test/backupService.test.ts
+++ b/app/test/backupService.test.ts
@@ -6,6 +6,7 @@ describe('backupService', () => {
   let AsyncStorage: any;
   let FileSystem: any;
   let BACKUP_FILE_PATH: string;
+  let EXPORT_FILE_PATH: string;
 
   beforeEach(() => {
     jest.resetModules();
@@ -32,7 +33,9 @@ describe('backupService', () => {
     });
 
     backupService = require('../src/services/backupService').backupService;
-    BACKUP_FILE_PATH = require('../src/services/backupService').BACKUP_FILE_PATH;
+    const paths = require('../src/services/backupService');
+    BACKUP_FILE_PATH = paths.BACKUP_FILE_PATH;
+    EXPORT_FILE_PATH = paths.EXPORT_FILE_PATH;
     gestureDataProtector = require('../src/services/dataProtection').gestureDataProtector;
   });
 
@@ -72,5 +75,21 @@ describe('backupService', () => {
     const restored = await backupService.restoreProtectedGestures();
     expect(restored).toBe(false);
     expect(await AsyncStorage.getItem('protectedGestures')).toBeNull();
+  });
+
+  it('exports decrypted gestures', async () => {
+    await gestureDataProtector.storeGesture({
+      gestureClass: 'hi',
+      confidence: 0.8,
+      timestamp: Date.now(),
+      sessionId: 'xyz',
+    });
+
+    const path = await backupService.exportProtectedGestures();
+    expect(path).toBe(EXPORT_FILE_PATH);
+    const content = await FileSystem.readAsStringAsync(EXPORT_FILE_PATH);
+    const parsed = JSON.parse(content);
+    expect(parsed.length).toBe(1);
+    expect(parsed[0].gestureClass).toBe('hi');
   });
 });

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -312,7 +312,7 @@ The project has a stable foundation after a major refactor. The database, naviga
 - [ ] **Data Management**
   - [x] Implement secure data backup/restore
   - Add GDPR compliance features
-  - Create data export functionality
+  - [x] Create data export functionality
   - Test data migration scenarios
   - [x] Protect gesture data
     - Implement `GestureDataProtector` for anonymization and AES encryption.


### PR DESCRIPTION
## Summary
- allow export of protected gestures as decrypted JSON
- expose export option in admin panel UI
- mark data export TODO complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689b1ab090448322b7c7eadeed92ff59