### PR TITLE
feat: sync offline corrections

### DIFF
--- a/app/src/context/AppServicesProvider.tsx
+++ b/app/src/context/AppServicesProvider.tsx
@@ -92,12 +92,14 @@ export const AppServicesProvider = ({ children, offline = false }: ProviderProps
             syncTrainingData().catch(() => {});
             checkForModelUpdate().catch(() => {});
             syncService.uploadPendingTrainingData().catch(() => {});
+            syncService.uploadPendingCorrections().catch(() => {});
             syncService.checkForNewModel().catch(() => {});
           }, 6 * 60 * 60 * 1000);
 
           syncTrainingData().catch(() => {});
           checkForModelUpdate().catch(() => {});
           syncService.uploadPendingTrainingData().catch(() => {});
+          syncService.uploadPendingCorrections().catch(() => {});
           syncService.checkForNewModel().catch(() => {});
         } else {
           logger.info('Starting in offline mode; skipping cloud sync');

--- a/app/src/services/syncService.ts
+++ b/app/src/services/syncService.ts
@@ -1,5 +1,5 @@
 import { database } from '../../db';
-import { GestureTrainingData } from '../../db/models';
+import { GestureTrainingData, Correction } from '../../db/models';
 import { API_URL, API_TOKEN, MODEL_VERSION_URL } from '../constants';
 import { logger } from '../utils/logger';
 import { loadActiveProfileId, loadProfile, saveCustomModelUri } from '../storage';
@@ -80,6 +80,50 @@ export const syncService = {
       }
     } catch (error) {
       logger.error('Error in uploadPendingTrainingData:', error);
+    }
+  },
+
+  async uploadPendingCorrections(): Promise<void> {
+    logger.info('Attempting to upload pending corrections...');
+    try {
+      const pending = await database
+        .get<Correction>('corrections')
+        .query(Q.where('is_synced', false))
+        .fetch();
+
+      if (pending.length === 0) {
+        logger.info('No pending corrections to upload.');
+        return;
+      }
+
+      for (const correction of pending) {
+        try {
+          const response = await fetch(`${API_URL}/api/corrections`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${API_TOKEN}`,
+            },
+            body: JSON.stringify({ gesture: correction.actualGesture }),
+          });
+
+          if (response.ok) {
+            await database.write(async () => {
+              await correction.update((c) => {
+                c.isSynced = true;
+              });
+            });
+          } else {
+            logger.error(
+              `Failed to upload correction: ${response.status} ${response.statusText}`,
+            );
+          }
+        } catch (uploadError) {
+          logger.error('Error uploading correction:', uploadError);
+        }
+      }
+    } catch (error) {
+      logger.error('Error in uploadPendingCorrections:', error);
     }
   },
 

--- a/app/test/syncServiceCorrections.test.ts
+++ b/app/test/syncServiceCorrections.test.ts
@@ -1,0 +1,57 @@
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: async () => null,
+  setItem: async () => {},
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: async () => null,
+  setItemAsync: async () => {},
+}));
+
+jest.mock('@nozbe/watermelondb', () => ({
+  Q: { where: () => ({}) },
+}));
+
+jest.mock('../db', () => {
+  const correction = {
+    actualGesture: 'wave',
+    update: jest.fn(async (fn: any) => fn(correction)),
+  };
+  return {
+    database: {
+      get: jest.fn().mockReturnValue({
+        query: jest.fn().mockReturnValue({
+          fetch: jest.fn().mockResolvedValue([correction]),
+        }),
+      }),
+      write: jest.fn(async (fn: any) => {
+        await fn();
+      }),
+    },
+    __correction: correction,
+  };
+});
+
+import { syncService } from '../src/services/syncService';
+import { API_URL, API_TOKEN } from '../src/constants';
+const { __correction: correction } = require('../db');
+
+describe('syncService.uploadPendingCorrections', () => {
+  it('uploads unsynced corrections and marks them synced', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    (global as any).fetch = fetchMock;
+
+    await syncService.uploadPendingCorrections();
+
+    expect(fetchMock).toHaveBeenCalledWith(`${API_URL}/api/corrections`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_TOKEN}`,
+      },
+      body: JSON.stringify({ gesture: 'wave' }),
+    });
+    expect(correction.update).toHaveBeenCalled();
+  });
+});
+

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -321,10 +321,10 @@ The project has a stable foundation after a major refactor. The database, naviga
     - Added hash validation and secure storage in `SecureConfigManager`.
 
 - [ ] **Offline Capability**
-  - Ensure full offline functionality
-  - Implement offline model training
-  - Add offline progress sync
-  - Test extended offline usage
+- Ensure full offline functionality
+- Implement offline model training
+  - [x] Add offline progress sync
+- Test extended offline usage
 
 ### Documentation & Support
 - [ ] **User Documentation**


### PR DESCRIPTION
## Summary
- upload unsynced corrections on reconnect
- schedule correction upload in service provider
- mark offline progress sync as complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689b6e1a0b5c8322a7e8b6d0d67b56a8