### PR TITLE
feat(ml): honor remote retry cooldown

### DIFF
--- a/server/src/tools/autoRetrain.ts
+++ b/server/src/tools/autoRetrain.ts
@@ -1,10 +1,10 @@
-import { loadDatabase, Database } from '../db';
+import { loadDatabase } from '../db';
 import { spawn } from 'child_process';
 import path from 'path';
 import { promises as fs } from 'fs';
 
-async function autoRetrain() {
-  const db = await loadDatabase();
+async function autoRetrain(dbPath: string) {
+  const db = await loadDatabase(dbPath);
   const corrections = db.corrections;
   const negativeSamples = db.negativeSamples;
 
@@ -37,4 +37,6 @@ async function autoRetrain() {
   });
 }
 
-autoRetrain();
+const dbPath = process.argv[2] || path.join(__dirname, '../db.json');
+// fire and forget
+autoRetrain(dbPath);


### PR DESCRIPTION
## Summary
- wire circuit breaker retry cooldown into ml service and expose configuration
- add hand-landmark worklet, adaptive throttling, and debug UI components
- fix autoRetrain script to provide database path

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `node app/test/run-tests.js`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689bb99d32cc8322a2bcb3b499d7e570