### PR TITLE
fix: silence act env warnings in tests

### DIFF
--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -1,10 +1,11 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transformIgnorePatterns: [
     "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|react-native-reanimated))"
   ],
   moduleNameMapper: {
-    "\.(tflite|task)$": "<rootDir>/test/__mocks__/fileMock.js",
+    "\\.(tflite|task)$": "<rootDir>/test/__mocks__/fileMock.js",
   },
 };

--- a/app/jest.setup.ts
+++ b/app/jest.setup.ts
@@ -1,0 +1,4 @@
+// Ensure React 19 act() warnings are silenced during tests
+// by telling React that the test environment supports `act`.
+// See https://react.dev/reference/react/act for details.
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;


### PR DESCRIPTION
## Summary
- add Jest setup file enabling React 19 `act` environment
- load setup file in Jest config to silence noisy warnings

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689c29f086c48322a3f20c2598f8c543