### PR TITLE
Improve auto retrain and cleanup server deps

### DIFF
--- a/docs/deps/server-deps.json
+++ b/docs/deps/server-deps.json
@@ -1,63 +1,51 @@
 {
   "version": "1.0.0",
   "name": "amysecho_backend",
-  "problems": [
-    "missing: @types/express@^5.0.3, required by amysecho_backend@1.0.0",
-    "missing: @types/node@^24.1.0, required by amysecho_backend@1.0.0",
-    "missing: express-rate-limit@^6.7.0, required by amysecho_backend@1.0.0",
-    "missing: express@^5.0.0, required by amysecho_backend@1.0.0",
-    "missing: node-fetch@^3.3.2, required by amysecho_backend@1.0.0",
-    "missing: ts-node@^10.9.2, required by amysecho_backend@1.0.0",
-    "missing: typescript@^5.8.3, required by amysecho_backend@1.0.0"
-  ],
   "dependencies": {
     "@types/express": {
-      "required": "^5.0.3",
-      "missing": true,
-      "problems": [
-        "missing: @types/express@^5.0.3, required by amysecho_backend@1.0.0"
-      ]
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
+      "overridden": false
+    },
+    "@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "overridden": false
     },
     "@types/node": {
-      "missing": true,
-      "problems": [
-        "missing: @types/node@^24.1.0, required by amysecho_backend@1.0.0"
-      ]
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "overridden": false
     },
     "express-rate-limit": {
-      "missing": true,
-      "problems": [
-        "missing: express-rate-limit@^6.7.0, required by amysecho_backend@1.0.0"
-      ]
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "overridden": false
     },
     "express": {
-      "missing": true,
-      "problems": [
-        "missing: express@^5.0.0, required by amysecho_backend@1.0.0"
-      ]
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.0.0.tgz",
+      "overridden": false
     },
-    "node-fetch": {
-      "missing": true,
-      "problems": [
-        "missing: node-fetch@^3.3.2, required by amysecho_backend@1.0.0"
-      ]
+    "jest": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.0.5.tgz",
+      "overridden": false
+    },
+    "ts-jest": {
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
+      "overridden": false
     },
     "ts-node": {
-      "missing": true,
-      "problems": [
-        "missing: ts-node@^10.9.2, required by amysecho_backend@1.0.0"
-      ]
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "overridden": false
     },
     "typescript": {
-      "missing": true,
-      "problems": [
-        "missing: typescript@^5.8.3, required by amysecho_backend@1.0.0"
-      ]
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "overridden": false
     }
-  },
-  "error": {
-    "code": "ELSPROBLEMS",
-    "summary": "missing: @types/express@^5.0.3, required by amysecho_backend@1.0.0\nmissing: @types/node@^24.1.0, required by amysecho_backend@1.0.0\nmissing: express-rate-limit@^6.7.0, required by amysecho_backend@1.0.0\nmissing: express@^5.0.0, required by amysecho_backend@1.0.0\nmissing: node-fetch@^3.3.2, required by amysecho_backend@1.0.0\nmissing: ts-node@^10.9.2, required by amysecho_backend@1.0.0\nmissing: typescript@^5.8.3, required by amysecho_backend@1.0.0",
-    "detail": ""
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,18 +9,20 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/express": "5.0.3",
-        "@types/node": "24.1.0",
         "express": "5.0.0",
-        "express-rate-limit": "6.7.0",
-        "node-fetch": "3.3.2"
+        "express-rate-limit": "6.7.0"
       },
       "devDependencies": {
+        "@types/express": "5.0.3",
         "@types/jest": "^30.0.0",
+        "@types/node": "24.1.0",
         "jest": "^30.0.5",
         "ts-jest": "^29.4.1",
         "ts-node": "10.9.2",
         "typescript": "5.8.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1224,6 +1226,7 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -1234,6 +1237,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1243,6 +1247,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
       "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1254,6 +1259,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
       "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1266,6 +1272,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -1310,12 +1317,14 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
       "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -1325,18 +1334,21 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
       "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -1347,6 +1359,7 @@
       "version": "1.15.8",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
       "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -2300,15 +2313,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2701,29 +2705,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2783,18 +2764,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -4223,44 +4192,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5436,6 +5367,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -5572,15 +5504,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/server/package.json
+++ b/server/package.json
@@ -8,14 +8,13 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "@types/express": "5.0.3",
-    "@types/node": "24.1.0",
     "express": "5.0.0",
-    "express-rate-limit": "6.7.0",
-    "node-fetch": "3.3.2"
+    "express-rate-limit": "6.7.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/express": "5.0.3",
+    "@types/node": "24.1.0",
     "jest": "^30.0.5",
     "ts-jest": "^29.4.1",
     "ts-node": "10.9.2",
@@ -28,5 +27,8 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "download-models": "ts-node src/tools/downloadModels.ts"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/server/src/recognizer.test.ts
+++ b/server/src/recognizer.test.ts
@@ -4,10 +4,27 @@ import { classifyGesture } from './recognizer';
 describe('classifyGesture', () => {
   it('falls back to offline model when cloud fails', async () => {
     const originalFetch = global.fetch;
-    global.fetch = jest.fn().mockRejectedValue(new Error('network')) as any;
-    process.env.OFFLINE_MODEL_PATH = path.join(__dirname, 'offlineModel.json');
-    const result = await classifyGesture([0, 0]);
-    expect(result).toEqual({ label: 'g1', processedBy: 'local', confidence: expect.any(Number) });
-    (global.fetch as any) = originalFetch;
+    try {
+      global.fetch = jest.fn().mockRejectedValue(new Error('network')) as any;
+      process.env.OFFLINE_MODEL_PATH = path.join(
+        __dirname,
+        'offlineModel.json'
+      );
+      const result = await classifyGesture([0, 0]);
+      expect(result).toEqual({
+        label: 'g1',
+        processedBy: 'local',
+        confidence: expect.any(Number),
+      });
+    } finally {
+      if (originalFetch === undefined) {
+        // remove the mock if there was no fetch prior
+        // @ts-expect-error delete global property
+        delete global.fetch;
+      } else {
+        (global.fetch as any) = originalFetch as any;
+      }
+      delete process.env.OFFLINE_MODEL_PATH;
+    }
   });
 });

--- a/server/src/tools/autoRetrain.ts
+++ b/server/src/tools/autoRetrain.ts
@@ -18,7 +18,7 @@ async function autoRetrain(dbPath: string) {
   const tmp = path.join(process.cwd(), 'tmp_training_data.json');
   await fs.writeFile(tmp, JSON.stringify(trainingData));
 
-  const script = path.join(__dirname, '../train.py');
+  const script = process.env.TRAIN_SCRIPT ?? path.join(__dirname, '../train.py');
   const child = spawn('python3', [script, tmp], {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
@@ -37,6 +37,15 @@ async function autoRetrain(dbPath: string) {
   });
 }
 
-const dbPath = process.argv[2] || path.join(__dirname, '../db.json');
-// fire and forget
-autoRetrain(dbPath);
+// determine where our database JSON lives
+const dbPath =
+  process.argv[2] ??
+  process.env.DB_PATH ??
+  path.resolve(process.cwd(), 'db.json');
+
+// run retraining asynchronously, but avoid unhandled rejections
+// fire-and-forget with error handling
+void autoRetrain(dbPath).catch((err) => {
+  console.error('autoRetrain failed:', err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Harden `autoRetrain` script with configurable paths and proper error handling
- Move type packages to devDependencies, drop unused `node-fetch`, and require Node 18+
- Ensure recognizer test cleans up global mutations
- Refresh server dependency documentation

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689c2c2124508322bb376024c670f974

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Auto-retraining now configurable via environment variables and CLI arguments; improved error handling for more reliable runs.
- Tests
  - Increased test robustness with guaranteed cleanup to prevent side effects.
- Chores
  - Refreshed dependency metadata and moved type packages to development-only.
  - Removed an unused fetch dependency.
  - Enforced Node.js 18+ runtime requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->