### PR TITLE
feat: extend performance telemetry

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -301,6 +301,7 @@ export default function RecognitionScreen({ navigation }: any) {
         label: result?.label ?? 'uncertain',
         confidence: result?.confidence ?? 0,
         requiresConfirmation: result?.requiresConfirmation ?? true,
+        inferenceType: result?.isLocal ? 'local' : 'cloud',
       });
       setShowPerfBanner(perfMonitorRef.current.isDegraded());
     } catch {}

--- a/app/src/services/ModelPerformanceMonitor.ts
+++ b/app/src/services/ModelPerformanceMonitor.ts
@@ -4,6 +4,7 @@ export type PerfEvent = {
   confidence: number;
   requiresConfirmation?: boolean;
   latencyMs?: number;
+  inferenceType?: 'local' | 'cloud';
 };
 
 export type PerfMetrics = {
@@ -11,6 +12,10 @@ export type PerfMetrics = {
   avgConfidence: number;
   uncertainRate: number; // fraction of events that required confirmation or were uncertain
   avgLatencyMs: number;
+  medianLatencyMs: number;
+  framesProcessed: number;
+  framesDropped: number;
+  localVsCloudRatio: number;
 };
 
 export class ModelPerformanceMonitor {
@@ -18,6 +23,11 @@ export class ModelPerformanceMonitor {
   private latencyThreshold = 200;
   private window: PerfEvent[] = [];
   private readonly maxWindow: number;
+  private latencies: number[] = [];
+  private framesProcessed = 0;
+  private framesDropped = 0;
+  private localCount = 0;
+  private cloudCount = 0;
 
   constructor(maxWindow = 50) {
     this.maxWindow = maxWindow;
@@ -37,13 +47,47 @@ export class ModelPerformanceMonitor {
     this.window.push(e);
     if (this.window.length > this.maxWindow) {
       this.window.shift();
+      this.latencies.shift();
     }
+    if (typeof e.latencyMs === 'number') {
+      this.latencies.push(e.latencyMs);
+      if (this.latencies.length > this.maxWindow) this.latencies.shift();
+    }
+    this.framesProcessed += 1;
+    if (e.inferenceType === 'cloud') this.cloudCount += 1; else this.localCount += 1;
+  }
+
+  recordDroppedFrame() {
+    this.framesDropped += 1;
+  }
+
+  private medianLatency(): number {
+    if (this.latencies.length === 0) return 0;
+    const sorted = [...this.latencies].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+      ? (sorted[mid - 1] + sorted[mid]) / 2
+      : sorted[mid];
+  }
+
+  private localRatio(): number {
+    const total = this.localCount + this.cloudCount;
+    return total === 0 ? 0 : this.localCount / total;
   }
 
   metrics(): PerfMetrics {
     const n = this.window.length;
     if (n === 0) {
-      return { windowSize: 0, avgConfidence: 0, uncertainRate: 0, avgLatencyMs: 0 };
+      return {
+        windowSize: 0,
+        avgConfidence: 0,
+        uncertainRate: 0,
+        avgLatencyMs: 0,
+        medianLatencyMs: 0,
+        framesProcessed: this.framesProcessed,
+        framesDropped: this.framesDropped,
+        localVsCloudRatio: this.localRatio(),
+      };
     }
     let sum = 0;
     let uncertain = 0;
@@ -58,6 +102,10 @@ export class ModelPerformanceMonitor {
       avgConfidence: sum / n,
       uncertainRate: uncertain / n,
       avgLatencyMs: latencySum / n,
+      medianLatencyMs: this.medianLatency(),
+      framesProcessed: this.framesProcessed,
+      framesDropped: this.framesDropped,
+      localVsCloudRatio: this.localRatio(),
     };
   }
 
@@ -72,6 +120,10 @@ export class ModelPerformanceMonitor {
     if (m.uncertainRate > 0.4) return true;
     if (m.avgLatencyMs > this.latencyThreshold) return true;
     return false;
+  }
+
+  export(): string {
+    return JSON.stringify(this.metrics());
   }
 }
 

--- a/app/src/services/ModelPerformanceMonitor.ts
+++ b/app/src/services/ModelPerformanceMonitor.ts
@@ -47,7 +47,6 @@ export class ModelPerformanceMonitor {
     this.window.push(e);
     if (this.window.length > this.maxWindow) {
       this.window.shift();
-      this.latencies.shift();
     }
     if (typeof e.latencyMs === 'number') {
       this.latencies.push(e.latencyMs);

--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -398,6 +398,7 @@ class MachineLearningService {
     if (result) {
       const smoothed = this.applyGestureSmoothing(result);
       if (!smoothed) {
+        this.perfMonitor.recordDroppedFrame();
         onResult(null);
         return;
       }
@@ -411,6 +412,7 @@ class MachineLearningService {
         confidence: result.confidence,
         requiresConfirmation: result.requiresConfirmation,
         latencyMs: processingTime,
+        inferenceType: result.isLocal ? 'local' : 'cloud',
       });
       if (this.perfMonitor.isDegraded()) {
         logger.warn('Model performance degraded', this.perfMonitor.metrics());
@@ -426,6 +428,7 @@ class MachineLearningService {
       return;
     }
 
+    this.perfMonitor.recordDroppedFrame();
     onResult(null);
   }
 

--- a/app/test/modelPerformanceMonitor.test.ts
+++ b/app/test/modelPerformanceMonitor.test.ts
@@ -55,4 +55,17 @@ describe('ModelPerformanceMonitor', () => {
     expect(metrics.localVsCloudRatio).toBeCloseTo(0.5);
     expect(() => JSON.parse(m.export())).not.toThrow();
   });
+
+  test('ignores missing latencies when computing median', () => {
+    const m = new ModelPerformanceMonitor(3);
+    m.add({ t: 0, label: 'ok', confidence: 0.9, latencyMs: 10, inferenceType: 'local' });
+    m.add({ t: 1, label: 'ok', confidence: 0.9, latencyMs: 20, inferenceType: 'local' });
+    m.add({ t: 2, label: 'ok', confidence: 0.9, latencyMs: 30, inferenceType: 'local' });
+    // event without latency should not desync the sliding window
+    m.add({ t: 3, label: 'ok', confidence: 0.9, inferenceType: 'local' });
+    // adding a new latency should drop the oldest latency value only once
+    m.add({ t: 4, label: 'ok', confidence: 0.9, latencyMs: 40, inferenceType: 'local' });
+    const metrics = m.metrics();
+    expect(metrics.medianLatencyMs).toBe(30); // median of [20,30,40]
+  });
 });

--- a/app/test/modelPerformanceMonitor.test.ts
+++ b/app/test/modelPerformanceMonitor.test.ts
@@ -5,7 +5,7 @@ describe('ModelPerformanceMonitor', () => {
     const m = new ModelPerformanceMonitor(10);
     m.setBaseline(0.9);
     for (let i = 0; i < 10; i++) {
-      m.add({ t: i, label: 'ok', confidence: 0.7, latencyMs: 50 });
+      m.add({ t: i, label: 'ok', confidence: 0.7, latencyMs: 50, inferenceType: 'local' });
     }
     expect(m.isDegraded()).toBe(true);
   });
@@ -14,7 +14,14 @@ describe('ModelPerformanceMonitor', () => {
     const m = new ModelPerformanceMonitor(10);
     m.setBaseline(0.9);
     for (let i = 0; i < 10; i++) {
-      m.add({ t: i, label: i < 5 ? 'uncertain' : 'ok', confidence: 0.9, requiresConfirmation: i < 5, latencyMs: 50 });
+      m.add({
+        t: i,
+        label: i < 5 ? 'uncertain' : 'ok',
+        confidence: 0.9,
+        requiresConfirmation: i < 5,
+        latencyMs: 50,
+        inferenceType: 'local',
+      });
     }
     expect(m.isDegraded()).toBe(true);
   });
@@ -23,7 +30,7 @@ describe('ModelPerformanceMonitor', () => {
     const m = new ModelPerformanceMonitor(10);
     m.setBaseline(0.8);
     for (let i = 0; i < 10; i++) {
-      m.add({ t: i, label: 'ok', confidence: 0.8, latencyMs: 50 });
+      m.add({ t: i, label: 'ok', confidence: 0.8, latencyMs: 50, inferenceType: 'local' });
     }
     expect(m.isDegraded()).toBe(false);
   });
@@ -31,8 +38,21 @@ describe('ModelPerformanceMonitor', () => {
   test('detects high latency', () => {
     const m = new ModelPerformanceMonitor(10);
     for (let i = 0; i < 10; i++) {
-      m.add({ t: i, label: 'ok', confidence: 0.9, latencyMs: 300 });
+      m.add({ t: i, label: 'ok', confidence: 0.9, latencyMs: 300, inferenceType: 'local' });
     }
     expect(m.isDegraded()).toBe(true);
+  });
+
+  test('tracks frames and exports metrics', () => {
+    const m = new ModelPerformanceMonitor(10);
+    m.add({ t: 0, label: 'ok', confidence: 0.9, latencyMs: 10, inferenceType: 'local' });
+    m.add({ t: 1, label: 'ok', confidence: 0.8, latencyMs: 30, inferenceType: 'cloud' });
+    m.recordDroppedFrame();
+    const metrics = m.metrics();
+    expect(metrics.framesProcessed).toBe(2);
+    expect(metrics.framesDropped).toBe(1);
+    expect(metrics.medianLatencyMs).toBe(20);
+    expect(metrics.localVsCloudRatio).toBeCloseTo(0.5);
+    expect(() => JSON.parse(m.export())).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- track inference source, frame counts, and latency in `ModelPerformanceMonitor`
- log dropped frames and inference origin in `mlService`
- propagate inference type from `RecognitionScreen` and verify via unit test

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689cb89e49808322ab0af41b7a834a85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Performance tracking now distinguishes between local and cloud inferences.
  * Metrics enhanced with median latency, frames processed, frames dropped, and local-vs-cloud ratio.
  * Dropped frames are now recorded for more accurate processing statistics.
  * Metrics can be exported as JSON for external analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->