### PR TITLE
fix: remove plugin require from metro config

### DIFF
--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -1,8 +1,5 @@
 const { getDefaultConfig } = require('expo/metro-config');
 
-// Ensure frame processor plugins like vision-camera-resize-plugin are available
-require('vision-camera-resize-plugin');
-
 const config = getDefaultConfig(__dirname);
 
 // Include TFLite and MediaPipe Task model files in the bundle


### PR DESCRIPTION
## Summary
- fix metro.config to avoid loading vision-camera-resize-plugin at config time

## Testing
- `npx expo-doctor app` *(fails: connect ENETUNREACH 34.110.201.56:443)*
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`
- `CI=1 npx eas-cli build --platform android --profile apk --non-interactive` *(fails: An Expo user account is required to proceed.)*

------
https://chatgpt.com/codex/tasks/task_e_689cccdfc0248322b48741bca3d893aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Streamlined build configuration by removing an unnecessary runtime plugin hook, reducing complexity and potential startup overhead.
  * Retains existing asset support and configuration behavior; no feature changes are expected.
  * Improves maintainability and reduces risk of configuration-related issues across environments.
  * No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->