### PR TITLE
Add expo battery and device dependencies

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,7 +21,9 @@
         "crypto-js": "4.2.0",
         "expo": "53.0.20",
         "expo-audio": "0.4.8",
+        "expo-battery": "~9.1.4",
         "expo-camera": "16.1.11",
+        "expo-device": "~7.1.4",
         "expo-doctor": "1.13.5",
         "expo-haptics": "14.1.4",
         "expo-linear-gradient": "14.1.5",
@@ -8397,6 +8399,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-battery": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/expo-battery/-/expo-battery-9.1.4.tgz",
+      "integrity": "sha512-iPV0ZIXVHfoVoxPwpCSkLKg4TFRexIGO7DLl/kZhXr70mR4IscanJwaWh9yvER80Lu6Q0WSp1afmJPJLu3Fesg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-camera": {
       "version": "16.1.11",
       "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.1.11.tgz",
@@ -8483,6 +8495,18 @@
       "integrity": "sha512-NxtM/qot5Rh2cY333iOE87dDg1S8CibW+Wu4WdLua3UMjy81pXYzAGCZGNOeY7k9GpNFqDPNDXWyBSlk9r2pBg==",
       "dev": true,
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-device": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-7.1.4.tgz",
+      "integrity": "sha512-HS04IiE1Fy0FRjBLurr9e5A6yj3kbmQB+2jCZvbSGpsjBnCLdSk/LCii4f5VFhPIBWJLyYuN5QqJyEAw6BcS4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ua-parser-js": "^0.7.33"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -17941,6 +17965,32 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "0.7.40",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.40.tgz",
+      "integrity": "sha512-us1E3K+3jJppDBa3Tl0L3MOJiGhe1C6P0+nIvQAFYbxlMAx0h81eOwLmU57xgqToduDDPx3y5QsdjPfDu+FgOQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/undici": {

--- a/app/package.json
+++ b/app/package.json
@@ -50,7 +50,9 @@
     "react-native-svg": "^15.11.2",
     "react-native-vision-camera": "4.7.1",
     "react-native-worklets-core": "1.6.0",
-    "vision-camera-resize-plugin": "3.2.0"
+    "vision-camera-resize-plugin": "3.2.0",
+    "expo-battery": "~9.1.4",
+    "expo-device": "~7.1.4"
   },
   "devDependencies": {
     "@babel/core": "7.28.0",


### PR DESCRIPTION
## Summary
- include expo-battery and expo-device so AdaptivePerformanceManager can resolve modules

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `cd app && npx expo install --check`
- `npx expo-doctor` (fails: This check requires a connection to the Expo API. Ensure your network connection is stable.)
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689d0778356883228358fe1863a7057a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated app dependencies to include device and battery modules.
  - No user-facing changes or UI updates in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->