### PR TITLE
handle missing vision camera plugins

### DIFF
--- a/app/src/worklets/extractHandLandmarks.worklet.ts
+++ b/app/src/worklets/extractHandLandmarks.worklet.ts
@@ -2,12 +2,14 @@
 import type { Frame } from 'react-native-vision-camera';
 
 // Plug these names into your native JSI bridge (vision-camera-resize-plugin + your hand model runner).
-declare const __VISION_RESIZE__: (frame: Frame, w: number, h: number) => Uint8Array;
-declare const __RUN_HAND_LANDMARKER__: (
-  rgb: Uint8Array,
-  w: number,
-  h: number
-) => Float32Array | null;
+// When running without the native plugins (e.g. in development or on devices
+// where they are not available) these globals will simply be undefined.  We
+// therefore access them via `globalThis` at runtime so that bundling the
+// worklet does not crash the app when the native side is missing.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ResizeFn = (frame: Frame, w: number, h: number) => Uint8Array;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LandmarkFn = (rgb: Uint8Array, w: number, h: number) => Float32Array | null;
 
 /**
  * Returns Float32Array length 63: [x0,y0,z0, x1,y1,z1, ...] (normalized 0..1),
@@ -18,12 +20,21 @@ export function extractHandLandmarks(frame: Frame): Float32Array | null {
   const W = 224; // adjust to your model input
   const H = 224;
   try {
+    // Access native functions through the global object so that the worklet can
+    // safely run even when the native plugins are not installed.
+    const visionResize = (globalThis as any).__VISION_RESIZE__ as ResizeFn | undefined;
+    const runHandLandmarker = (globalThis as any)
+      .__RUN_HAND_LANDMARKER__ as LandmarkFn | undefined;
+    if (typeof visionResize !== 'function' || typeof runHandLandmarker !== 'function') {
+      return null;
+    }
+
     // 1) YUV->RGB + resize (native)
-    const rgb = __VISION_RESIZE__(frame, W, H);
+    const rgb = visionResize(frame, W, H);
     if (!rgb || rgb.length !== W * H * 3) return null;
 
     // 2) Landmark inference (native)
-    const out = __RUN_HAND_LANDMARKER__(rgb, W, H) as Float32Array | null;
+    const out = runHandLandmarker(rgb, W, H) as Float32Array | null;
     if (!out || out.length !== 63) return null;
     return out;
   } catch (_e) {

--- a/app/test/extractHandLandmarks.worklet.test.ts
+++ b/app/test/extractHandLandmarks.worklet.test.ts
@@ -1,0 +1,8 @@
+import { extractHandLandmarks } from '../src/worklets/extractHandLandmarks.worklet';
+
+describe('extractHandLandmarks worklet', () => {
+  it('gracefully handles missing native plugins', () => {
+    const frame = {} as any;
+    expect(extractHandLandmarks(frame)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- avoid undefined global usage in hand landmark worklet
- add regression test for worklet when native plugins absent

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `cd app && npx expo install --check`
- `cd app && npx expo-doctor` *(fails: fetch failed)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689d1452077c8322b0a42f2e844998a5