### PR TITLE
docs: clarify dev vs production builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,22 @@ If you want to run the app on a physical device with a custom dev client, execut
 
 ### Creating test builds (APK)
 
+Before running any EAS build make sure you're logged in and the project passes Expo checks:
+
+```bash
+npx expo whoami             # run `npx expo login` if this fails
+(cd app && npx expo install --check)
+(cd app && npx expo-doctor) # requires network access
+```
+
+Set `CI=1` when building from a non-interactive terminal to disable progress spinners.
+
 #### Custom dev client
 
 To produce a debuggable APK for testers, trigger a development build via EAS:
 
 ```bash
-npm run build:android-dev
+CI=1 npm run build:android-dev
 ```
 
 The CLI prints a link to the artifact. You can also download the most recent build later:
@@ -162,7 +172,7 @@ This APK only contains the Expo dev client. After installing it on a device you 
 For an installable APK that bundles the app and runs without the bundler:
 
 ```bash
-npm run build:android-apk
+CI=1 npm run build:android-apk
 ```
 
 The resulting artifact includes the compiled JavaScript and assets, making it suitable for offline testing and sideloading.
@@ -172,8 +182,8 @@ The resulting artifact includes the compiled JavaScript and assets, making it su
 To generate store-ready binaries using EAS Build, run:
 
 ```bash
-npm run build:android
-npm run build:ios
+CI=1 npm run build:android
+CI=1 npm run build:ios
 ```
 
 This uses `eas.json` and requires credentials configured with Expo. If you run the build in a CI or other non-interactive environment, set the `EXPO_TOKEN` environment variable with an Expo access token. Otherwise the command will fail when it prompts for login.

--- a/docs/BUILD_AND_TEST.md
+++ b/docs/BUILD_AND_TEST.md
@@ -54,6 +54,22 @@ Before attempting a native build, verify that your Expo packages match the insta
 
 Amy's Echo relies on Expo's **EAS Build** service. Two build profiles are available in `app/eas.json`.
 
+### Prerequisites
+
+Before kicking off any remote build:
+
+1. **Authenticate with Expo**
+   ```bash
+   npx expo login        # or set EXPO_TOKEN for CI usage
+   npx expo whoami       # verify you are logged in
+   ```
+2. **Verify the project configuration** (requires network access)
+   ```bash
+   (cd app && npx expo install --check)
+   (cd app && npx expo-doctor)
+   ```
+3. **Prepare for non-interactive logs** – prefix build commands with `CI=1` to disable spinners. If fingerprinting stalls, add `EAS_SKIP_AUTO_FINGERPRINT=1`.
+
 ### Development build (testing APK)
 
 Use this to produce a debuggable APK for internal testing:
@@ -68,7 +84,7 @@ Use this to produce a debuggable APK for internal testing:
    ```
 3. Trigger the remote build from the `app` directory:
    ```bash
-   npm run build:android-dev
+   CI=1 npm run build:android-dev
    ```
    The command prints a link where you can download the APK. You can also fetch the latest build later:
    ```bash
@@ -86,7 +102,7 @@ To sideload the full app without the Expo dev client:
 1. Ensure tests pass and native projects exist as above.
 2. Trigger a production build that outputs an APK instead of an Android App Bundle:
    ```bash
-   npm run build:android-apk
+   CI=1 npm run build:android-apk
    ```
    The resulting file contains the compiled JavaScript bundle and assets, so it can run without `expo start`.
 
@@ -104,7 +120,7 @@ For store-ready binaries the recommended workflow is:
    ```
 3. Trigger the remote build from the `app` directory:
    ```bash
-   npm run build:android
+   CI=1 npm run build:android
    ```
    The command prints a link where you can monitor progress. You can also query the latest build using:
    ```bash


### PR DESCRIPTION
## Summary
- document prerequisite Expo login and env checks before builds
- differentiate dev, installable test, and production Android builds with `CI=1` examples

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH 34.110.201.56:443)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`
- `CI=1 EAS_SKIP_AUTO_FINGERPRINT=1 npx eas-cli build --platform android --profile apk --non-interactive --json --no-wait`


------
https://chatgpt.com/codex/tasks/task_e_689d0ce5482c8322b3a27cc77c3308a8