### PR TITLE
fix: stabilize hook usage in service provider

### DIFF
--- a/app/src/context/AppServicesProvider.tsx
+++ b/app/src/context/AppServicesProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useContext, useEffect, useState, useMemo } from 'react';
+import React, { createContext, ReactNode, useContext, useEffect, useState } from 'react';
 import {
   audioService,
   backupService,
@@ -45,13 +45,10 @@ interface ProviderProps {
   offline?: boolean;
 }
 
+const services = { mlService, audioService, adaptiveLearningService, backupService, gestureDataProtector };
+
 export const AppServicesProvider = ({ children, offline = false }: ProviderProps) => {
   const [areServicesReady, setAreServicesReady] = useState(false);
-
-  const services = useMemo(
-    () => ({ mlService, audioService, adaptiveLearningService, backupService, gestureDataProtector }),
-    [],
-  );
 
   useEffect(() => {
     let interval: ReturnType<typeof setInterval>;

--- a/app/src/context/AppServicesProvider.tsx
+++ b/app/src/context/AppServicesProvider.tsx
@@ -47,7 +47,11 @@ interface ProviderProps {
 
 export const AppServicesProvider = ({ children, offline = false }: ProviderProps) => {
   const [areServicesReady, setAreServicesReady] = useState(false);
-  
+
+  const services = useMemo(
+    () => ({ mlService, audioService, adaptiveLearningService, backupService, gestureDataProtector }),
+    [],
+  );
 
   useEffect(() => {
     let interval: ReturnType<typeof setInterval>;
@@ -123,11 +127,6 @@ export const AppServicesProvider = ({ children, offline = false }: ProviderProps
       </View>
     );
   }
-
-  const services = useMemo(
-    () => ({ mlService, audioService, adaptiveLearningService, backupService, gestureDataProtector }),
-    [],
-  );
 
   return <ServicesContext.Provider value={services}>{children}</ServicesContext.Provider>;
 };


### PR DESCRIPTION
## Summary
- ensure AppServicesProvider runs a consistent number of hooks by memoizing services before conditional rendering

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: fetch failed, requires network connection to Expo API)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689d7e72740c8322b3f4b43450d374ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined initialization of app services to reduce duplication and potential inconsistencies.
  * Consolidated service memoization to improve reliability and maintainability.

* **Chores**
  * Confirmed no changes to public APIs or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->