### PR TITLE
fix: avoid JS calls in frame processor

### DIFF
--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -697,12 +697,13 @@ export const useGestureClassifier = (
         return;
       }
 
-      addFrameJS(frame);
       const now = Date.now();
-      if (now - lastFrameTime.value < 1000 / targetFps.value) {
+      const fps = targetFps.value;
+      if (fps <= 0 || now - lastFrameTime.value < 1000 / fps) {
         return;
       }
       lastFrameTime.value = now;
+      addFrameJS(frame);
 
       try {
         // Run dedicated worklet to extract and flatten landmarks
@@ -728,7 +729,7 @@ export const useGestureClassifier = (
         }
       }
     },
-    [serviceReady, targetFps, lastFrameTime],
+    [serviceReady, targetFps, lastFrameTime, localThreshold, extractLandmarks],
   );
 
   return frameProcessor;
@@ -773,7 +774,7 @@ export const useRecordingProcessor = (
         logErrorJS('WORKLET ERROR:', error);
       }
     },
-    [fps],
+    [fps, extractLandmarksRec],
   );
 
   return frameProcessor;


### PR DESCRIPTION
## Summary
- avoid accessing AdaptivePerformanceManager from frame processor
- rate-limit frame processing via shared timing values

## Testing
- `./scripts/full-check.sh` *(expo doctor reported network failures)*

------
https://chatgpt.com/codex/tasks/task_e_689de07b7a308322a51cd43b1362e001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Captures and attaches raw landmarks with timestamps to processed frames for improved tracking and overlay accuracy.
* Refactor
  * Switched to time-based frame throttling to better maintain target FPS and smoother performance across devices.
  * Processing pipeline now uses worklet-provided landmarks for prediction while preserving raw landmarks for overlays.
* Bug Fixes
  * Fewer dropped or duplicated frames, improving responsiveness and stability in camera-driven features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->