### PR TITLE
Fix hand landmark extraction for typed array model output

### DIFF
--- a/app/src/services/landmarkExtractor.ts
+++ b/app/src/services/landmarkExtractor.ts
@@ -49,6 +49,26 @@ const logLandmarks = Worklets?.createRunOnJS
     )
   : (_: number[][] | null) => {};
 
+function reshapeLandmarks(raw: any): number[][] | null {
+  'worklet';
+  let values: number[] | null = null;
+  if (Array.isArray(raw)) {
+    if (Array.isArray(raw[0])) {
+      return raw as number[][];
+    }
+    values = raw as number[];
+  } else if (raw && typeof raw === 'object' && 'length' in raw) {
+    values = Array.from(raw as ArrayLike<number>);
+  }
+  if (!values || values.length !== 63) return null;
+  const landmarks: number[][] = [];
+  for (let i = 0; i < 21; i++) {
+    const base = i * 3;
+    landmarks.push([values[base], values[base + 1], values[base + 2]]);
+  }
+  return landmarks;
+}
+
 export function useHandLandmarkExtractor(): (frame: Frame) => number[][] | null {
   const { resize } = useResizePlugin();
   return (frame: Frame): number[][] | null => {
@@ -61,13 +81,18 @@ export function useHandLandmarkExtractor(): (frame: Frame) => number[][] | null 
         dataType: 'uint8',
       });
       const result = handModel.runSync([input]) as any[];
-      const landmarks = result[0] as number[][] | undefined;
-      const conf = (result[1]?.[0] ?? 0) as number;
+      const landmarks = reshapeLandmarks(result[0]);
+      const confSource = result[1];
+      const conf = Array.isArray(confSource)
+        ? (confSource[0] ?? 0)
+        : confSource && typeof confSource === 'object' && 'length' in confSource
+        ? ((confSource as any)[0] ?? 0)
+        : 0;
       if (__DEV__ && Date.now() - lastLog > 500) {
         lastLog = Date.now();
         logJS(`LM ok: ${landmarks?.length ?? 0} pts, conf=${conf.toFixed(2)}`);
       }
-      return landmarks ?? null;
+      return landmarks;
     } catch (e: any) {
       logErrorJS(e.message);
       return null;
@@ -87,7 +112,7 @@ export function extractHandLandmarks(frame: Frame): number[][] | null {
         })
       : new Uint8Array(frame.toArrayBuffer());
     const result = handModel.runSync([input]) as any[];
-    const landmarks = (result[0] as number[][]) ?? null;
+    const landmarks = reshapeLandmarks(result[0]);
     if (typeof __DEV__ !== 'undefined' && __DEV__ && Date.now() - lastLog > 500) {
       lastLog = Date.now();
       logLandmarks(landmarks);
@@ -111,10 +136,14 @@ export function extractHandLandmarksFlat(frame: Frame): Float32Array | null {
         })
       : new Uint8Array(frame.toArrayBuffer());
     const result = handModel.runSync([input]) as any[];
-    const landmarks = result[0] as number[][] | undefined;
-    if (!landmarks) return null;
-    const flat = Float32Array.from(landmarks.flat());
-    return flat.length === 63 ? flat : null;
+    const raw = result[0];
+    let flat: Float32Array | null = null;
+    if (Array.isArray(raw) && Array.isArray(raw[0])) {
+      flat = Float32Array.from((raw as number[][]).flat());
+    } else if (Array.isArray(raw) || (raw && typeof raw === 'object' && 'length' in raw)) {
+      flat = Float32Array.from(raw as ArrayLike<number>);
+    }
+    return flat && flat.length === 63 ? flat : null;
   } catch (e: any) {
     logErrorJS(e.message);
     return null;

--- a/app/src/services/landmarkExtractor.ts
+++ b/app/src/services/landmarkExtractor.ts
@@ -9,6 +9,10 @@ let handModel: TensorflowModel | null = null;
 
 let resizePlugin: any | null = null;
 
+const NUM_HAND_LANDMARKS = 21;
+const NUM_COORDINATES = 3;
+const FLATTENED_LANDMARKS_SIZE = NUM_HAND_LANDMARKS * NUM_COORDINATES;
+
 if ((globalThis as any).VisionCameraProxy) {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -60,10 +64,10 @@ function reshapeLandmarks(raw: any): number[][] | null {
   } else if (raw && typeof raw === 'object' && 'length' in raw) {
     values = Array.from(raw as ArrayLike<number>);
   }
-  if (!values || values.length !== 63) return null;
+  if (!values || values.length !== FLATTENED_LANDMARKS_SIZE) return null;
   const landmarks: number[][] = [];
-  for (let i = 0; i < 21; i++) {
-    const base = i * 3;
+  for (let i = 0; i < NUM_HAND_LANDMARKS; i++) {
+    const base = i * NUM_COORDINATES;
     landmarks.push([values[base], values[base + 1], values[base + 2]]);
   }
   return landmarks;
@@ -83,11 +87,10 @@ export function useHandLandmarkExtractor(): (frame: Frame) => number[][] | null 
       const result = handModel.runSync([input]) as any[];
       const landmarks = reshapeLandmarks(result[0]);
       const confSource = result[1];
-      const conf = Array.isArray(confSource)
-        ? (confSource[0] ?? 0)
-        : confSource && typeof confSource === 'object' && 'length' in confSource
-        ? ((confSource as any)[0] ?? 0)
-        : 0;
+      let conf = 0;
+      if (confSource && typeof confSource === 'object' && 'length' in confSource) {
+        conf = (confSource as any)[0] ?? 0;
+      }
       if (__DEV__ && Date.now() - lastLog > 500) {
         lastLog = Date.now();
         logJS(`LM ok: ${landmarks?.length ?? 0} pts, conf=${conf.toFixed(2)}`);
@@ -140,10 +143,10 @@ export function extractHandLandmarksFlat(frame: Frame): Float32Array | null {
     let flat: Float32Array | null = null;
     if (Array.isArray(raw) && Array.isArray(raw[0])) {
       flat = Float32Array.from((raw as number[][]).flat());
-    } else if (Array.isArray(raw) || (raw && typeof raw === 'object' && 'length' in raw)) {
+    } else if (raw && typeof raw === 'object' && 'length' in raw) {
       flat = Float32Array.from(raw as ArrayLike<number>);
     }
-    return flat && flat.length === 63 ? flat : null;
+    return flat && flat.length === FLATTENED_LANDMARKS_SIZE ? flat : null;
   } catch (e: any) {
     logErrorJS(e.message);
     return null;

--- a/app/test/landmarkExtractor.test.ts
+++ b/app/test/landmarkExtractor.test.ts
@@ -5,6 +5,9 @@ jest.mock('react-native-fast-tflite', () => ({
 
 jest.mock('expo-file-system', () => ({}));
 
+const NUM_HAND_LANDMARKS = 21;
+const FLATTENED_LANDMARKS_SIZE = NUM_HAND_LANDMARKS * 3;
+
 describe('extractHandLandmarks', () => {
   it('accepts YUV frames and returns landmarks', () => {
     const { setHandLandmarkModel, extractHandLandmarks } = require('../src/services/landmarkExtractor');
@@ -40,7 +43,7 @@ describe('extractHandLandmarks', () => {
       extractHandLandmarksFlat,
     } = require('../src/services/landmarkExtractor');
 
-    const data = Float32Array.from({ length: 63 }, (_, i) => i * 0.1);
+    const data = Float32Array.from({ length: FLATTENED_LANDMARKS_SIZE }, (_, i) => i * 0.1);
     const fakeModel = {
       runSync: (_: any[]) => [data],
     };
@@ -53,14 +56,14 @@ describe('extractHandLandmarks', () => {
     } as any;
 
     const lm = extractHandLandmarks(frame);
-    expect(lm).toHaveLength(21);
+    expect(lm).toHaveLength(NUM_HAND_LANDMARKS);
     expect(lm?.[0][0]).toBeCloseTo(0);
     expect(lm?.[0][1]).toBeCloseTo(0.1);
     expect(lm?.[0][2]).toBeCloseTo(0.2);
 
     const flat = extractHandLandmarksFlat(frame);
     expect(flat).not.toBeNull();
-    expect(flat).toHaveLength(63);
+    expect(flat).toHaveLength(FLATTENED_LANDMARKS_SIZE);
     expect(Array.from(flat!)).toEqual(Array.from(data));
   });
 });

--- a/app/test/landmarkExtractor.test.ts
+++ b/app/test/landmarkExtractor.test.ts
@@ -32,4 +32,35 @@ describe('extractHandLandmarks', () => {
       [0.3, 0.4, 0.0],
     ]);
   });
+
+  it('handles flat Float32Array outputs', () => {
+    const {
+      setHandLandmarkModel,
+      extractHandLandmarks,
+      extractHandLandmarksFlat,
+    } = require('../src/services/landmarkExtractor');
+
+    const data = Float32Array.from({ length: 63 }, (_, i) => i * 0.1);
+    const fakeModel = {
+      runSync: (_: any[]) => [data],
+    };
+    setHandLandmarkModel(fakeModel);
+
+    const ab = new ArrayBuffer(10);
+    const frame = {
+      pixelFormat: 'yuv',
+      toArrayBuffer: () => ab,
+    } as any;
+
+    const lm = extractHandLandmarks(frame);
+    expect(lm).toHaveLength(21);
+    expect(lm?.[0][0]).toBeCloseTo(0);
+    expect(lm?.[0][1]).toBeCloseTo(0.1);
+    expect(lm?.[0][2]).toBeCloseTo(0.2);
+
+    const flat = extractHandLandmarksFlat(frame);
+    expect(flat).not.toBeNull();
+    expect(flat).toHaveLength(63);
+    expect(Array.from(flat!)).toEqual(Array.from(data));
+  });
 });


### PR DESCRIPTION
## Summary
- handle TFLite models that return flat Float32Array outputs when extracting hand landmarks
- test landmark extractor against typed array model output

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `npx expo install --check`
- `npx expo-doctor` *(fails: fetch failed, network unreachable)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689e24b00c5c832291515f9fa4c92724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple hand-landmark output formats, including flat numeric arrays, improving compatibility across models and devices.
  * Introduced a flat landmark output option for easier downstream processing.
* **Bug Fixes**
  * More reliable confidence handling and landmark normalization to prevent invalid or partial results.
* **Refactor**
  * Consolidated landmark parsing into a single normalization path for consistency and resilience.
* **Tests**
  * Added tests covering flat landmark outputs to ensure accuracy and consistency across formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->