### PR TITLE
fix: robust hand landmark flattening

### DIFF
--- a/app/src/services/landmarkExtractor.ts
+++ b/app/src/services/landmarkExtractor.ts
@@ -141,7 +141,7 @@ export function extractHandLandmarksFlat(frame: Frame): Float32Array | null {
     const result = handModel.runSync([input]) as any[];
     const raw = result[0];
     let flat: Float32Array | null = null;
-    if (Array.isArray((raw as any)?.[0])) {
+    if (Array.isArray(raw) && Array.isArray(raw[0])) {
       flat = Float32Array.from((raw as number[][]).flat());
     } else if (raw && typeof raw === 'object' && 'length' in raw) {
       flat = Float32Array.from(raw as ArrayLike<number>);


### PR DESCRIPTION
## Summary
- streamline hand landmark flattening by removing redundant array checks
- define coordinate count constant in tests to avoid magic numbers

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689e2c0704488322ad2e6a245f608904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of hand landmark extraction to handle array-like and nested inputs more reliably, reducing errors with certain data sources.

* **Tests**
  * Updated test constants to use a dedicated coordinate count, keeping expectations consistent without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->