### PR TITLE
refactor: reuse typed arrays in landmark extractor

### DIFF
--- a/app/src/services/landmarkExtractor.ts
+++ b/app/src/services/landmarkExtractor.ts
@@ -53,7 +53,7 @@ const logLandmarks = Worklets?.createRunOnJS
     )
   : (_: number[][] | null) => {};
 
-function reshapeLandmarks(raw: any): number[][] | null {
+function reshapeLandmarks(raw: unknown): number[][] | null {
   'worklet';
   let values: ArrayLike<number> | null = null;
   if (Array.isArray(raw)) {
@@ -62,9 +62,16 @@ function reshapeLandmarks(raw: any): number[][] | null {
     }
     values = raw as number[];
   } else if (raw && typeof raw === 'object' && 'length' in raw) {
-    values = ArrayBuffer.isView(raw)
-      ? (raw as unknown as ArrayLike<number>)
-      : Array.from(raw as ArrayLike<number>);
+    if (ArrayBuffer.isView(raw)) {
+      const isBigInt64 = typeof BigInt64Array !== 'undefined' && raw instanceof BigInt64Array;
+      const isBigUint64 = typeof BigUint64Array !== 'undefined' && raw instanceof BigUint64Array;
+      if (isBigInt64 || isBigUint64) {
+        return null;
+      }
+      values = raw as ArrayLike<number>;
+    } else {
+      values = Array.from(raw as ArrayLike<number>);
+    }
   }
   if (!values || values.length !== FLATTENED_LANDMARKS_SIZE) return null;
   const landmarks: number[][] = [];
@@ -129,6 +136,11 @@ export function extractHandLandmarks(frame: Frame): number[][] | null {
   }
 }
 
+/**
+ * Extracts hand landmarks and returns a flattened view of the coordinates.
+ * The returned array may be a borrowed Float32Array from the model output;
+ * consumers must treat it as read-only and avoid mutating it.
+ */
 export function extractHandLandmarksFlat(frame: Frame): Float32Array | null {
   'worklet';
   if (!handModel) return null;
@@ -144,7 +156,16 @@ export function extractHandLandmarksFlat(frame: Frame): Float32Array | null {
     const raw = result[0];
     let flat: Float32Array | null = null;
     if (Array.isArray(raw) && Array.isArray(raw[0])) {
-      flat = Float32Array.from((raw as number[][]).flat());
+      const src = raw as number[][];
+      const out = new Float32Array(src.length * NUM_COORDINATES);
+      let k = 0;
+      for (let i = 0; i < src.length; i++) {
+        const p = src[i];
+        out[k++] = p[0];
+        out[k++] = p[1];
+        out[k++] = p[2];
+      }
+      flat = out;
     } else if (raw && typeof raw === 'object' && 'length' in raw) {
       flat = raw instanceof Float32Array ? raw : Float32Array.from(raw as ArrayLike<number>);
     }

--- a/app/src/services/landmarkExtractor.ts
+++ b/app/src/services/landmarkExtractor.ts
@@ -55,14 +55,16 @@ const logLandmarks = Worklets?.createRunOnJS
 
 function reshapeLandmarks(raw: any): number[][] | null {
   'worklet';
-  let values: number[] | null = null;
+  let values: ArrayLike<number> | null = null;
   if (Array.isArray(raw)) {
     if (Array.isArray(raw[0])) {
       return raw as number[][];
     }
     values = raw as number[];
   } else if (raw && typeof raw === 'object' && 'length' in raw) {
-    values = Array.from(raw as ArrayLike<number>);
+    values = ArrayBuffer.isView(raw)
+      ? (raw as unknown as ArrayLike<number>)
+      : Array.from(raw as ArrayLike<number>);
   }
   if (!values || values.length !== FLATTENED_LANDMARKS_SIZE) return null;
   const landmarks: number[][] = [];
@@ -144,7 +146,7 @@ export function extractHandLandmarksFlat(frame: Frame): Float32Array | null {
     if (Array.isArray(raw) && Array.isArray(raw[0])) {
       flat = Float32Array.from((raw as number[][]).flat());
     } else if (raw && typeof raw === 'object' && 'length' in raw) {
-      flat = Float32Array.from(raw as ArrayLike<number>);
+      flat = raw instanceof Float32Array ? raw : Float32Array.from(raw as ArrayLike<number>);
     }
     return flat && flat.length === FLATTENED_LANDMARKS_SIZE ? flat : null;
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- reuse existing typed arrays in `reshapeLandmarks` to avoid unnecessary copies
- skip converting `Float32Array` outputs in `extractHandLandmarksFlat`

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` (fails: connect ENETUNREACH)
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689e38d09ecc83228881cef57bf092e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized landmark processing to reuse typed arrays, reducing memory allocations and improving runtime efficiency.
  - Smoother, more consistent frame times during continuous tracking and playback.
  - No changes to user-facing behavior, settings, or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->