### PR TITLE
feat: add JS fallback for hand landmarks

### DIFF
--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -772,8 +772,10 @@ export const useGestureClassifier = (
       try {
         // Run dedicated worklet to extract and flatten landmarks
         let rawLandmarks: number[][] = [];
-        let flat = extractHandLandmarksWorklet(frame);
-        if (!flat) {
+        // Only invoke the worklet extractor when the native plugin is available
+        let flat = pluginAvailable ? extractHandLandmarksWorklet(frame) : null;
+        // Guard against invalid worklet output (e.g. empty or unexpected length)
+        if (!flat || flat.length % 3 !== 0) {
           rawLandmarks = extractLandmarks(frame) || [];
           if (rawLandmarks.length === 0) {
             if (!pluginError.value) {
@@ -782,21 +784,19 @@ export const useGestureClassifier = (
             }
             return;
           }
-          const out = new Float32Array(rawLandmarks.length * 3);
-          let k = 0;
-          for (let i = 0; i < rawLandmarks.length; i++) {
-            const p = rawLandmarks[i];
-            out[k++] = p[0];
-            out[k++] = p[1];
-            out[k++] = p[2];
-          }
-          flat = out;
+          flat = new Float32Array(rawLandmarks.flat());
           if (!pluginError.value) {
             pluginError.value = true;
             onErrorJS('Using JS landmark extractor fallback');
           }
         } else {
-          rawLandmarks = extractLandmarks(frame) || [];
+          // Derive 2D landmarks from the flattened worklet output to avoid duplicate extraction
+          const arr = flat as any; // Float32Array or number[]
+          const count = Math.floor(arr.length / 3);
+          rawLandmarks = new Array(count);
+          for (let i = 0, k = 0; i < count; i++) {
+            rawLandmarks[i] = [arr[k++], arr[k++], arr[k++]];
+          }
         }
         const predictions = classifyGesture(flat, localThreshold);
 

--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -771,18 +771,35 @@ export const useGestureClassifier = (
 
       try {
         // Run dedicated worklet to extract and flatten landmarks
-        const flat = extractHandLandmarksWorklet(frame);
+        let rawLandmarks: number[][] = [];
+        let flat = extractHandLandmarksWorklet(frame);
         if (!flat) {
+          rawLandmarks = extractLandmarks(frame) || [];
+          if (rawLandmarks.length === 0) {
+            if (!pluginError.value) {
+              pluginError.value = true;
+              onErrorJS('Landmark extraction failed');
+            }
+            return;
+          }
+          const out = new Float32Array(rawLandmarks.length * 3);
+          let k = 0;
+          for (let i = 0; i < rawLandmarks.length; i++) {
+            const p = rawLandmarks[i];
+            out[k++] = p[0];
+            out[k++] = p[1];
+            out[k++] = p[2];
+          }
+          flat = out;
           if (!pluginError.value) {
             pluginError.value = true;
-            onErrorJS('Landmark extraction failed');
+            onErrorJS('Using JS landmark extractor fallback');
           }
-          return;
+        } else {
+          rawLandmarks = extractLandmarks(frame) || [];
         }
         const predictions = classifyGesture(flat, localThreshold);
 
-        // Reconstruct landmark array shape for overlay using the hook extractor
-        const rawLandmarks = extractLandmarks(frame) || [];
         const end = Date.now();
         const processed: ProcessedFrame = {
           landmarks: rawLandmarks,

--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -48,9 +48,9 @@ class LandmarkSmoother {
   private lastTimestamp: number;
 
   constructor() {
-    this.filters = Array(21)
-      .fill(0)
-      .map(() => Array(3).fill(new OneEuroFilter()));
+    this.filters = Array.from({ length: 21 }, () =>
+      Array.from({ length: 3 }, () => new OneEuroFilter()),
+    );
     this.lastTimestamp = -1;
   }
 
@@ -675,7 +675,9 @@ export const useGestureClassifier = (
   const frameBufferRef = useRef(new FrameBufferManager(recommendedBufferSize()));
   const perfManagerRef = useRef(new AdaptivePerformanceManager());
   const pluginAvailable = isResizePluginAvailable();
-  const pluginError = useSharedValue(false);
+  const pluginUnavailableLogged = useSharedValue(false);
+  const fallbackLogged = useSharedValue(false);
+  const errorLogged = useSharedValue(false);
 
   useEffect(() => {
     const readyInterval = setInterval(() => {
@@ -754,8 +756,8 @@ export const useGestureClassifier = (
         return;
       }
 
-      if (!pluginAvailable && !pluginError.value) {
-        pluginError.value = true;
+      if (!pluginAvailable && !pluginUnavailableLogged.value) {
+        pluginUnavailableLogged.value = true;
         onErrorJS('Frame processor plugin unavailable; using JS fallback');
       }
 
@@ -772,30 +774,32 @@ export const useGestureClassifier = (
       try {
         // Run dedicated worklet to extract and flatten landmarks
         let rawLandmarks: number[][] = [];
+        const STRIDE = 3; // components per landmark: x, y, z
         // Only invoke the worklet extractor when the native plugin is available
         let flat = pluginAvailable ? extractHandLandmarksWorklet(frame) : null;
         // Guard against invalid worklet output (e.g. empty or unexpected length)
-        if (!flat || flat.length % 3 !== 0) {
+        if (!flat || flat.length % STRIDE !== 0) {
           rawLandmarks = extractLandmarks(frame) || [];
           if (rawLandmarks.length === 0) {
-            if (!pluginError.value) {
-              pluginError.value = true;
+            if (!errorLogged.value) {
+              errorLogged.value = true;
               onErrorJS('Landmark extraction failed');
             }
             return;
           }
           flat = new Float32Array(rawLandmarks.flat());
-          if (!pluginError.value) {
-            pluginError.value = true;
+          if (!fallbackLogged.value) {
+            fallbackLogged.value = true;
             onErrorJS('Using JS landmark extractor fallback');
           }
         } else {
           // Derive 2D landmarks from the flattened worklet output to avoid duplicate extraction
-          const arr = flat as any; // Float32Array or number[]
-          const count = Math.floor(arr.length / 3);
+          const arr = flat as Float32Array | number[];
+          const count = arr.length / STRIDE;
           rawLandmarks = new Array(count);
-          for (let i = 0, k = 0; i < count; i++) {
-            rawLandmarks[i] = [arr[k++], arr[k++], arr[k++]];
+          for (let i = 0; i < count; i++) {
+            const base = i * STRIDE;
+            rawLandmarks[i] = [arr[base], arr[base + 1], arr[base + 2]];
           }
         }
         const predictions = classifyGesture(flat, localThreshold);
@@ -814,8 +818,8 @@ export const useGestureClassifier = (
         enqueueFrameJS(processed);
       } catch (error: any) {
         logErrorJS('WORKLET ERROR:', error);
-        if (!pluginError.value) {
-          pluginError.value = true;
+        if (!errorLogged.value) {
+          errorLogged.value = true;
           onErrorJS(error.message);
         }
       }
@@ -827,7 +831,9 @@ export const useGestureClassifier = (
       localThreshold,
       extractLandmarks,
       pluginAvailable,
-      pluginError,
+      pluginUnavailableLogged,
+      fallbackLogged,
+      errorLogged,
     ],
   );
 
@@ -852,7 +858,7 @@ export const useRecordingProcessor = (
   const extractWithPluginRec = useHandLandmarkExtractor();
   const extractLandmarksRec =
     pluginAvailable ? extractWithPluginRec : extractHandLandmarks;
-  const pluginError = useSharedValue(false);
+  const pluginUnavailableLogged = useSharedValue(false);
 
   const frameProcessor = useFrameProcessor(
     (frame: Frame) => {
@@ -861,8 +867,8 @@ export const useRecordingProcessor = (
         return;
       }
 
-      if (!pluginAvailable && !pluginError.value) {
-        pluginError.value = true;
+      if (!pluginAvailable && !pluginUnavailableLogged.value) {
+        pluginUnavailableLogged.value = true;
         logErrorJS('Frame processor plugin unavailable; using JS fallback');
       }
 
@@ -882,7 +888,7 @@ export const useRecordingProcessor = (
         logErrorJS('WORKLET ERROR:', error);
       }
     },
-    [fps, extractLandmarksRec, pluginAvailable, pluginError],
+    [fps, extractLandmarksRec, pluginAvailable, pluginUnavailableLogged],
   );
 
   return frameProcessor;


### PR DESCRIPTION
## Summary
- add JS-based landmark extraction fallback when worklet plugin is unavailable

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: fetch failed, requires connection)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_689fab93362083229558cc0740350b52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture recognition reliability with a robust fallback when native processing is unavailable.
  * Fixed cases where landmarks or overlays could be missing or invalid, preventing processing errors.
  * Ensures errors and fallbacks are logged only once to reduce noisy reporting.

* **Refactor**
  * Streamlined landmark handling to keep both detailed coordinates and a flat representation, reducing duplicate work and ensuring consistent classification and overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->