### PR TITLE
feat(ml): add softmax temperature scaling

### DIFF
--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -14,6 +14,10 @@ export const REMOTE_TIMEOUT_MS = Number(
   process.env.EXPO_PUBLIC_REMOTE_TIMEOUT_MS || 400,
 );
 
+export const SOFTMAX_TEMPERATURE = Number(
+  process.env.EXPO_PUBLIC_SOFTMAX_TEMPERATURE || 1.0,
+);
+
 // Enable landmark normalization before classification (wrist-center, scale)
 export const NORMALIZE_LANDMARKS =
   process.env.EXPO_PUBLIC_NORMALIZE_LANDMARKS !== 'false';

--- a/app/src/context/AppServicesProvider.tsx
+++ b/app/src/context/AppServicesProvider.tsx
@@ -19,6 +19,7 @@ import {
   ENABLE_REMOTE_CLASSIFICATION,
   REMOTE_RETRY_MS,
   REMOTE_TIMEOUT_MS,
+  SOFTMAX_TEMPERATURE,
 } from '../constants';
 import { logger } from '../utils/logger';
 import { ServicesContext, type Services } from './ServicesContext';
@@ -79,6 +80,7 @@ export const AppServicesProvider = ({ children, offline = false }: ProviderProps
             smootherMinCutOff: 1.0,
             smootherBeta: 0.5,
             smootherDerivateCutOff: 1.0,
+            softmaxTemperature: SOFTMAX_TEMPERATURE,
           },
         );
         await audioService.initialize();

--- a/app/src/services/gestureClassifier.ts
+++ b/app/src/services/gestureClassifier.ts
@@ -10,17 +10,22 @@ const logError = Worklets?.createRunOnJS
   ? Worklets.createRunOnJS(logger.error)
   : (message?: any, ...optional: any[]) => logger.error(message, ...optional);
 
+export interface ClassificationOptions {
+  temperature?: number;
+}
+
 export function setGestureModel(model: TensorflowModel | null): void {
   gestureModel = model;
 }
 
 export function classifyGesture(
   input: Float32Array,
-  confidenceThreshold: number = 0.7,
+  options: ClassificationOptions = {},
 ): ClassificationOutput | null {
   'worklet';
   if (!gestureModel) return null;
   try {
+    const { temperature = 1.0 } = options;
     if (!inputBuffer || inputBuffer.length !== input.length) {
       inputBuffer = new Float32Array(input.length);
     }
@@ -42,8 +47,9 @@ export function classifyGesture(
     }
 
     let sum = 0;
+    const temp = temperature <= 0 ? 1 : temperature;
     for (let i = 0; i < len; i++) {
-      const e = Math.exp(logits[i] - maxLogit);
+      const e = Math.exp((logits[i] - maxLogit) / temp);
       outputBuffer[i] = e;
       sum += e;
     }
@@ -59,14 +65,11 @@ export function classifyGesture(
       }
     }
 
-    if (maxProb >= confidenceThreshold) {
-      return {
-        probabilities: Array.from(outputBuffer),
-        maxProbability: maxProb,
-        maxIndex,
-      };
-    }
-    return null;
+    return {
+      probabilities: Array.from(outputBuffer),
+      maxProbability: maxProb,
+      maxIndex,
+    };
   } catch (e) {
     logError('Gesture classification failed', e);
     return null;

--- a/app/src/services/mlService.ts
+++ b/app/src/services/mlService.ts
@@ -181,6 +181,7 @@ class MachineLearningService {
   private smootherMinCutOff = 1.0;
   private smootherBeta = 0.5;
   private smootherDerivateCutOff = 1.0;
+  private softmaxTemperature = 1.0;
   private perfMonitor = new ModelPerformanceMonitor();
   private labels: string[] = [];
   private teachingSession: { id: string; label: string } | null = null;
@@ -225,6 +226,10 @@ class MachineLearningService {
 
   setLowPowerMode(low: boolean) {
     this.localThreshold = low ? this.lowPowerConfidence : this.baseConfidence;
+  }
+
+  getSoftmaxTemperature(): number {
+    return this.softmaxTemperature;
   }
 
   getPerfMetrics() {
@@ -321,6 +326,9 @@ class MachineLearningService {
       }
       if (config?.smootherDerivateCutOff) {
         this.smootherDerivateCutOff = config.smootherDerivateCutOff;
+      }
+      if (config?.softmaxTemperature !== undefined) {
+        this.softmaxTemperature = config.softmaxTemperature;
       }
 
       this.labels = labels;
@@ -703,6 +711,7 @@ export const useGestureClassifier = (
   const pluginUnavailableLogged = useSharedValue(false);
   const fallbackLogged = useSharedValue(false);
   const errorLogged = useSharedValue(false);
+  const softmaxTemp = mlService.getSoftmaxTemperature();
 
   useEffect(() => {
     const readyInterval = setInterval(() => {
@@ -836,8 +845,12 @@ export const useGestureClassifier = (
                 }
                 return out;
               })();
-          const pred = classifyGesture(flatH, localThreshold);
-          if (pred && (!bestPred || pred.maxProbability > bestPred.maxProbability)) {
+          const pred = classifyGesture(flatH, { temperature: softmaxTemp });
+          if (
+            pred &&
+            pred.maxProbability >= localThreshold &&
+            (!bestPred || pred.maxProbability > bestPred.maxProbability)
+          ) {
             bestPred = pred;
             bestHandIdx = h;
           }
@@ -876,6 +889,7 @@ export const useGestureClassifier = (
       pluginUnavailableLogged,
       fallbackLogged,
       errorLogged,
+      softmaxTemp,
     ],
   );
 

--- a/app/src/types/ml.ts
+++ b/app/src/types/ml.ts
@@ -38,4 +38,5 @@ export interface MLServiceConfig {
   smootherMinCutOff?: number;
   smootherBeta?: number;
   smootherDerivateCutOff?: number;
+  softmaxTemperature?: number;
 }

--- a/app/test/gestureClassifierTemperature.test.ts
+++ b/app/test/gestureClassifierTemperature.test.ts
@@ -1,0 +1,16 @@
+import { classifyGesture, setGestureModel } from '../src/services/gestureClassifier';
+
+describe('classifyGesture temperature scaling', () => {
+  afterEach(() => {
+    setGestureModel(null as any);
+  });
+
+  it('sharpens probabilities when temperature is low', () => {
+    const mockModel = { runSync: () => [[2.0, 1.0, 0.5]] };
+    setGestureModel(mockModel as any);
+    const sample = new Float32Array(63);
+    const defaultRes = classifyGesture(sample, { temperature: 1.0 })!;
+    const sharpRes = classifyGesture(sample, { temperature: 0.5 })!;
+    expect(sharpRes.maxProbability).toBeGreaterThan(defaultRes.maxProbability);
+  });
+});


### PR DESCRIPTION
## Summary
- make softmax temperature configurable for gesture classifier
- propagate temperature through ML service and initialization
- cover temperature scaling with unit tests

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)` *(warn: outdated dependencies)*
- `(cd app && npx expo-doctor)` *(fails: network unreachable)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68a535fe79e0832296965e36d48b6eb3