### PR TITLE
feat(server): prewarm all wasm variants

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -52,7 +52,7 @@ _Last updated: 2025-08-21_
 - [x] Serve gesture_recognizer.task at `/static/models/gesture_recognizer.task`.
 - [x] Proxy/cache MediaPipe Tasks Vision assets at `/static/mediapipe/tasks-vision/<version>/...`.
 - [x] Prewarm `vision_bundle.mjs` and a common WASM file on server start.
-- [ ] Prewarm all WASM variants by parsing the bundle or logging first-hit filenames.
+- [x] Prewarm all WASM variants by parsing the bundle or logging first-hit filenames.
 
 ## Telemetry & Observability
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -127,17 +127,44 @@ setupDatabase(DB_FILE_PATH)
           console.log('[prewarm] Cached tasks-vision bundle');
         }
       }
-      // Try to prewarm a common WASM filename; if missing, route will fetch on demand
+
       const wasmDir = path.join(cacheRoot, 'wasm');
       await fs.mkdir(wasmDir, { recursive: true });
-      const wasmFile = path.join(wasmDir, 'tasks_vision_wasm_internal.wasm');
-      if (!fsSync.existsSync(wasmFile)) {
-        const upstreamWasm = `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@${version}/wasm/tasks_vision_wasm_internal.wasm`;
-        const r2 = await (globalThis as any).fetch(upstreamWasm);
-        if (r2?.ok) {
-          const ab2 = await r2.arrayBuffer();
-          await fs.writeFile(wasmFile, Buffer.from(ab2));
-          console.log('[prewarm] Cached tasks-vision wasm');
+
+      // Parse vision bundle to discover all wasm filenames
+      let wasmFiles: string[] = [];
+      try {
+        const bundleContent = await fs.readFile(localFile, 'utf8');
+        const regex = /["']([^"']+\.wasm)["']/g;
+        const matches = bundleContent.matchAll(regex);
+        const unique = new Set<string>();
+        for (const m of matches) {
+          const fname = path.basename(m[1]);
+          if (fname) unique.add(fname);
+        }
+        wasmFiles = Array.from(unique);
+      } catch (parseErr) {
+        console.warn('[prewarm] Failed to parse bundle for wasm names', parseErr);
+      }
+
+      if (wasmFiles.length === 0) {
+        // Fallback to common filename if parsing failed
+        wasmFiles = ['tasks_vision_wasm_internal.wasm'];
+      }
+
+      for (const file of wasmFiles) {
+        const wasmFile = path.join(wasmDir, file);
+        if (fsSync.existsSync(wasmFile)) continue;
+        const upstreamWasm = `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@${version}/wasm/${file}`;
+        try {
+          const r2 = await (globalThis as any).fetch(upstreamWasm);
+          if (r2?.ok) {
+            const ab2 = await r2.arrayBuffer();
+            await fs.writeFile(wasmFile, Buffer.from(ab2));
+            console.log('[prewarm] Cached tasks-vision wasm', file);
+          }
+        } catch (wasmErr) {
+          console.warn(`[prewarm] Failed to cache wasm ${file}`, wasmErr);
         }
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- parse `vision_bundle.mjs` to discover and pre-cache all MediaPipe Tasks Vision WASM files
- mark WASM prewarm task as complete in the TODO list

## Testing
- `npm run type-check --prefix app` *(fails: Cannot find module 'react-native-webview', Cannot find name 'requestPermission')*
- `npm test --prefix app` *(fails: Cannot find module '@testing-library/react-native')*
- `(cd app && npx expo install --check)` *(fails: "react-native-webview" is added as a dependency but not installed)*
- `(cd app && npx expo-doctor)` *(fails: fetch failed; network unreachable)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration` *(fails: server exited 1; 8 pass, 6 fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a78641f7908322964331a744c2b908