### PR TITLE
Add gesture speech with audio fallback

### DIFF
--- a/app/src/services/audioService.ts
+++ b/app/src/services/audioService.ts
@@ -232,13 +232,14 @@ export class AudioService {
       }
     }
 
-    // Speak the recognized gesture
-    const text = confidence > 0.9 ? `${gesture}` : `Ich denke, du meinst: ${gesture}`;
-
-    await this.speak(text, {
-      pitch: 1.1,
-      rate: 0.8,
-    });
+    if (confidence > 0.9) {
+      await playSymbolAudio({ id: gesture, label: gesture });
+    } else {
+      await this.speak(`Ich denke, du meinst: ${gesture}`, {
+        pitch: 1.1,
+        rate: 0.8,
+      });
+    }
   }
 
   /**

--- a/app/test/audioFeedback.test.ts
+++ b/app/test/audioFeedback.test.ts
@@ -38,7 +38,7 @@ jest.mock('../db', () => ({
   Symbol: class {},
 }));
 
-import { audioService } from '../src/services/audioService';
+import { audioService } from '../src/services';
 import * as Haptics from 'expo-haptics';
 import * as Speech from 'expo-speech';
 import * as FileSystem from 'expo-file-system';

--- a/app/test/audioFeedback.test.ts
+++ b/app/test/audioFeedback.test.ts
@@ -65,15 +65,15 @@ describe('audioService feedback', () => {
     (audioService as any).speechQueue = [];
   });
 
-  it('plays success sound before speech with haptic feedback', async () => {
-    await audioService.playSuccessFeedback('Hallo', 1);
+  it('plays success sound and speaks guidance when confidence is low', async () => {
+    await audioService.playSuccessFeedback('Hallo', 0.8);
 
     const successSound = (audioService as any).sounds.get('success');
     const confirmationSound = (audioService as any).sounds.get('confirmation');
     expect(successSound.play).toHaveBeenCalled();
     expect(confirmationSound.play).toHaveBeenCalled();
     expect(Speech.speak).toHaveBeenCalledWith(
-      'Hallo',
+      'Ich denke, du meinst: Hallo',
       expect.objectContaining({ pitch: 1.1, rate: 0.8 })
     );
     expect(Haptics.notificationAsync).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Success);

--- a/app/test/audioFeedback.test.ts
+++ b/app/test/audioFeedback.test.ts
@@ -41,6 +41,8 @@ jest.mock('../db', () => ({
 import { audioService } from '../src/services/audioService';
 import * as Haptics from 'expo-haptics';
 import * as Speech from 'expo-speech';
+import * as FileSystem from 'expo-file-system';
+import { database } from '../db';
 
 describe('audioService feedback', () => {
   const soundMock = () => ({
@@ -97,6 +99,22 @@ describe('audioService feedback', () => {
       'Lass uns Winken nochmal versuchen!',
       'Wie wäre es mit etwas Übung für Winken?',
     ]).toContain(phrase);
+  });
+
+  it('plays pre-recorded audio when available', async () => {
+    const findMock = jest.fn().mockResolvedValue({ audioUri: '/doc/sounds/papa.mp3' });
+    const originalGet = database.get;
+    (database as any).get = jest.fn(() => ({ find: findMock }));
+    (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: true });
+    const customSpy = jest.spyOn(audioService, 'playCustomAudio').mockResolvedValue();
+
+    await audioService.playSuccessFeedback('papa', 1);
+
+    expect(customSpy).toHaveBeenCalledWith('/doc/sounds/papa.mp3');
+    expect(Speech.speak).not.toHaveBeenCalled();
+
+    (database as any).get = originalGet;
+    customSpy.mockRestore();
   });
 });
 

--- a/app/test/speakShow.test.tsx
+++ b/app/test/speakShow.test.tsx
@@ -7,8 +7,7 @@ jest.mock('../src/services/audioService', () => ({
   audioService: { playSuccessFeedback: jest.fn() },
 }));
 
-import { triggerSpeakAndShow } from '../src/services/feedbackService';
-import { audioService } from '../src/services/audioService';
+import { triggerSpeakAndShow, audioService } from '../src/services';
 import * as Haptics from 'expo-haptics';
 
 describe('triggerSpeakAndShow', () => {

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -71,7 +71,7 @@ _Last updated: 2025-08-21_
 - [ ] Enable training of new gestures in `TrainingScreen` so they are available in `RecognitionScreen`.
   - Persist labeled samples locally and sync them to the server.
   - Refresh the gesture library after training completes.
-- [ ] Play the spoken name of a recognized gesture (e.g., "Papa").
+- [x] Play the spoken name of a recognized gesture (e.g., "Papa").
   - Use `expo-speech` with a pre-recorded audio fallback.
 - [ ] Support DGS gestures that require both hands.
   - Capture and classify dual-hand landmarks in the WebView and server pipeline.


### PR DESCRIPTION
## Summary
- speak recognized gesture names with pre-recorded audio when available
- cover audio fallback in tests
- mark spoken gesture playback task complete in docs

## Testing
- `npm run type-check --prefix app` *(fails: Cannot find type definition file for 'jest', 'node', expo tsconfig)*
- `npm test --prefix app` *(fails: jest: not found)*
- `(cd app && npx expo install --check)` *(requires manual confirmation)*
- `(cd app && npx expo-doctor)` *(requires manual confirmation)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68a7a7afe7d48322bc55aea5ee5a4144