### PR TITLE
docs: add caregiver guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project turns those gestures into speech and symbols so she can be heard an
 - [Codebase overview](docs/CodebaseOverview.md)
 - [User stories](docs/UserStories.md)
 - [Kindergarten staff field guide](docs/KindergartenWorkflow.md)
+- [Caregiver guide](docs/CaregiverGuide.md)
 - [Build & test instructions](docs/BUILD_AND_TEST.md)
 - [Android in WSL2 guide](docs/AndroidWSL2.md)
 - [Project roadmap](docs/TODO.md)

--- a/docs/CaregiverGuide.md
+++ b/docs/CaregiverGuide.md
@@ -1,0 +1,31 @@
+# Caregiver Guide for Amy's Echo
+
+This guide helps caregivers set up and use **Amy's Echo** with a child who communicates using gestures.
+
+## Getting Started
+1. **Charge the device** and ensure the camera lens is clean.
+2. **Connect to Wi‑Fi** when available. Recognition is more accurate online, but the app continues to work offline.
+3. **Open the app** and select the child’s profile on the **Profile Select** screen.
+4. Tap **Recognition** to enter camera mode. The **Parent** area is protected by a multiplication gate.
+
+## Recognizing Gestures
+1. Keep the child’s hands visible in the camera frame.
+2. When a known gesture is detected, the app:
+   - Speaks the associated word aloud.
+   - Shows a large symbol or emoji on screen.
+3. If confidence is low, a **Help Me** panel appears. Select the correct symbol to teach the app.
+
+## Training New Gestures
+1. Go to the **Training** screen.
+2. Follow the on-screen prompts to record the gesture a few times.
+3. Name the gesture and save it. It becomes available immediately in recognition.
+
+## Review and Practice
+- Practice banners occasionally appear to rehearse signs. Tap to begin a guided practice session.
+- Each correction and practice improves future recognition automatically.
+
+## Tips
+- The app logs corrections and training data; avoid sharing the device without supervision.
+- Video reference clips can be added under `app/assets/videos/dgs/` for gestures.
+
+With consistent use, Amy’s gestures become speech and symbols that everyone around her can understand.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -45,7 +45,7 @@ _Last updated: 2025-08-21_
 
 - [ ] **Store Preparation**: Finalize EAS Build config, screenshots, etc.
 - [ ] **Data Management**: Implement backup/restore and GDPR features.
-- [ ] **User Documentation**: Create caregiver guides and tutorials.
+- [x] **User Documentation**: Create caregiver guides and tutorials.
 
 ## Backend + Hosting Tasks
 


### PR DESCRIPTION
## Summary
- add caregiver guide with setup, recognition, and training steps
- link caregiver guide from README
- mark user documentation task as complete in TODO list

## Testing
- `npm run type-check --prefix app` *(fails: Cannot find type definition file for 'jest')*
- `npm test --prefix app` *(fails: jest: not found)*
- `(cd app && npx expo install --check)` *(fails: requires expo@53.0.20 confirmation)*
- `(cd app && npx expo-doctor)` *(fails: requires expo-doctor@1.17.0 confirmation)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration` *(fails: practiceMode.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b108cb2083229c1786e17e94f09b