### PR TITLE
Add GDPR profile management service

### DIFF
--- a/app/src/context/AppServicesProvider.tsx
+++ b/app/src/context/AppServicesProvider.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useEffect, useState } from 'react';
-import { audioService, backupService, checkForModelUpdate, syncService, syncTrainingData, gestureDataProtector } from '../services';
+import { audioService, backupService, checkForModelUpdate, syncService, syncTrainingData, gestureDataProtector, gdprService } from '../services';
 import { adaptiveLearningService } from '../services/adaptiveLearningService';
 import { ActivityIndicator, View } from 'react-native';
 import { useMessage } from './MessageContext';
@@ -21,7 +21,7 @@ interface ProviderProps {
   offline?: boolean;
 }
 
-const services: Services = { audioService, adaptiveLearningService, backupService, gestureDataProtector };
+const services: Services = { audioService, adaptiveLearningService, backupService, gestureDataProtector, gdprService };
 
 export const AppServicesProvider = ({ children, offline = false }: ProviderProps) => {
   const [areServicesReady, setAreServicesReady] = useState(false);

--- a/app/src/context/ServicesContext.tsx
+++ b/app/src/context/ServicesContext.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import type { audioService, backupService, gestureDataProtector } from '../services';
+import type { audioService, backupService, gestureDataProtector, gdprService } from '../services';
 import type { adaptiveLearningService } from '../services/adaptiveLearningService';
 
 export interface Services {
@@ -7,6 +7,7 @@ export interface Services {
   adaptiveLearningService: typeof adaptiveLearningService;
   backupService: typeof backupService;
   gestureDataProtector: typeof gestureDataProtector;
+  gdprService: typeof gdprService;
 }
 
 export const ServicesContext = React.createContext<Services | null>(null);

--- a/app/src/declarations.d.ts
+++ b/app/src/declarations.d.ts
@@ -2,3 +2,12 @@ declare module '*.tflite';
 declare module '@shopify/react-native-skia';
 declare module 'crypto-js';
 declare module 'react-native-webview';
+declare module 'expo-crypto' {
+  export enum CryptoDigestAlgorithm {
+    SHA256 = 'SHA256',
+  }
+  export function digestFileAsync(
+    algorithm: CryptoDigestAlgorithm,
+    fileUri: string
+  ): Promise<string>;
+}

--- a/app/src/model.ts
+++ b/app/src/model.ts
@@ -1,4 +1,5 @@
-import { loadCustomGestures } from './storage';
+// Dynamically import storage only when initializing to avoid bundling React Native
+// modules in non-native environments (e.g., integration tests).
 
 export interface GestureModelEntry {
   id: string;
@@ -78,6 +79,7 @@ export function addGesture(entry: GestureModelEntry): void {
 }
 
 export async function initGestureModel(): Promise<void> {
+  const { loadCustomGestures } = await import('./storage');
   const custom = await loadCustomGestures();
   custom.forEach((g) => addGesture(g));
 }

--- a/app/src/screens/AdminScreen.tsx
+++ b/app/src/screens/AdminScreen.tsx
@@ -15,6 +15,7 @@ import {
   loadBackendApiToken,
   saveBackendApiToken,
   saveCustomModelUri,
+  loadActiveProfileId,
 } from '../storage';
 import * as FileSystem from 'expo-file-system';
 import { API_URL } from '../constants';
@@ -31,7 +32,7 @@ import { usePerformance } from '../context/PerformanceContext';
 const SYMBOL_EXPORT_PATH = `${FileSystem.documentDirectory || ''}symbols-export.json`;
 
 export default function AdminScreen({ navigation }: any) {
-  const { audioService, backupService } = useServices();
+  const { audioService, backupService, gdprService } = useServices();
   const { isLowPerformanceMode, toggleLowPerformanceMode } = usePerformance();
   const [symbols, setSymbols] = useState<DBSymbol[]>([]);
   const [editing, setEditing] = useState<DBSymbol | null>(null);
@@ -265,6 +266,44 @@ export default function AdminScreen({ navigation }: any) {
     }
   };
 
+  const handleExportProfile = async () => {
+    try {
+      const profileId = await loadActiveProfileId();
+      if (!profileId) {
+        Alert.alert('No active profile');
+        return;
+      }
+      const data = await gdprService.exportProfile(profileId);
+      if (!data) {
+        Alert.alert('Export failed');
+        return;
+      }
+      const path = `${FileSystem.documentDirectory || ''}profile-export.json`;
+      await FileSystem.writeAsStringAsync(path, JSON.stringify(data, null, 2));
+      Alert.alert('Profile export complete', `Saved to ${path}`);
+    } catch (e) {
+      Alert.alert('Export failed', (e as Error).message || 'Unknown error');
+    }
+  };
+
+  const handleDeleteProfile = async () => {
+    try {
+      const profileId = await loadActiveProfileId();
+      if (!profileId) {
+        Alert.alert('No active profile');
+        return;
+      }
+      const ok = await gdprService.deleteProfile(profileId);
+      if (ok) {
+        Alert.alert('Profile deleted');
+      } else {
+        Alert.alert('Delete failed');
+      }
+    } catch (e) {
+      Alert.alert('Delete failed', (e as Error).message || 'Unknown error');
+    }
+  };
+
   const handleDelete = (sym: DBSymbol) => {
     Alert.alert('Symbol löschen', `"${sym.name}" wirklich entfernen?`, [
       { text: 'Abbrechen', style: 'cancel' },
@@ -363,6 +402,16 @@ export default function AdminScreen({ navigation }: any) {
         title="Gesten wiederherstellen"
         onPress={handleRestoreGestures}
         accessibilityLabel="Gesten wiederherstellen"
+      />
+      <Button
+        title="Export Profile"
+        onPress={handleExportProfile}
+        accessibilityLabel="Profil exportieren"
+      />
+      <Button
+        title="Delete Profile"
+        onPress={handleDeleteProfile}
+        accessibilityLabel="Profil löschen"
       />
       <Button title="Add Symbol" onPress={openAdd} accessibilityLabel="Symbol hinzufügen" />
       <Button

--- a/app/src/services/gdprService.ts
+++ b/app/src/services/gdprService.ts
@@ -1,0 +1,47 @@
+import { API_URL, API_TOKEN } from '../constants';
+import { logger } from '../utils/logger';
+
+export interface ExportedProfileData {
+  profile: any;
+  usageStats: any[];
+  corrections: any[];
+}
+
+async function request(url: string, options: RequestInit = {}): Promise<Response | null> {
+  try {
+    const resp = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${API_TOKEN}`,
+        'Content-Type': 'application/json',
+        ...(options.headers || {}),
+      },
+    });
+    if (!resp.ok) {
+      logger.error(`[gdprService] Request failed: ${resp.status}`);
+      return null;
+    }
+    return resp;
+  } catch (e) {
+    logger.error('[gdprService] Network error', e);
+    return null;
+  }
+}
+
+export const gdprService = {
+  async exportProfile(profileId: string): Promise<ExportedProfileData | null> {
+    const resp = await request(`${API_URL}/api/profiles/${profileId}/export`);
+    if (!resp) return null;
+    try {
+      return (await resp.json()) as ExportedProfileData;
+    } catch (e) {
+      logger.error('[gdprService] Failed to parse export', e);
+      return null;
+    }
+  },
+
+  async deleteProfile(profileId: string): Promise<boolean> {
+    const resp = await request(`${API_URL}/api/profiles/${profileId}`, { method: 'DELETE' });
+    return !!resp;
+  },
+};

--- a/app/src/services/index.ts
+++ b/app/src/services/index.ts
@@ -16,3 +16,4 @@ export * from './accessibilityService';
 export * from './AdaptivePerformanceManager';
 export * from './backupService';
 export * from './dataProtection';
+export * from './gdprService';

--- a/app/src/services/modelUpdateService.ts
+++ b/app/src/services/modelUpdateService.ts
@@ -54,9 +54,11 @@ export class ModelUpdateService {
       if (downloadResult.status === 200) {
         // Verify checksum if expo-crypto is available; otherwise skip (best-effort)
         try {
-          // @ts-ignore dynamic optional dependency
-          const mod = await import('expo-crypto');
-          const computed = await mod.digestFileAsync(mod.CryptoDigestAlgorithm.SHA256, tmpPath);
+          const crypto = await import('expo-crypto');
+          const computed = await crypto.digestFileAsync(
+            crypto.CryptoDigestAlgorithm.SHA256,
+            tmpPath
+          );
           if (
             typeof computed === 'string' &&
             modelInfo.checksum &&

--- a/app/test/appServicesProvider.test.tsx
+++ b/app/test/appServicesProvider.test.tsx
@@ -64,6 +64,7 @@ jest.mock('../src/services', () => ({
   adaptiveLearningService: {},
   backupService: {},
   gestureDataProtector: {},
+  gdprService: {},
   checkForModelUpdate: jest.fn(),
   syncTrainingData: jest.fn(),
   syncService: {

--- a/app/test/gdprService.test.ts
+++ b/app/test/gdprService.test.ts
@@ -1,0 +1,36 @@
+import { gdprService } from '../src/services/gdprService';
+
+describe('gdprService', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+  });
+
+  it('exports profile data', async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ profile: { id: 'p1' }, usageStats: [], corrections: [] }),
+    });
+    const data = await gdprService.exportProfile('p1');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/profiles/p1/export'),
+      expect.any(Object),
+    );
+    expect(data?.profile.id).toBe('p1');
+  });
+
+  it('deletes profile', async () => {
+    (global as any).fetch.mockResolvedValue({ ok: true });
+    const ok = await gdprService.deleteProfile('p2');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/profiles/p2'),
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+    expect(ok).toBe(true);
+  });
+
+  it('handles failures', async () => {
+    (global as any).fetch.mockResolvedValue({ ok: false, status: 500 });
+    const ok = await gdprService.deleteProfile('p3');
+    expect(ok).toBe(false);
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -44,7 +44,7 @@ _Last updated: 2025-08-21_
 ## 🚀 Production Readiness
 
 - [ ] **Store Preparation**: Finalize EAS Build config, screenshots, etc.
-- [ ] **Data Management**: Implement backup/restore and GDPR features.
+- [x] **Data Management**: Implement backup/restore and GDPR features.
 - [x] **User Documentation**: Create caregiver guides and tutorials.
 
 ## Backend + Hosting Tasks


### PR DESCRIPTION
## Summary
- implement `gdprService` for exporting and deleting profile data via server API
- expose new service through provider and Admin screen
- mark Data Management todo complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)` *(warn: outdated dependencies)*
- `(cd app && npx expo-doctor)` *(fail: network errors)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration` *(fail: practiceMode.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b51f32b883228f09341676cc0eed