### PR TITLE
feat: support dual-hand gesture landmarks

### DIFF
--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -4,7 +4,11 @@ import { WebView } from 'react-native-webview';
 import { API_URL, API_TOKEN, ANALYTICS_TELEMETRY_ENDPOINT } from '../constants';
 
 interface Props {
-  onGestureDetected: (gesture: string, confidence: number, landmarks: number[][]) => void;
+  onGestureDetected: (
+    gesture: string,
+    confidence: number,
+    landmarks: number[][][],
+  ) => void;
   onError: (error: string) => void;
 }
 
@@ -44,7 +48,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
             delegate: "GPU",
           },
           runningMode,
-          numHands: 1,
+          numHands: 2,
         });
         const initMs = Math.round(performance.now() - visionStart);
         window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: 'telemetry', event: 'recognizer_init', ms: initMs }));
@@ -70,7 +74,9 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
             if (frameCount % 30 === 0) {
               window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: 'telemetry', event: 'frame_latency', ms: frameLatency }));
             }
-            const lms = (results?.landmarks?.[0] || []).map(lm => [lm.x, lm.y, lm.z ?? 0]);
+            const allLandmarks = (results?.landmarks || []).map(hand =>
+              hand.map(lm => [lm.x, lm.y, lm.z ?? 0])
+            );
             let outGesture = null;
             let outScore = 0;
             if (results?.gestures?.length) {
@@ -78,22 +84,39 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
               outGesture = top.categoryName;
               outScore = top.score;
             }
-            // Custom gesture logic (preserved)
-            if ((!outGesture || outScore < 0.5) && lms.length === 21) {
-              const thumbUp = lms[4][1] < lms[2][1];
-              const indexUp = lms[8][1] < lms[6][1];
-              const middleUp = lms[12][1] < lms[10][1];
-              const ringUp = lms[16][1] < lms[14][1];
-              const pinkyUp = lms[20][1] < lms[18][1];
+            // Custom gesture logic (preserved for single-hand fallback)
+            const firstHand = allLandmarks[0] || [];
+            if ((!outGesture || outScore < 0.5) && firstHand.length === 21) {
+              const thumbUp = firstHand[4][1] < firstHand[2][1];
+              const indexUp = firstHand[8][1] < firstHand[6][1];
+              const middleUp = firstHand[12][1] < firstHand[10][1];
+              const ringUp = firstHand[16][1] < firstHand[14][1];
+              const pinkyUp = firstHand[20][1] < firstHand[18][1];
               const allUp = indexUp && middleUp && ringUp && pinkyUp;
               const noneUp = !indexUp && !middleUp && !ringUp && !pinkyUp;
-              if (thumbUp && !indexUp && !middleUp) { outGesture = 'thumbs_up'; outScore = 0.8; }
-              else if (indexUp && !middleUp && !ringUp && !pinkyUp) { outGesture = 'point'; outScore = 0.7; }
-              else if (allUp) { outGesture = 'open_palm'; outScore = 0.6; }
-              else if (noneUp) { outGesture = 'fist'; outScore = 0.6; }
+              if (thumbUp && !indexUp && !middleUp) {
+                outGesture = 'thumbs_up';
+                outScore = 0.8;
+              } else if (indexUp && !middleUp && !ringUp && !pinkyUp) {
+                outGesture = 'point';
+                outScore = 0.7;
+              } else if (allUp) {
+                outGesture = 'open_palm';
+                outScore = 0.6;
+              } else if (noneUp) {
+                outGesture = 'fist';
+                outScore = 0.6;
+              }
             }
             if (outGesture) {
-              window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: 'gesture', gesture: outGesture, confidence: outScore, landmarks: lms }));
+              window.ReactNativeWebView?.postMessage?.(
+                JSON.stringify({
+                  type: 'gesture',
+                  gesture: outGesture,
+                  confidence: outScore,
+                  landmarks: allLandmarks,
+                }),
+              );
             }
           }
         }
@@ -127,8 +150,12 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
               const result = await resp.json();
               const g = result?.gesture || 'unknown';
               const conf = result?.confidence ?? 0;
-              const lms = Array.isArray(result?.landmarks) ? result.landmarks : [];
-              window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: 'gesture', gesture: g, confidence: conf, landmarks: lms }));
+              let lms = Array.isArray(result?.landmarks?.[0])
+                ? result.landmarks
+                : [result.landmarks || []];
+              window.ReactNativeWebView?.postMessage?.(
+                JSON.stringify({ type: 'gesture', gesture: g, confidence: conf, landmarks: lms }),
+              );
             }
           } catch (e) {
             window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: 'warn', message: 'Server fallback error: ' + (e?.message || e) }));

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -150,7 +150,8 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
               const result = await resp.json();
               const g = result?.gesture || 'unknown';
               const conf = result?.confidence ?? 0;
-              let lms = Array.isArray(result?.landmarks?.[0])
+              // normalize landmarks to always be number[][][]
+              let lms = Array.isArray(result?.landmarks?.[0]?.[0])
                 ? result.landmarks
                 : [result.landmarks || []];
               window.ReactNativeWebView?.postMessage?.(

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -80,9 +80,13 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
             let outGesture = null;
             let outScore = 0;
             if (results?.gestures?.length) {
-              const top = results.gestures[0][0];
-              outGesture = top.categoryName;
-              outScore = top.score;
+              for (const handGestures of results.gestures) {
+                const top = handGestures?.[0];
+                if (top && top.score > outScore) {
+                  outGesture = top.categoryName;
+                  outScore = top.score;
+                }
+              }
             }
             // Custom gesture logic (preserved for single-hand fallback)
             const firstHand = allLandmarks[0] || [];

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -62,7 +62,11 @@ export default function RecognitionScreen({ navigation }: any) {
     }).start();
   }, [fadeAnim, symbolScaleAnim]);
 
-  const handleGestureDetected = useCallback(async (gesture: string, confidence: number, landmarks: number[][]) => {
+  const handleGestureDetected = useCallback(async (
+    gesture: string,
+    confidence: number,
+    landmarks: number[][][],
+  ) => {
     const start = Date.now();
     try {
       const response = await fetch(`${API_URL}/api/classify-landmarks`, {

--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -24,7 +24,7 @@ export default function TeachingScreen({ navigation }: any) {
   const sessionId = useRef<string | null>(null);
   const SAMPLES_NEEDED = 5;
   const PREVIEW_SIZE = 240;
-  const [landmarks, setLandmarks] = useState<number[][]>([]);
+  const [landmarks, setLandmarks] = useState<number[][][]>([]);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { setMessage } = useMessage();
@@ -90,10 +90,14 @@ export default function TeachingScreen({ navigation }: any) {
     setIsRecording(true);
     setError(null);
     try {
-      const frames: number[][][] = [];
+      const frames: number[][][][] = [];
       const start = Date.now();
       while (Date.now() - start < 2000) {
-        if (landmarks.length === 21) frames.push(landmarks);
+        if (
+          landmarks.length > 0 &&
+          landmarks.every((h) => h.length === 21)
+        )
+          frames.push(landmarks);
         await new Promise((r) => setTimeout(r, 66));
       }
       if (frames.length === 0) throw new Error('No landmarks captured');

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -211,9 +211,17 @@ export default function TrainingScreen({ navigation, route }: any) {
                   viewBox={`0 0 ${PREVIEW_SIZE} ${PREVIEW_SIZE}`}
                   pointerEvents="none"
                 >
-                  {landmarks.flat().map((l, idx) => (
-                    <Circle key={idx} cx={l[0] * PREVIEW_SIZE} cy={l[1] * PREVIEW_SIZE} r={3} fill={COLORS.warning} />
-                  ))}
+                  {landmarks.map((hand, handIdx) =>
+                    hand.map((l, lmIdx) => (
+                      <Circle
+                        key={`${handIdx}-${lmIdx}`}
+                        cx={l[0] * PREVIEW_SIZE}
+                        cy={l[1] * PREVIEW_SIZE}
+                        r={3}
+                        fill={COLORS.warning}
+                      />
+                    ))
+                  )}
                 </Svg>
               )}
               <View style={styles.detectionIndicator}>

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -24,11 +24,11 @@ export default function TrainingScreen({ navigation, route }: any) {
   const [gestureId, setGestureId] = useState<string | null>(gestureLabel || null);
   const [count, setCount] = useState(0);
   const [isRecording, setIsRecording] = useState(false);
-  const [recordedLandmarks, setRecordedLandmarks] = useState<number[][][]>([]);
+  const [recordedLandmarks, setRecordedLandmarks] = useState<number[][][][]>([]);
   const [framesCaptured, setFramesCaptured] = useState(0);
   const [lastDetection, setLastDetection] = useState(0);
   const [now, setNow] = useState(Date.now());
-  const [landmarks, setLandmarks] = useState<number[][]>([]);
+  const [landmarks, setLandmarks] = useState<number[][][]>([]);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { setMessage } = useMessage();
@@ -211,7 +211,7 @@ export default function TrainingScreen({ navigation, route }: any) {
                   viewBox={`0 0 ${PREVIEW_SIZE} ${PREVIEW_SIZE}`}
                   pointerEvents="none"
                 >
-                  {landmarks.map((l, idx) => (
+                  {landmarks.flat().map((l, idx) => (
                     <Circle key={idx} cx={l[0] * PREVIEW_SIZE} cy={l[1] * PREVIEW_SIZE} r={3} fill={COLORS.warning} />
                   ))}
                 </Svg>

--- a/app/src/services/TrainingDataValidator.ts
+++ b/app/src/services/TrainingDataValidator.ts
@@ -12,7 +12,7 @@ export interface ValidationResult {
 
 // Basic quality checks for recorded gesture samples used in training.
 // Assumes landmarks are normalized to [0,1] if available.
-export function validateLandmarkSequence(samples: number[][][]): ValidationResult {
+export function validateLandmarkSequence(samples: number[][][][]): ValidationResult {
   const issues: ValidationIssue[] = [];
   const suggestions: string[] = [];
 
@@ -28,7 +28,7 @@ export function validateLandmarkSequence(samples: number[][][]): ValidationResul
   let motionSamples = 0;
 
   for (let i = 0; i < frameCount; i++) {
-    const frame = samples[i];
+    const frame = samples[i].flat();
     if (!frame || frame.length === 0) {
       hasMissing = true;
       continue;
@@ -51,12 +51,15 @@ export function validateLandmarkSequence(samples: number[][][]): ValidationResul
       ) {
         outOfRange = true;
       }
-      if (i > 0 && samples[i - 1] && samples[i - 1][j]) {
-        const [px, py] = samples[i - 1][j];
-        const dx = x - px;
-        const dy = y - py;
-        totalMotion += Math.hypot(dx, dy);
-        motionSamples += 1;
+      if (i > 0) {
+        const prev = samples[i - 1].flat();
+        if (prev[j]) {
+          const [px, py] = prev[j];
+          const dx = x - px;
+          const dy = y - py;
+          totalMotion += Math.hypot(dx, dy);
+          motionSamples += 1;
+        }
       }
     }
   }

--- a/app/src/services/dgsTrainingService.ts
+++ b/app/src/services/dgsTrainingService.ts
@@ -1,6 +1,10 @@
 import { API_URL, API_TOKEN } from '../constants';
 
-export async function sendDgsSample(label: string, landmarks: number[][][], profileId?: string): Promise<boolean> {
+export async function sendDgsSample(
+  label: string,
+  landmarks: number[][][][],
+  profileId?: string,
+): Promise<boolean> {
   try {
     const resp = await fetch(`${API_URL}/api/v1/dgs/samples`, {
       method: 'POST',

--- a/app/src/types/ml.ts
+++ b/app/src/types/ml.ts
@@ -5,8 +5,8 @@ export interface ClassificationOutput {
 }
 
 export interface ProcessedFrame {
-  landmarks: number[][];
-  landmarksRaw?: number[][];
+  landmarks: number[][][];
+  landmarksRaw?: number[][][];
   width: number;
   height: number;
   timestamp: number;

--- a/app/test/MediaPipeGestureDetector.test.tsx
+++ b/app/test/MediaPipeGestureDetector.test.tsx
@@ -34,13 +34,13 @@ describe('MediaPipeGestureDetector', () => {
             type: 'gesture',
             gesture: 'thumbs_up',
             confidence: 0.9,
-            landmarks: [[1, 2, 3]],
+            landmarks: [[[1, 2, 3]]],
           }),
         },
       });
     });
 
-    expect(onGestureDetected).toHaveBeenCalledWith('thumbs_up', 0.9, [[1, 2, 3]]);
+    expect(onGestureDetected).toHaveBeenCalledWith('thumbs_up', 0.9, [[[1, 2, 3]]]);
     expect(onError).not.toHaveBeenCalled();
   });
 

--- a/app/test/trainingValidator.test.ts
+++ b/app/test/trainingValidator.test.ts
@@ -4,14 +4,14 @@ const makeFlat = (n: number): number[][] => Array.from({ length: n }, (_, i) => 
 
 describe('TrainingDataValidator', () => {
   it('flags too few frames', () => {
-    const seq = [makeFlat(5)];
+    const seq = [[makeFlat(5)]];
     const result = validateLandmarkSequence(seq);
     expect(result.ok).toBe(false);
     expect(result.issues).toContain('too_few_frames');
   });
 
   it('flags insufficient motion', () => {
-    const frame = makeFlat(21);
+    const frame = [makeFlat(21)];
     const seq = Array.from({ length: 15 }, () => frame); // identical frames -> no motion
     const result = validateLandmarkSequence(seq);
     expect(result.ok).toBe(false);
@@ -19,11 +19,11 @@ describe('TrainingDataValidator', () => {
   });
 
   it('accepts reasonable sample', () => {
-    const seq: number[][][] = [];
-    let base = makeFlat(21);
+    const seq: number[][][][] = [];
+    let base = [makeFlat(21)];
     for (let i = 0; i < 15; i++) {
       // create slight motion per frame
-      base = base.map(([x, y, z]) => [x + 0.002, y + 0.001, z]);
+      base = [base[0].map(([x, y, z]) => [x + 0.002, y + 0.001, z])];
       seq.push(base);
     }
     const result = validateLandmarkSequence(seq);

--- a/docs/API.md
+++ b/docs/API.md
@@ -151,7 +151,12 @@ Upload hand landmarks and trigger model training.
 
 **Body**
 ```json
-{ "landmarks": [...] }
+{
+  "landmarks": [
+    [[0.1,0.2,0], ...21],
+    [[0.3,0.4,0], ...21]
+  ]
+}
 ```
 
 **Response**
@@ -200,11 +205,16 @@ Retrieve stored analytics summary.
 ```
 
 ### POST /api/classify-landmarks
-Send an array of 21 hand landmarks for server-side classification. The server forwards the landmarks to a cloud model and falls back to a lightweight local classifier if the request fails.
+Send an array of hand landmarks for server-side classification. Each frame contains one or two hands, where each hand is an array of 21 landmark `[x,y,z]` coordinates. The server forwards the landmarks to a cloud model and falls back to a lightweight local classifier if the request fails.
 
 **Body**
 ```json
-{ "landmarks": [...] }
+{
+  "landmarks": [
+    [[0.1,0.2,0], ...21],
+    [[0.3,0.4,0], ...21]
+  ]
+}
 ```
 
 **Response**

--- a/docs/ExpoGestureRecognition.md
+++ b/docs/ExpoGestureRecognition.md
@@ -8,7 +8,7 @@ Below are four proven approaches for Expo projects. Each option includes code sa
 
 ## 1. MediaPipe Tasks in WebView (recommended)
 
-MediaPipe Tasks Vision `GestureRecognizer` runs inside a `WebView` using WebAssembly. It detects hand landmarks and recognized gestures on-device and streams landmarks to the backend classifier when available.
+MediaPipe Tasks Vision `GestureRecognizer` runs inside a `WebView` using WebAssembly. It detects hand landmarks (up to two hands) and recognized gestures on-device and streams landmarks to the backend classifier when available.
 
 ### Install
 ```bash
@@ -25,7 +25,11 @@ import { View, StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 interface Props {
-  onGestureDetected: (gesture: string, confidence: number, landmarks: number[][]) => void;
+  onGestureDetected: (
+    gesture: string,
+    confidence: number,
+    landmarks: number[][][],
+  ) => void;
   onError: (error: string) => void;
 }
 
@@ -49,20 +53,20 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
       const vision = await FilesetResolver.forVisionTasks('${API_URL}/static/mediapipe/tasks-vision/0.10.9/wasm');
       gestureRecognizer = await GestureRecognizer.createFromOptions(vision,{
         baseOptions:{ modelAssetPath:'https://storage.googleapis.com/mediapipe-models/gesture_recognizer/gesture_recognizer/float16/latest/gesture_recognizer.task', delegate:'GPU' },
-        runningMode, numHands:1
+        runningMode, numHands:2
       });
     }
-    function predict(){
-      if(gestureRecognizer && video.currentTime>0 && !video.paused){
-        const r = gestureRecognizer.recognizeForVideo(video, performance.now());
-        if(r?.gestures?.length){
-          const g = r.gestures[0][0];
-          const lms = (r.landmarks?.[0]||[]).map(l=>[l.x,l.y,l.z||0]);
-          window.ReactNativeWebView?.postMessage?.(JSON.stringify({type:'gesture',gesture:g.categoryName,confidence:g.score,landmarks:lms}));
+      function predict(){
+        if(gestureRecognizer && video.currentTime>0 && !video.paused){
+          const r = gestureRecognizer.recognizeForVideo(video, performance.now());
+          if(r?.gestures?.length){
+            const g = r.gestures[0][0];
+            const lms = (r.landmarks||[]).map(hand=>hand.map(l=>[l.x,l.y,l.z||0]));
+            window.ReactNativeWebView?.postMessage?.(JSON.stringify({type:'gesture',gesture:g.categoryName,confidence:g.score,landmarks:lms}));
+          }
         }
+        requestAnimationFrame(predict);
       }
-      requestAnimationFrame(predict);
-    }
     async function start(){
       try{ const s = await navigator.mediaDevices.getUserMedia({video:{facingMode:'user'}}); video.srcObject=s; await createGestureRecognizer(); video.addEventListener('loadeddata',()=>requestAnimationFrame(predict)); }
       catch(e){ window.ReactNativeWebView?.postMessage?.(JSON.stringify({type:'error',message:'Camera error: '+(e?.message||e)})); }

--- a/docs/ExpoGestureRecognition.md
+++ b/docs/ExpoGestureRecognition.md
@@ -60,9 +60,11 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
         if(gestureRecognizer && video.currentTime>0 && !video.paused){
           const r = gestureRecognizer.recognizeForVideo(video, performance.now());
           if(r?.gestures?.length){
-            const g = r.gestures[0][0];
-            const lms = (r.landmarks||[]).map(hand=>hand.map(l=>[l.x,l.y,l.z||0]));
-            window.ReactNativeWebView?.postMessage?.(JSON.stringify({type:'gesture',gesture:g.categoryName,confidence:g.score,landmarks:lms}));
+            const topGesture = r.gestures.flatMap(g => g).sort((a, b) => b.score - a.score)[0];
+            if (topGesture) {
+              const lms = (r.landmarks || []).map(hand => hand.map(l => [l.x, l.y, l.z || 0]));
+              window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: 'gesture', gesture: topGesture.categoryName, confidence: topGesture.score, landmarks: lms }));
+            }
           }
         }
         requestAnimationFrame(predict);

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -73,7 +73,7 @@ _Last updated: 2025-08-21_
    - Refresh the gesture library after training completes.
 - [x] Play the spoken name of a recognized gesture (e.g., "Papa").
   - Use `expo-speech` with a pre-recorded audio fallback.
-- [ ] Support DGS gestures that require both hands.
+- [x] Support DGS gestures that require both hands.
   - Capture and classify dual-hand landmarks in the WebView and server pipeline.
 
 ---

--- a/docs/UnifiedAIImplementationBlueprint.md
+++ b/docs/UnifiedAIImplementationBlueprint.md
@@ -24,7 +24,7 @@ For a list of alternative approaches and the current implementation status, refe
     *   `@mediapipe/hands`: The JavaScript library for hand tracking.
 *   **Functionality**:
     *   The component renders an HTML page with the necessary JavaScript to access the device's camera and run the MediaPipe hand tracking model.
-    *   When hands are detected, the component extracts the 21 hand landmarks.
+*   When hands are detected, the component extracts 21 landmarks per hand (supports two hands).
     *   It then uses `window.ReactNativeWebView.postMessage` to send the landmark data back to the React Native application.
 
 ### **Section 2: Integration with `RecognitionScreen.tsx`**
@@ -46,7 +46,7 @@ For a list of alternative approaches and the current implementation status, refe
 
 *   **Endpoint**: `POST /api/classify-landmarks`
 *   **Logic**:
-    *   Receives an array of 21 hand landmarks.
+*   Receives an array of hand landmarks (one or two hands, each with 21 points).
     *   Uses a powerful, server-side machine learning model to classify the gesture.
     *   Returns the gesture label and a confidence score.
 

--- a/server/src/recognizer.test.ts
+++ b/server/src/recognizer.test.ts
@@ -27,4 +27,24 @@ describe('classifyGesture', () => {
       delete process.env.OFFLINE_MODEL_PATH;
     }
   });
+
+  it('flattens landmark arrays of varying depth for offline classification', async () => {
+    const originalFetch = global.fetch;
+    try {
+      global.fetch = jest.fn().mockRejectedValue(new Error('network')) as any;
+      process.env.OFFLINE_MODEL_PATH = path.join(__dirname, 'offlineModel.json');
+      const shallow = await classifyGesture([[0, 0], [0, 0]]);
+      const deep = await classifyGesture([[[0, 0, 0], [0, 0, 0]]]);
+      expect(shallow.label).toBe('g1');
+      expect(deep.label).toBe('g1');
+    } finally {
+      if (originalFetch === undefined) {
+        // @ts-expect-error delete global property
+        delete global.fetch;
+      } else {
+        (global.fetch as any) = originalFetch as any;
+      }
+      delete process.env.OFFLINE_MODEL_PATH;
+    }
+  });
 });

--- a/server/src/recognizer.ts
+++ b/server/src/recognizer.ts
@@ -50,29 +50,18 @@ function loadOfflineModel(): void {
 }
 
 function flattenLandmarks(data: unknown): number[] {
-  const result: number[] = [];
-  if (Array.isArray(data)) {
-    for (const hand of data as any[]) {
-      if (Array.isArray(hand)) {
-        for (const p of hand as any[]) {
-          if (Array.isArray(p)) {
-            result.push(Number(p[0] ?? 0), Number(p[1] ?? 0), Number(p[2] ?? 0));
-          }
-        }
-      }
-    }
+  if (!Array.isArray(data)) {
+    return [];
   }
-  return result;
+  return (data as any[]).flat(Infinity).map((v) => Number(v ?? 0));
 }
 
 function classifyOffline(landmarks: unknown): ClassificationResult {
   loadOfflineModel();
-  if (!offlineModel || !Array.isArray(landmarks)) {
+  const input = flattenLandmarks(landmarks);
+  if (!offlineModel || input.length === 0) {
     return { label: 'unknown', confidence: 0.5, processedBy: 'local' };
   }
-  const input = Array.isArray((landmarks as any)[0])
-    ? flattenLandmarks(landmarks)
-    : (landmarks as number[]).map(Number);
 
   let bestLabel = 'unknown';
   let bestScore = Number.POSITIVE_INFINITY;

--- a/server/src/recognizer.ts
+++ b/server/src/recognizer.ts
@@ -49,12 +49,30 @@ function loadOfflineModel(): void {
   }
 }
 
+function flattenLandmarks(data: unknown): number[] {
+  const result: number[] = [];
+  if (Array.isArray(data)) {
+    for (const hand of data as any[]) {
+      if (Array.isArray(hand)) {
+        for (const p of hand as any[]) {
+          if (Array.isArray(p)) {
+            result.push(Number(p[0] ?? 0), Number(p[1] ?? 0), Number(p[2] ?? 0));
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
 function classifyOffline(landmarks: unknown): ClassificationResult {
   loadOfflineModel();
   if (!offlineModel || !Array.isArray(landmarks)) {
     return { label: 'unknown', confidence: 0.5, processedBy: 'local' };
   }
-  const input = (landmarks as number[]).map(Number);
+  const input = Array.isArray((landmarks as any)[0])
+    ? flattenLandmarks(landmarks)
+    : (landmarks as number[]).map(Number);
 
   let bestLabel = 'unknown';
   let bestScore = Number.POSITIVE_INFINITY;


### PR DESCRIPTION
## Summary
- allow WebView recognizer to capture up to two hands and forward landmarks
- propagate multi-hand landmarks through recognition, training, and validation flows
- flatten nested landmark arrays for offline server classification and update docs

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` (fails: Fetch errors, network unreachable)
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`

------
https://chatgpt.com/codex/tasks/task_e_68a7c41e6b548322b7c437eb00d250a7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Two-hand gesture detection (up to 2 hands); landmarks are now per-hand 3D points and recorded as multi-frame sequences.
  - Offline recognition accepts single- or multi-hand inputs via a unified flattening approach.

- **Documentation**
  - API and guides updated with multi-frame, per-hand 3D payload examples and updated callback signature.
  - Expo guide and blueprint updated; TODO for two-hand DGS support marked complete.

- **Tests**
  - Test suites updated to cover new multi-hand/multi-frame landmark shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->