### PR TITLE
feat(app): add global error boundary

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -8,6 +8,7 @@ import { setupDatabase } from './db';
 import { AppServicesProvider } from './src/context/AppServicesProvider';
 import { MessageProvider } from './src/context/MessageContext';
 import { AccessibilityContext, AccessibilitySettings } from './src/components/AccessibilityContext';
+import ErrorBoundary from './src/components/ErrorBoundary';
 import { loadProfile, loadActiveProfileId, setActiveProfileId } from './src/storage';
 import { initGestureModel } from './src/model';
 import RootNavigator from './src/navigation/RootNavigator';
@@ -109,11 +110,13 @@ export default function App() {
                 setAccessibility((prev) => ({ ...prev, ...s })),
             }}
           >
-            <LinearGradient colors={gradientColors} style={styles.gradient}>
-              <NavigationContainer>
-                <RootNavigator />
-              </NavigationContainer>
-            </LinearGradient>
+            <ErrorBoundary>
+              <LinearGradient colors={gradientColors} style={styles.gradient}>
+                <NavigationContainer>
+                  <RootNavigator />
+                </NavigationContainer>
+              </LinearGradient>
+            </ErrorBoundary>
           </AccessibilityContext.Provider>
         </AppServicesProvider>
       </PerformanceProvider>

--- a/app/src/components/ErrorBoundary.tsx
+++ b/app/src/components/ErrorBoundary.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { AccessibilityContext, AccessibilityContextType } from './AccessibilityContext';
+import { SPACING, COLORS, RADIUS } from '../constants/ui';
+import { logger } from '../utils/logger';
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<React.PropsWithChildren<{}>, State> {
+  static contextType = AccessibilityContext;
+  declare context: AccessibilityContextType;
+
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: any, info: any) {
+    logger.error('Uncaught app error:', error, info);
+  }
+
+  reset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      const { largeText, highContrast } = this.context;
+      return (
+        <View
+          style={[
+            styles.container,
+            highContrast && { backgroundColor: COLORS.highContrastBackground },
+          ]}
+        >
+          <Text
+            accessibilityRole="alert"
+            style={[
+              styles.text,
+              {
+                fontSize: largeText ? 22 : 18,
+                color: highContrast ? COLORS.highContrastText : COLORS.text,
+              },
+            ]}
+          >
+            Oops! Something went wrong.
+          </Text>
+          <Pressable
+            onPress={this.reset}
+            accessibilityRole="button"
+            style={[
+              styles.button,
+              {
+                backgroundColor: highContrast
+                  ? COLORS.highContrastText
+                  : COLORS.primaryAccent,
+              },
+            ]}
+          >
+            <Text
+              style={[
+                styles.buttonText,
+                {
+                  fontSize: largeText ? 20 : 16,
+                  color: highContrast
+                    ? COLORS.highContrastBackground
+                    : COLORS.highContrastText,
+                },
+              ]}
+            >
+              Try Again
+            </Text>
+          </Pressable>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: SPACING.lg,
+  },
+  text: {
+    textAlign: 'center',
+    marginBottom: SPACING.md,
+  },
+  button: {
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    borderRadius: RADIUS,
+  },
+  buttonText: {
+    fontWeight: 'bold',
+  },
+});
+

--- a/app/test/errorBoundary.test.tsx
+++ b/app/test/errorBoundary.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import ErrorBoundary from '../src/components/ErrorBoundary';
+import { AccessibilityContext } from '../src/components/AccessibilityContext';
+import { Text } from 'react-native';
+
+jest.mock('react-native', () => {
+  const React = require('react');
+  return {
+    View: (props: any) => React.createElement('View', props, props.children),
+    Text: (props: any) => React.createElement('Text', props, props.children),
+    Pressable: (props: any) => React.createElement('Pressable', props, props.children),
+    StyleSheet: { create: (styles: any) => styles },
+  };
+});
+
+jest.mock('../src/utils/logger', () => ({ logger: { error: jest.fn() } }));
+
+describe('ErrorBoundary', () => {
+  it('shows fallback UI and recovers on retry', () => {
+    const Faulty = ({ boom }: { boom: boolean }) => {
+      if (boom) throw new Error('fail');
+      return <Text>ok</Text>;
+    };
+    let causeError = true;
+    let component: renderer.ReactTestRenderer;
+    const ctx = { largeText: false, highContrast: false, update: () => {} };
+
+    act(() => {
+      component = renderer.create(
+        <AccessibilityContext.Provider value={ctx}>
+          <ErrorBoundary>
+            <Faulty boom={causeError} />
+          </ErrorBoundary>
+        </AccessibilityContext.Provider>,
+      );
+    });
+
+    const texts = (component as renderer.ReactTestRenderer).root.findAllByType('Text');
+    expect(texts.map(t => t.props.children)).toEqual(
+      expect.arrayContaining(['Oops! Something went wrong.', 'Try Again']),
+    );
+
+    causeError = false;
+    act(() => {
+      (component as renderer.ReactTestRenderer).update(
+        <AccessibilityContext.Provider value={ctx}>
+          <ErrorBoundary>
+            <Faulty boom={causeError} />
+          </ErrorBoundary>
+        </AccessibilityContext.Provider>,
+      );
+    });
+
+    const button = (component as renderer.ReactTestRenderer).root.findByType('Pressable');
+    act(() => {
+      button.props.onPress();
+    });
+
+    const finalTexts = (component as renderer.ReactTestRenderer).root.findAllByType('Text');
+    expect(finalTexts.map(t => t.props.children)).toContain('ok');
+  });
+});
+

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -2,7 +2,11 @@
 
 Amy's Echo aims to surface user-friendly messages while capturing technical details for developers. This document describes the standard pattern for dealing with errors in the mobile app.
 
-## 1. Log with the shared logger
+## 1. Global Error Boundary
+
+The app wraps its navigation tree in a shared `ErrorBoundary` (`app/src/components/ErrorBoundary.tsx`). It records unexpected exceptions with the logger and shows a friendly "Try Again" screen so Amy never sees technical details.
+
+## 2. Log with the shared logger
 
 Use the `logger` utility instead of `console.*` to record errors:
 
@@ -18,7 +22,7 @@ try {
 
 The logger automatically filters output by build type and keeps the console consistent.
 
-## 2. Pass errors through callbacks
+## 3. Pass errors through callbacks
 
 Components such as `MediaPipeGestureDetector` accept an `onError` callback. The component invokes the callback whenever the WebView reports a problem, allowing screens to react:
 
@@ -31,7 +35,7 @@ const handleError = (msg: string) => {
 <MediaPipeGestureDetector onGestureDetected={onGestureResult} onError={handleError} />
 ```
 
-## 3. Display a friendly message
+## 4. Display a friendly message
 
 Use the shared `ErrorMessage` component to surface problems to the user. It respects accessibility settings and can be reused on any screen.
 
@@ -41,7 +45,7 @@ import ErrorMessage from '../components/ErrorMessage';
 <ErrorMessage message={processingError} />
 ```
 
-## 4. Reset when recovered
+## 5. Reset when recovered
 
 Clear the error state when the operation succeeds so the UI returns to normal. In gesture recognition, `onGestureResult` resets the `processingError` state when a frame is processed successfully.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,7 +13,7 @@
 
 ### 1.1 User-Friendly Error Shielding
 **Priority: Critical - Child Safety First**
-- **Implement centralized error boundary system**
+- ✅ **Implement centralized error boundary system**
   - Create child-safe error messages with gentle visual feedback
   - Replace all technical errors with age-appropriate responses
   - Add automatic recovery mechanisms that don't require adult intervention


### PR DESCRIPTION
## Summary
- add ErrorBoundary component to log crashes and show a child-friendly retry screen
- wrap navigation tree with ErrorBoundary so uncaught errors surface a "Try Again" message
- document global error boundary and mark related TODO as complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)` *(fails: outdated dependencies)*
- `(cd app && npx expo-doctor)` *(fails: fetch failed)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68a855b06e3c83229ca5e46c398eb4df

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a global error boundary to catch unexpected errors and display a friendly fallback with a “Try Again” action.
  - Fallback UI adapts to accessibility settings (large text and high contrast) for improved usability.
- Tests
  - Added unit tests verifying the fallback appears on errors and that retry restores the app.
- Documentation
  - Added/updated guidance on global error handling, logging practices, error flows, and recovery patterns.
  - Updated TODOs to reflect completion of centralized error boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->