### PR TITLE
feat: show offline indicator banner

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,6 +1,6 @@
 import 'react-native-gesture-handler';
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, Alert, StyleSheet, Platform, ToastAndroid } from 'react-native';
+import { ActivityIndicator, Alert, StyleSheet } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import { NavigationContainer } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -39,13 +39,8 @@ export default function App() {
         logger.info('Database setup complete, initial profile:', profileId);
 
         const netState = await NetInfo.fetch();
-        if (!netState.isConnected) {
+        if (netState.isConnected === false || netState.isInternetReachable === false) {
           setIsOffline(true);
-          if (Platform.OS === 'android') {
-            ToastAndroid.show('Working offline', ToastAndroid.SHORT);
-          } else {
-            Alert.alert('Working offline');
-          }
         }
 
         const activeId = await loadActiveProfileId();
@@ -85,7 +80,7 @@ export default function App() {
 
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener((state) => {
-      setIsOffline(!state.isConnected);
+      setIsOffline(state.isConnected === false || state.isInternetReachable === false);
     });
     return () => unsubscribe();
   }, []);

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -18,6 +18,7 @@ import { initCrashReporting, onAppStartCrashFlush } from './src/services/crashRe
 
 import { PerformanceProvider } from './src/context/PerformanceContext';
 import ChildErrorBoundary from './src/components/ChildErrorBoundary';
+import OfflineBanner from './src/components/OfflineBanner';
 
 export default function App() {
   const [isReady, setIsReady] = useState(false);
@@ -82,6 +83,13 @@ export default function App() {
     initialize();
   }, []);
 
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      setIsOffline(!state.isConnected);
+    });
+    return () => unsubscribe();
+  }, []);
+
   const gradientColors = accessibility.highContrast
     ? [COLORS.highContrastBackground, COLORS.highContrastBackground]
     : [COLORS.backgroundStart, COLORS.backgroundEnd];
@@ -112,6 +120,7 @@ export default function App() {
           >
             <ChildErrorBoundary>
               <LinearGradient colors={gradientColors} style={styles.gradient}>
+                <OfflineBanner visible={isOffline} />
                 <NavigationContainer>
                   <RootNavigator />
                 </NavigationContainer>

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,6 +1,6 @@
 import 'react-native-gesture-handler';
-import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, Alert, StyleSheet } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Alert, StyleSheet, AccessibilityInfo } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import { NavigationContainer } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -38,11 +38,6 @@ export default function App() {
         const profileId = await setupDatabase();
         logger.info('Database setup complete, initial profile:', profileId);
 
-        const netState = await NetInfo.fetch();
-        if (netState.isConnected === false || netState.isInternetReachable === false) {
-          setIsOffline(true);
-        }
-
         const activeId = await loadActiveProfileId();
         if (!activeId) {
           await setActiveProfileId(profileId);
@@ -78,9 +73,17 @@ export default function App() {
     initialize();
   }, []);
 
+  const handledInitial = useRef(false);
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener((state) => {
-      setIsOffline(state.isConnected === false || state.isInternetReachable === false);
+      const offline = state.isConnected === false || state.isInternetReachable === false;
+      setIsOffline(offline);
+      if (!handledInitial.current) {
+        handledInitial.current = true;
+        if (offline) {
+          AccessibilityInfo.announceForAccessibility('Offline mode');
+        }
+      }
     });
     return () => unsubscribe();
   }, []);

--- a/app/src/components/OfflineBanner.tsx
+++ b/app/src/components/OfflineBanner.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { COLORS, SPACING } from '../constants/ui';
+
+interface Props {
+  visible: boolean;
+}
+
+export default function OfflineBanner({ visible }: Props) {
+  if (!visible) return null;
+  return (
+    <View style={styles.container} accessibilityRole="text" accessibilityLabel="Offline mode">
+      <Text style={styles.text}>Offline mode</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: COLORS.warningBackground,
+    padding: SPACING.sm,
+    alignItems: 'center',
+    zIndex: 1,
+  },
+  text: {
+    fontWeight: 'bold',
+  },
+});

--- a/app/src/components/OfflineBanner.tsx
+++ b/app/src/components/OfflineBanner.tsx
@@ -1,16 +1,28 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { COLORS, SPACING } from '../constants/ui';
+import { useAccessibility } from './AccessibilityContext';
 
 interface Props {
   visible: boolean;
 }
 
 export default function OfflineBanner({ visible }: Props) {
+  const { highContrast, largeText } = useAccessibility();
   if (!visible) return null;
   return (
-    <View style={styles.container} accessibilityRole="text" accessibilityLabel="Offline mode">
-      <Text style={styles.text}>Offline mode</Text>
+    <View
+      style={[styles.container, highContrast && styles.containerHC]}
+      pointerEvents="none"
+      accessibilityRole="text"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel="Offline mode"
+    >
+      <Text
+        style={[styles.text, highContrast && styles.textHC, { fontSize: largeText ? 16 : 14 }]}
+      >
+        Offline mode
+      </Text>
     </View>
   );
 }
@@ -26,7 +38,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     zIndex: 1,
   },
+  containerHC: {
+    backgroundColor: COLORS.highContrastBackground,
+  },
   text: {
     fontWeight: 'bold',
+  },
+  textHC: {
+    color: COLORS.highContrastText,
   },
 });

--- a/app/src/components/OfflineBanner.tsx
+++ b/app/src/components/OfflineBanner.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { COLORS, SPACING } from '../constants/ui';
 import { useAccessibility } from './AccessibilityContext';
 
@@ -8,15 +9,19 @@ interface Props {
 }
 
 export default function OfflineBanner({ visible }: Props) {
+  const insets = useSafeAreaInsets();
   const { highContrast, largeText } = useAccessibility();
   if (!visible) return null;
   return (
     <View
-      style={[styles.container, highContrast && styles.containerHC]}
+      style={[
+        styles.container,
+        highContrast && styles.containerHC,
+        { paddingTop: insets.top },
+      ]}
       pointerEvents="none"
-      accessibilityRole="text"
+      accessibilityRole="alert"
       accessibilityLiveRegion="polite"
-      accessibilityLabel="Offline mode"
     >
       <Text
         style={[styles.text, highContrast && styles.textHC, { fontSize: largeText ? 16 : 14 }]}
@@ -34,15 +39,18 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     backgroundColor: COLORS.warningBackground,
-    padding: SPACING.sm,
+    paddingHorizontal: SPACING.sm,
+    paddingBottom: SPACING.sm,
     alignItems: 'center',
     zIndex: 1,
+    elevation: 2,
   },
   containerHC: {
     backgroundColor: COLORS.highContrastBackground,
   },
   text: {
     fontWeight: 'bold',
+    color: COLORS.text,
   },
   textHC: {
     color: COLORS.highContrastText,

--- a/app/test/offlineBanner.test.tsx
+++ b/app/test/offlineBanner.test.tsx
@@ -7,6 +7,10 @@ jest.mock('react-native', () => {
   };
 });
 
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0 }),
+}));
+
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import OfflineBanner from '../src/components/OfflineBanner';
@@ -30,8 +34,11 @@ describe('OfflineBanner', () => {
         </AccessibilityContext.Provider>,
       );
     });
-    const text = (component as renderer.ReactTestRenderer).root.findByType('Text');
+    const tree = component as renderer.ReactTestRenderer;
+    const view = tree.root.findByType('View');
+    const text = tree.root.findByType('Text');
     expect(text.props.children).toBe('Offline mode');
+    expect(view.props.accessibilityRole).toBe('alert');
   });
 
   it('applies high contrast styles', () => {

--- a/app/test/offlineBanner.test.tsx
+++ b/app/test/offlineBanner.test.tsx
@@ -1,0 +1,60 @@
+jest.mock('react-native', () => {
+  const React = require('react');
+  return {
+    View: (props: any) => React.createElement('View', props, props.children),
+    Text: (props: any) => React.createElement('Text', props, props.children),
+    StyleSheet: { create: (styles: any) => styles },
+  };
+});
+
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import OfflineBanner from '../src/components/OfflineBanner';
+import { AccessibilityContext } from '../src/components/AccessibilityContext';
+import { COLORS } from '../src/constants/ui';
+
+describe('OfflineBanner', () => {
+  const providerValue = { highContrast: false, largeText: false, update: () => {} };
+
+  it('renders nothing when not visible', () => {
+    const tree = renderer.create(<OfflineBanner visible={false} />).toJSON();
+    expect(tree).toBeNull();
+  });
+
+  it('renders banner when visible', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <AccessibilityContext.Provider value={providerValue}>
+          <OfflineBanner visible />
+        </AccessibilityContext.Provider>,
+      );
+    });
+    const text = (component as renderer.ReactTestRenderer).root.findByType('Text');
+    expect(text.props.children).toBe('Offline mode');
+  });
+
+  it('applies high contrast styles', () => {
+    const hcValue = { highContrast: true, largeText: true, update: () => {} };
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <AccessibilityContext.Provider value={hcValue}>
+          <OfflineBanner visible />
+        </AccessibilityContext.Provider>,
+      );
+    });
+    const view = (component as renderer.ReactTestRenderer).root.findByType('View');
+    const text = (component as renderer.ReactTestRenderer).root.findByType('Text');
+    expect(view.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: COLORS.highContrastBackground })]),
+    );
+    expect(text.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ color: COLORS.highContrastText }),
+        expect.objectContaining({ fontSize: 16 }),
+      ]),
+    );
+  });
+});
+

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21,11 +21,11 @@
 - **WebView-to-React Native error bridge**
   - Catch MediaPipe failures gracefully in WebView
   - Implement seamless fallback to rule-based classifier
-  - Add visual indicators when offline mode is active (without alarming the child)
+  - ✅ Add visual indicators when offline mode is active (without alarming the child)
 - **Network resilience patterns**
   - Handle server classification timeouts elegantly
   - Implement progressive degradation (server → WebView fallback → encouraging gesture retry)
-  - Add connection status awareness without technical complexity for users
+  - ✅ Add connection status awareness without technical complexity for users
 
 ### 1.2 HIP 4 Proactive Practice Implementation
 **Priority: High - Learning Continuity**


### PR DESCRIPTION
## Summary
- display an OfflineBanner when network is unavailable
- monitor connection changes with NetInfo
- mark offline mode tasks complete in docs/TODO

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)` (fails: Found outdated dependencies)
- `(cd app && npx expo-doctor)` (fails: connect ENETUNREACH)
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68a87263da4883229e0a6bfa63a73886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app Offline banner that appears in real time when connectivity is lost, hides when restored, and announces "Offline mode" once for accessibility.
  * Banner adapts to accessibility settings (high-contrast and large text) and exposes an accessible alert role.

* **Documentation**
  * Marked TODOs complete for offline visual indicators and user-friendly connection status awareness.

* **Tests**
  * Added unit tests validating banner visibility, accessibility role, text, and high-contrast/large-text styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->