### PR TITLE
feat: dual-hand gesture recognition and camera toggle

### DIFF
--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -209,7 +209,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
                 const left = perHand.find(h => /left/i.test(h.hand)) || perHand[0];
                 const right = perHand.find(h => /right/i.test(h.hand)) || perHand[1];
                 if (left && right) {
-                  outGesture = `${left.label}+${right.label}`;
+                  outGesture = left.label + '+' + right.label;
                   outScore = Math.min(left.score, right.score);
                 }
               }

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -19,6 +19,9 @@ import { telemetry } from '../telemetry/recorder';
 import { USE_EXPO_CAMERA } from '../constants';
 import { loadProfile, Profile, logCorrection } from '../storage';
 import { gestureModel, GestureModelEntry } from '../model';
+import { buildLocalCentroids } from '../services/localCentroids';
+import { classifyWithCentroids } from '../services/offlineClassifier';
+import type { CentroidMap } from '../services/dgsModelClient';
 import { LLMSuggestionResponse } from '../services/dialogEngine';
 import MaintenanceBanner from '../components/MaintenanceBanner';
 import { logInteractionEvent } from '../services/analytics';
@@ -61,9 +64,14 @@ export default function RecognitionScreen({ navigation }: any) {
   const seqRef = useRef(new SequenceRecognizer(seqDefsRef.current));
   const uncertainCountRef = useRef(0);
   const lastUncertainAtRef = useRef<number>(0);
+  const centroidsRef = useRef<CentroidMap>({});
 
   useEffect(() => {
     loadProfile().then(setProfile);
+  }, []);
+
+  useEffect(() => {
+    buildLocalCentroids().then((c) => { centroidsRef.current = c; }).catch(() => {});
   }, []);
 
   // Auto-fallback to Expo camera if WebView doesn't start camera within 5 seconds
@@ -112,12 +120,35 @@ export default function RecognitionScreen({ navigation }: any) {
     }).start();
   }, [fadeAnim, symbolScaleAnim]);
 
+  const flattenHands = (hands: number[][][]): number[][] => {
+    const left = hands[0] || [];
+    const right = hands[1] || [];
+    const out: number[][] = [];
+    for (let i = 0; i < 21; i++) {
+      out.push(left[i] ? [...left[i]] : [0, 0, 0]);
+    }
+    for (let i = 0; i < 21; i++) {
+      out.push(right[i] ? [...right[i]] : [0, 0, 0]);
+    }
+    return out;
+  };
+
   const handleGestureDetected = useCallback(async (
     gesture: string,
     confidence: number,
     landmarks: number[][][],
   ) => {
-    const start = Date.now();
+    let g = gesture;
+    let c = confidence;
+
+    if (centroidsRef.current && (!g || c < 0.6)) {
+      const flat = flattenHands(landmarks);
+      const res = classifyWithCentroids(flat, centroidsRef.current);
+      if (res && res.confidence > c) {
+        g = res.label;
+        c = res.confidence;
+      }
+    }
 
     // Helper to apply a classification to UI + logs
     const handleOutcome = async (
@@ -227,8 +258,8 @@ export default function RecognitionScreen({ navigation }: any) {
       }
     };
 
-    // On-device classification only: use provided gesture/confidence from WebView
-    await handleOutcome(gesture, confidence, 'local');
+    // On-device classification only: use provided or locally-classified gesture
+    await handleOutcome(g, c, 'local');
   }, [dialogContext, startFeedbackAnimation, lastRecognizedGesture]);
 
   const handleGestureError = useCallback((errorMessage: string) => {
@@ -325,6 +356,15 @@ export default function RecognitionScreen({ navigation }: any) {
 
   return (
     <SafeAreaView style={styles.container}>
+      <Button
+        title={facingMode === 'user' ? 'Use Back Camera' : 'Use Front Camera'}
+        onPress={() => {
+          const m = facingMode === 'user' ? 'environment' : 'user';
+          setFacingMode(m);
+          setWebviewKey((k) => k + 1);
+        }}
+        accessibilityLabel="Switch camera"
+      />
       <View style={styles.cameraContainer}>
         {
           <MediaPipeGestureDetector

--- a/app/src/services/localCentroids.ts
+++ b/app/src/services/localCentroids.ts
@@ -5,6 +5,19 @@ const TRAINING_KEY = 'gestureTrainingData';
 
 type Frame = number[][][]; // hands -> 21x3
 
+function flattenHands(frame: Frame): number[][] {
+  const left = frame[0] || [];
+  const right = frame[1] || [];
+  const out: number[][] = [];
+  for (let i = 0; i < 21; i++) {
+    out.push(left[i] ? [...left[i]] : [0, 0, 0]);
+  }
+  for (let i = 0; i < 21; i++) {
+    out.push(right[i] ? [...right[i]] : [0, 0, 0]);
+  }
+  return out;
+}
+
 export async function buildLocalCentroids(): Promise<CentroidMap> {
   const raw = await AsyncStorage.getItem(TRAINING_KEY);
   if (!raw) return {};
@@ -17,16 +30,16 @@ export async function buildLocalCentroids(): Promise<CentroidMap> {
     const framesAny = sample.landmarkData as any;
     const frames: Frame[] = Array.isArray(framesAny) ? framesAny : [];
     for (const frame of frames) {
-      const firstHand = Array.isArray(frame?.[0]) ? frame[0] : [];
-      if (!firstHand || firstHand.length < 21) continue;
+      const flat = flattenHands(frame);
+      if (flat.length < 21) continue;
       if (!sums[label]) {
-        sums[label] = { sum: firstHand.map(p => [0,0,0]), count: 0 };
+        sums[label] = { sum: flat.map(() => [0, 0, 0]), count: 0 };
       }
       const s = sums[label];
-      for (let i=0;i<Math.min(21, firstHand.length);i++) {
-        s.sum[i][0] += firstHand[i][0] || 0;
-        s.sum[i][1] += firstHand[i][1] || 0;
-        s.sum[i][2] += firstHand[i][2] || 0;
+      for (let i = 0; i < flat.length; i++) {
+        s.sum[i][0] += flat[i][0] || 0;
+        s.sum[i][1] += flat[i][1] || 0;
+        s.sum[i][2] += flat[i][2] || 0;
       }
       s.count += 1;
     }

--- a/app/src/services/offlineClassifier.ts
+++ b/app/src/services/offlineClassifier.ts
@@ -1,9 +1,22 @@
 import type { CentroidMap } from './dgsModelClient';
 
 function normalize(lm: number[][]): number[][] {
-  if (!lm || lm.length < 21) return lm;
-  const [wx, wy, wz] = lm[0];
-  const pts = lm.map(([x, y, z]) => [x - wx, y - wy, (z ?? 0) - (wz ?? 0)]);
+  if (!lm || lm.length === 0) return lm;
+  const pts = lm.map((p) => [...p]);
+
+  const normalizeHand = (start: number) => {
+    if (pts.length < start + 1) return;
+    const [wx, wy, wz] = pts[start];
+    for (let i = 0; i < 21 && start + i < pts.length; i++) {
+      const [x, y, z] = pts[start + i];
+      pts[start + i] = [x - wx, y - wy, (z ?? 0) - (wz ?? 0)];
+    }
+  };
+
+  // Normalize first hand and second hand (if present) separately
+  normalizeHand(0);
+  if (pts.length >= 42) normalizeHand(21);
+
   let maxd = 0;
   for (const [x, y] of pts) maxd = Math.max(maxd, Math.abs(x) + Math.abs(y));
   const s = maxd || 1;


### PR DESCRIPTION
## Summary
- allow switching between front and back cameras during recognition
- build and use dual-hand centroids for custom gesture detection
- normalize landmarks for two-hand offline classification

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app` *(fails: missing test IDs in RecognitionScreen.test.tsx)*
- `(cd app && npx expo install --check)` *(fails: missing react-dom)*
- `(cd app && npx expo-doctor)` *(fails: network error)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8dff8a88322b69bcccda5720f33