### PR TITLE
Include gesture labels in training sync

### DIFF
--- a/app/src/services/syncService.ts
+++ b/app/src/services/syncService.ts
@@ -53,14 +53,17 @@ export const syncService = {
       logger.info(`Found ${pendingSamples.length} pending training samples.`);
 
       try {
-        const payload = pendingSamples.map((s) => JSON.parse(s.landmarkData));
+        const payload = pendingSamples.map((s) => ({
+          gestureDefinitionId: s.gestureDefinition.id,
+          landmarkData: JSON.parse(s.landmarkData),
+        }));
         const response = await fetch(`${API_URL}/train-model`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${API_TOKEN}`,
           },
-          body: JSON.stringify({ landmarks: payload }),
+          body: JSON.stringify({ samples: payload }),
         });
 
         if (response.ok) {

--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -19,17 +19,21 @@ export async function syncTrainingData(): Promise<void> {
 
   const raw = await AsyncStorage.getItem(TRAINING_KEY);
   const data: TrainingSample[] = raw ? JSON.parse(raw) : [];
-  const pending = data.filter(d => d.syncStatus === 'pending');
+  const pending = data.filter((d) => d.syncStatus === 'pending');
   if (pending.length === 0) return;
   try {
     const token = await loadBackendApiToken();
+    const samples = pending.map((p) => ({
+      gestureDefinitionId: p.gestureDefinitionId,
+      landmarkData: p.landmarkData,
+    }));
     await fetch(`${API_URL}/train-model`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token || ''}`,
       },
-      body: JSON.stringify({ landmarks: pending.map(p => p.landmarkData) }),
+      body: JSON.stringify({ samples }),
     });
     for (const p of pending) p.syncStatus = 'synced';
     await AsyncStorage.setItem(TRAINING_KEY, JSON.stringify(data));

--- a/app/test/trainingSamples.test.ts
+++ b/app/test/trainingSamples.test.ts
@@ -1,0 +1,41 @@
+const store: Record<string, string> = {};
+const stubAsync = {
+  async getItem(key: string) {
+    return store[key] ?? null;
+  },
+  async setItem(key: string, value: string) {
+    store[key] = value;
+  },
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => stubAsync);
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: async () => null,
+  setItemAsync: async () => {},
+}));
+
+const createMock = jest.fn(async (cb: any) => cb({ gestureDefinition: {}, landmarkData: '', source: '', qualityScore: 1, frameMetadata: '', createdAt: new Date(), customSyncStatus: 'pending' }));
+const dbMock = {
+  get: jest.fn(() => ({ create: createMock })),
+  write: jest.fn(async (fn: any) => fn()),
+};
+
+jest.mock('../db', () => ({ database: dbMock }));
+jest.mock('../db/models', () => ({ GestureTrainingData: {} }));
+
+import { saveTrainingSample, loadTrainingSampleCount } from '../src/storage';
+
+describe('training sample persistence', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+    createMock.mockClear();
+  });
+
+  it('saves samples and counts them', async () => {
+    await saveTrainingSample('g1', [1, 2, 3]);
+    await saveTrainingSample('g1', [4, 5, 6]);
+    const count = await loadTrainingSampleCount('g1');
+    expect(count).toBe(2);
+    expect(createMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/test/trainingSync.test.ts
+++ b/app/test/trainingSync.test.ts
@@ -1,0 +1,47 @@
+const store: Record<string, string> = {};
+const stubAsync = {
+  async getItem(key: string) {
+    return store[key] ?? null;
+  },
+  async setItem(key: string, value: string) {
+    store[key] = value;
+  },
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => stubAsync);
+
+jest.mock('@react-native-community/netinfo', () => ({
+  fetch: async () => ({ isConnected: true, isInternetReachable: true, type: 'wifi' }),
+}));
+
+jest.mock('../src/storage', () => ({
+  loadProfile: async () => ({ consentHelpMeGetSmarter: true }),
+  loadBackendApiToken: async () => 'token',
+}));
+
+import { syncTrainingData } from '../src/services/trainingSync';
+
+const TRAINING_KEY = 'gestureTrainingData';
+
+describe('syncTrainingData', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+    (global as any).fetch = jest.fn(async () => ({ ok: true }));
+  });
+
+  it('uploads pending samples with labels', async () => {
+    store[TRAINING_KEY] = JSON.stringify([
+      { id: '1', gestureDefinitionId: 'g1', landmarkData: [1, 2, 3], source: 'HIP_2', syncStatus: 'pending' },
+    ]);
+
+    await syncTrainingData();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.samples[0].gestureDefinitionId).toBe('g1');
+    expect(body.samples[0].landmarkData).toEqual([1, 2, 3]);
+    const updated = JSON.parse(store[TRAINING_KEY]);
+    expect(updated[0].syncStatus).toBe('synced');
+  });
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -147,21 +147,21 @@ Ask the dialog engine for caregiver suggestions.
 ```
 
 ### POST /train-model
-Upload hand landmarks and trigger model training.
+Upload labeled hand landmark samples and trigger model training.
 
 **Body**
 ```json
 {
-  "landmarks": [
-    [[0.1,0.2,0], ...21],
-    [[0.3,0.4,0], ...21]
+  "samples": [
+    { "gestureDefinitionId": "wave", "landmarkData": [[0.1,0.2,0], ...21] },
+    { "gestureDefinitionId": "wave", "landmarkData": [[0.3,0.4,0], ...21] }
   ]
 }
 ```
 
 **Response**
 ```json
-{ "status": "ok" }
+{ "status": "queued", "jobId": "abc123" }
 ```
 
 ### GET /model-version

--- a/integration/test/api.test.js
+++ b/integration/test/api.test.js
@@ -76,7 +76,7 @@ test('POST /train-model invalid payload', async () => {
       'Content-Type': 'application/json',
       Authorization: 'Bearer testtoken',
     },
-    body: JSON.stringify({ landmarks: 'bad' }),
+    body: JSON.stringify({ samples: 'bad' }),
   });
   assert.strictEqual(res.status, 400);
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -615,13 +615,13 @@ app.post('/dialog', auth, dialogLimiter, async (req: Request, res: Response) => 
 });
 
 app.post('/train-model', auth, async (req: Request, res: Response) => {
-  const landmarks = req.body?.landmarks;
-  if (!Array.isArray(landmarks)) {
-    res.status(400).json({ error: 'Invalid landmarks' });
+  const samples = req.body?.samples;
+  if (!Array.isArray(samples)) {
+    res.status(400).json({ error: 'Invalid samples' });
     return;
   }
   const tmp = path.join(process.cwd(), 'tmp_landmarks.json');
-  await fs.writeFile(tmp, JSON.stringify(landmarks));
+  await fs.writeFile(tmp, JSON.stringify(samples));
 
   const id = genId();
   const job: TrainingJob = { id, status: 'queued', progress: 0 };

--- a/server/test/test_train_endpoint.py
+++ b/server/test/test_train_endpoint.py
@@ -1,8 +1,8 @@
-import os
-import json
 import time
 import urllib.request
 import subprocess
+import os
+import json
 from pathlib import Path
 
 SERVER_DIR = Path(__file__).resolve().parents[1]
@@ -49,8 +49,8 @@ def test_train_endpoint(tmp_path):
     proc = start_server()
     try:
         url = f'http://localhost:{PORT}/train-model'
-        landmarks = [[0.0] * 63]
-        data = json.dumps({'landmarks': landmarks}).encode('utf-8')
+        samples = [{"gestureDefinitionId": "g1", "landmarkData": [[0.0] * 63]}]
+        data = json.dumps({'samples': samples}).encode('utf-8')
         headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer testtoken'}
         req = urllib.request.Request(url, data=data, headers=headers)
         with urllib.request.urlopen(req) as resp:


### PR DESCRIPTION
## Summary
- send gestureDefinitionId with training samples when syncing
- update server `/train-model` endpoint to accept labeled samples
- document and test training sample persistence and sync

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app` *(fails: RecognitionScreen tests)*
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: network/unmatched versions)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68a8fabc17f08322a177e8016f964a7e