### PR TITLE
Fix teaching screen sample capture

### DIFF
--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -15,6 +15,8 @@ import { useMessage } from '../context/MessageContext';
 import { logger } from '../utils/logger';
 import { syncTrainingData } from '../services';
 
+const PREVIEW_SIZE = 240;
+
 export default function TeachingScreen({ navigation }: any) {
   const { largeText, highContrast } = useAccessibility();
   // No native camera refs
@@ -44,6 +46,13 @@ export default function TeachingScreen({ navigation }: any) {
         setError('Failed to load profile');
       });
   }, []);
+
+  const handleGestureDetected = useCallback(
+    (_gesture: string | null, _confidence: number, lms: number[][][]) => {
+      landmarksRef.current = lms;
+    },
+    []
+  );
 
   const startSampleCaptureAnimation = useCallback(() => {
     sampleCaptureAnim.setValue(0);
@@ -193,7 +202,7 @@ export default function TeachingScreen({ navigation }: any) {
       ) : (
         <View style={styles.recordingContainer}>
           <View style={styles.camera}>
-            <MediaPipeGestureDetector onGestureDetected={(_g,_c,lms)=>{landmarksRef.current = lms;}} onError={(m)=>setError(m)} />
+            <MediaPipeGestureDetector onGestureDetected={handleGestureDetected} onError={setError} />
           </View>
           <Animated.View style={[
             styles.sampleIndicator,
@@ -263,7 +272,7 @@ const createStyles = (largeText: boolean, highContrast: boolean) =>
       borderRadius: RADIUS,
     },
     recordingContainer: { alignItems: 'center' },
-    camera: { width: 240, height: 240, marginBottom: SPACING.sm, borderRadius: RADIUS, overflow: 'hidden' },
+    camera: { width: PREVIEW_SIZE, height: PREVIEW_SIZE, marginBottom: SPACING.sm, borderRadius: RADIUS, overflow: 'hidden' },
     prompt: { fontSize: largeText ? 22 : 18, marginVertical: SPACING.sm, color: highContrast ? COLORS.highContrastText : COLORS.text },
     progress: { marginBottom: SPACING.sm, color: highContrast ? COLORS.highContrastText : COLORS.text },
     sampleIndicator: {


### PR DESCRIPTION
## Summary
- keep incoming landmark data in a ref during teaching sessions so recording always uses the latest frame

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68a903df34e88322bb90d1f2e50ee7b4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized gesture landmark handling to avoid unnecessary re-renders, yielding smoother interactions, lower latency, and improved stability across devices.
  * Standardized preview sizing for more consistent camera display.
  * No changes to controls, messages, or the existing teaching flow; user-facing behavior remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->