### PR TITLE
Ensure atomic sample writes and correct training payload

### DIFF
--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -30,7 +30,7 @@ export async function syncTrainingData(opts?: SyncProgressOptions): Promise<void
   try {
     const token = await loadBackendApiToken();
     const samples = pending.flatMap((p) =>
-      (p.landmarkData as any[])
+      (p.landmarkData as number[][][][])
         .filter(frameHasAnyLandmarks)
         .map((frame) => ({
           gestureDefinitionId: p.gestureDefinitionId,

--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -4,6 +4,7 @@ import { loadProfile, TrainingSample, loadBackendApiToken } from '../storage';
 import { API_URL } from '../constants';
 import { logger } from '../utils/logger';
 import { fetchCentroids } from './dgsModelClient';
+import { flattenHands, frameHasAnyLandmarks } from './handUtils';
 
 const TRAINING_KEY = 'gestureTrainingData';
 
@@ -28,11 +29,16 @@ export async function syncTrainingData(opts?: SyncProgressOptions): Promise<void
   if (pending.length === 0) return;
   try {
     const token = await loadBackendApiToken();
-    const samples = pending.map((p) => ({
-      gestureDefinitionId: p.gestureDefinitionId,
-      landmarkData: p.landmarkData,
-      profileId: profile?.id,
-    }));
+    const samples = pending.flatMap((p) =>
+      (p.landmarkData as any[])
+        .filter(frameHasAnyLandmarks)
+        .map((frame) => ({
+          gestureDefinitionId: p.gestureDefinitionId,
+          landmarkData: flattenHands(frame),
+          profileId: profile?.id,
+        })),
+    );
+    if (samples.length === 0) return;
     const response = await fetch(`${API_URL}/train-model`, {
       method: 'POST',
       headers: {

--- a/app/test/trainingSync.test.ts
+++ b/app/test/trainingSync.test.ts
@@ -3,11 +3,16 @@ jest.mock('@react-native-community/netinfo', () => ({
 }));
 
 jest.mock('../src/storage', () => ({
-  loadProfile: async () => ({ consentHelpMeGetSmarter: true }),
+  loadProfile: async () => ({ consentHelpMeGetSmarter: true, id: 'amy' }),
   loadBackendApiToken: async () => 'token',
 }));
 
+jest.mock('../src/services/dgsModelClient', () => ({
+  fetchCentroids: jest.fn(async () => null),
+}));
+
 import { syncTrainingData } from '../src/services/trainingSync';
+import { fetchCentroids } from '../src/services/dgsModelClient';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const TRAINING_KEY = 'gestureTrainingData';
@@ -15,7 +20,12 @@ const TRAINING_KEY = 'gestureTrainingData';
 describe('syncTrainingData', () => {
   beforeEach(() => {
     (AsyncStorage as any).clear();
-    (global as any).fetch = jest.fn(async () => ({ ok: true }));
+    (global as any).fetch = jest.fn(async (url: string) => {
+      if (url.includes('/train-model')) {
+        return { ok: true, json: async () => ({ jobId: '1' }) } as any;
+      }
+      return { ok: true, json: async () => ({ status: 'completed', progress: 100 }) } as any;
+    });
   });
 
   it('uploads pending samples with labels', async () => {
@@ -39,12 +49,14 @@ describe('syncTrainingData', () => {
 
     await syncTrainingData();
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
     const [, options] = (global.fetch as jest.Mock).mock.calls[0];
     const body = JSON.parse(options.body);
     expect(body.samples[0].gestureDefinitionId).toBe('g1');
     expect(body.samples[0].landmarkData[0]).toEqual([1, 2, 3]);
     expect(body.samples[0].landmarkData).toHaveLength(42);
+    expect(body.samples[0].profileId).toBe('amy');
+    expect(fetchCentroids).toHaveBeenCalledWith('amy');
     const updated = JSON.parse((await AsyncStorage.getItem(TRAINING_KEY))!);
     expect(updated[0].syncStatus).toBe('synced');
   });

--- a/app/test/trainingSync.test.ts
+++ b/app/test/trainingSync.test.ts
@@ -22,7 +22,18 @@ describe('syncTrainingData', () => {
     await AsyncStorage.setItem(
       TRAINING_KEY,
       JSON.stringify([
-        { id: '1', gestureDefinitionId: 'g1', landmarkData: [1, 2, 3], source: 'HIP_2', syncStatus: 'pending' },
+        {
+          id: '1',
+          gestureDefinitionId: 'g1',
+          landmarkData: [
+            [
+              [[1, 2, 3]],
+              [],
+            ],
+          ],
+          source: 'HIP_2',
+          syncStatus: 'pending',
+        },
       ]),
     );
 
@@ -32,7 +43,8 @@ describe('syncTrainingData', () => {
     const [, options] = (global.fetch as jest.Mock).mock.calls[0];
     const body = JSON.parse(options.body);
     expect(body.samples[0].gestureDefinitionId).toBe('g1');
-    expect(body.samples[0].landmarkData).toEqual([1, 2, 3]);
+    expect(body.samples[0].landmarkData[0]).toEqual([1, 2, 3]);
+    expect(body.samples[0].landmarkData).toHaveLength(42);
     const updated = JSON.parse((await AsyncStorage.getItem(TRAINING_KEY))!);
     expect(updated[0].syncStatus).toBe('synced');
   });

--- a/integration/test/api.test.js
+++ b/integration/test/api.test.js
@@ -85,13 +85,14 @@ test('POST /train-model invalid sample items', async () => {
 });
 
 test('POST /train-model processes samples and returns model', async () => {
+  const sample = { gestureDefinitionId: 'g1', landmarkData: Array.from({ length: 42 }, () => [0, 0, 0]), profileId: 'p1' };
   const res = await fetch(`http://localhost:${PORT}/train-model`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: 'Bearer testtoken',
     },
-    body: JSON.stringify({ samples: [{ gestureDefinitionId: 'g1', landmarkData: Array.from({ length: 42 }, () => [0, 0, 0]) }] }),
+    body: JSON.stringify({ samples: [sample] }),
   });
   assert.strictEqual(res.status, 202);
   const { jobId } = await res.json();
@@ -118,6 +119,11 @@ test('POST /train-model processes samples and returns model', async () => {
   assert.strictEqual(json.type, 'centroid_model');
   assert.ok(json.centroids && typeof json.centroids === 'object');
   assert.ok(json.counts && typeof json.counts === 'object');
+
+  const profileRes = await fetch(`http://localhost:${PORT}/api/v1/dgs/model?profileId=p1`, { headers });
+  assert.strictEqual(profileRes.status, 200);
+  const profileModel = await profileRes.json();
+  assert.strictEqual(profileModel.counts.g1, 1);
 });
 
 test('GET /model-version returns version and path', async () => {

--- a/integration/test/api.test.js
+++ b/integration/test/api.test.js
@@ -91,7 +91,7 @@ test('POST /train-model processes samples and returns model', async () => {
       'Content-Type': 'application/json',
       Authorization: 'Bearer testtoken',
     },
-    body: JSON.stringify({ samples: [{ gestureDefinitionId: 'g1', landmarkData: Array.from({ length: 21 }, () => [0, 0, 0]) }] }),
+    body: JSON.stringify({ samples: [{ gestureDefinitionId: 'g1', landmarkData: Array.from({ length: 42 }, () => [0, 0, 0]) }] }),
   });
   assert.strictEqual(res.status, 202);
   const { jobId } = await res.json();

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -356,20 +356,21 @@ app.post('/api/v1/dgs/samples', auth, async (req: Request, res: Response) => {
     const Body = z.object({
       label: z.string().min(1),
       profileId: z.string().optional(),
-      // exactly 21 points of [x,y,z] in [0,1]
+      // exactly 42 points of [x,y,z] in [0,1]
       landmarks: z
         .array(z.tuple([z.number().finite(), z.number().finite(), z.number().finite()]))
         .length(42)
         .refine(
-          (pts) => pts.every(([x, y, z]) => x >= 0 && x <= 1 && y >= 0 && y <= 1 && Number.isFinite(z)),
-          'landmarks must be 21 points of [x,y,z] within [0,1] for x,y',
+          (pts: [number, number, number][]) =>
+            pts.every(([x, y, z]: [number, number, number]) => x >= 0 && x <= 1 && y >= 0 && y <= 1 && Number.isFinite(z)),
+          'landmarks must be 42 points of [x,y,z] within [0,1] for x,y',
         ),
     });
     const parsed = Body.safeParse(req.body);
     if (!parsed.success) {
       return res
         .status(400)
-        .json({ error: 'label and landmarks (21 × [x,y,z]) required', details: parsed.error.flatten() });
+        .json({ error: 'label and landmarks (42 × [x,y,z]) required', details: parsed.error.flatten() });
     }
     const { label, profileId, landmarks } = parsed.data;
     const dataPath = path.join(DATA_DIR, 'dgs_samples.json');
@@ -525,7 +526,9 @@ app.post('/train-model', auth, async (req: Request, res: Response) => {
           data.samples.push(s);
           job.progress = Math.round(((idx + 1) / total) * 50);
         });
-        await fs.writeFile(dataPath, JSON.stringify(data, null, 2));
+        const tmp = `${dataPath}.tmp`;
+        await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+        await fs.rename(tmp, dataPath);
       });
 
       // Compute centroids (global) and publish as the trained model

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -379,9 +379,13 @@ app.post('/api/v1/dgs/samples', auth, async (req: Request, res: Response) => {
         const raw = await fs.readFile(dataPath, 'utf8');
         data = JSON.parse(raw);
         if (!Array.isArray(data.samples)) data.samples = [];
-      } catch {}
+      } catch (err: any) {
+        if (err?.code !== 'ENOENT') throw err;
+      }
       data.samples.push({ id: genId(), label, profileId, landmarks, ts: Date.now() });
-      await fs.writeFile(dataPath, JSON.stringify(data, null, 2));
+      const tmp = `${dataPath}.tmp`;
+      await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+      await fs.rename(tmp, dataPath);
     });
     res.json({ status: 'ok' });
   } catch (e) {


### PR DESCRIPTION
## Summary
- Write `dgs_samples.json` atomically using temp file + rename
- Flatten training sample frames into per-frame payloads using `flattenHands`
- Update tests and integration expectations for 42-point landmarks

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `cd app && npx expo install --check`
- `cd app && npx expo-doctor` *(fails: fetch failed / outdated dependencies)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68aafc5fae7483228aff9ccebf71a8c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Generate training samples per frame instead of per item, increasing coverage and enabling richer datasets.
  - Skip syncing when no valid frames are present, avoiding unnecessary API calls.

- Bug Fixes
  - Improved server reliability with atomic writes to prevent partial data.
  - Tightened error handling to avoid silently masking unexpected file read errors.

- Tests
  - Updated unit and integration tests to reflect per-frame samples and increased landmark counts.
  - Adjusted payload expectations and assertions to match the new data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->