### PR TITLE
feat: add DGS video toggle

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -362,8 +362,8 @@ export default function RecognitionScreen({ navigation }: any) {
       position: 'absolute',
       top: SPACING.md,
       right: SPACING.md,
-      width: 160,
-      height: 160,
+      width: SPACING.md * 10,
+      height: SPACING.md * 10,
     },
     toggleRow: {
       flexDirection: 'row',

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -6,7 +6,8 @@ import {
   SafeAreaView,
   Animated,
   Easing,
-  Button
+  Button,
+  Switch,
 } from 'react-native';
 import { useAccessibility } from '../components/AccessibilityContext';
 import { MediaPipeGestureDetector } from '../components/MediaPipeGestureDetector';
@@ -33,6 +34,7 @@ import { shouldPromptPractice } from '../services/healthScore';
 import { OneEuroFilter } from '../services/OneEuroFilter';
 import { SequenceRecognizer, SequenceDefinition } from '../services/sequenceRecognizer';
 import { RecognitionPath } from '../utils/recognitionState';
+import DgsVideoPlayer from '../components/DgsVideoPlayer';
 // ExpoCameraDetector removed from default path (server-based); WebView is primary
 
 export default function RecognitionScreen({ navigation }: any) {
@@ -58,6 +60,7 @@ export default function RecognitionScreen({ navigation }: any) {
   const [cameraType, setCameraType] = useState<'front' | 'back'>('front');
   const [webviewKey, setWebviewKey] = useState(0);
   const [recognitionPath, setRecognitionPath] = useState<RecognitionPath>('local');
+  const [showDgsVideo, setShowDgsVideo] = useState(false);
 
   const fadeAnim = useRef(new Animated.Value(1)).current;
   const symbolScaleAnim = useRef(new Animated.Value(0)).current;
@@ -355,6 +358,24 @@ export default function RecognitionScreen({ navigation }: any) {
       marginBottom: SPACING.sm,
       color: '#fff',
     },
+    videoOverlay: {
+      position: 'absolute',
+      top: SPACING.md,
+      right: SPACING.md,
+      width: 160,
+      height: 160,
+    },
+    toggleRow: {
+      flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: SPACING.md,
+    },
+    toggleLabel: {
+      marginRight: SPACING.sm,
+      color: COLORS.text,
+      fontSize: largeText ? 18 : 16,
+    },
   });
 
   return (
@@ -386,20 +407,29 @@ export default function RecognitionScreen({ navigation }: any) {
           </View>
         )}
 
-        {!error && !showCorrection && lastRecognizedGesture && (
-          <Animated.View style={[styles.gestureInfo, { opacity: fadeAnim }]}> 
-            <Animated.Text style={[styles.symbolDisplay, { transform: [{ scale: symbolScaleAnim }] }]}> 
-              {lastRecognizedGesture.label} 
-            </Animated.Text> 
-            <Text style={styles.gestureText}>{(gestureConfidence * 100).toFixed(0)}%</Text>
-            <Text style={styles.confidenceText}>via {recognitionPath}</Text>
-          </Animated.View>
-        )}
-      </View>
+      {!error && !showCorrection && lastRecognizedGesture && (
+        <Animated.View style={[styles.gestureInfo, { opacity: fadeAnim }]}> 
+          <Animated.Text style={[styles.symbolDisplay, { transform: [{ scale: symbolScaleAnim }] }]}> 
+            {lastRecognizedGesture.label}
+          </Animated.Text>
+          <Text style={styles.gestureText}>{(gestureConfidence * 100).toFixed(0)}%</Text>
+          <Text style={styles.confidenceText}>via {recognitionPath}</Text>
+        </Animated.View>
+      )}
 
-      {showCorrection && (
-        <CorrectionPanel
-          onSelect={handleSelectCorrection}
+      {showDgsVideo && lastRecognizedGesture?.dgsVideoUri && (
+        <View style={styles.videoOverlay}>
+          <DgsVideoPlayer
+            videoSource={{ uri: lastRecognizedGesture.dgsVideoUri }}
+            shouldPlay={true}
+          />
+        </View>
+      )}
+    </View>
+
+    {showCorrection && (
+      <CorrectionPanel
+        onSelect={handleSelectCorrection}
           onAddNew={() => {
             setShowCorrection(false);
             navigation.navigate('Teaching');
@@ -418,15 +448,24 @@ export default function RecognitionScreen({ navigation }: any) {
           accessibilityLabel="Open correction screen"
           onPress={() => navigation.navigate('Correction')}
         />
-        <Button
-          testID="btn-help-me-choose"
-          title="Help Me Choose"
-          accessibilityLabel="Open help me choose"
-          onPress={() => setShowCorrection(true)}
-        />
-      </View>
+      <Button
+        testID="btn-help-me-choose"
+        title="Help Me Choose"
+        accessibilityLabel="Open help me choose"
+        onPress={() => setShowCorrection(true)}
+      />
+    </View>
 
-      <BottomNav active="recognition" profileId={profile?.id || 'default'} />
-    </SafeAreaView>
-  );
+    <View style={styles.toggleRow}>
+      <Text style={styles.toggleLabel}>Show DGS Video</Text>
+      <Switch
+        value={showDgsVideo}
+        onValueChange={setShowDgsVideo}
+        accessibilityLabel="Toggle DGS video"
+      />
+    </View>
+
+    <BottomNav active="recognition" profileId={profile?.id || 'default'} />
+  </SafeAreaView>
+);
 }

--- a/app/test/recognitionDebugOverlay.test.tsx
+++ b/app/test/recognitionDebugOverlay.test.tsx
@@ -53,6 +53,7 @@ jest.mock('../src/utils/landmarkMapping', () => ({ mapToPreview: (p: any) => ({ 
 
 jest.mock('../src/components/BottomNav', () => () => React.createElement('BottomNav'));
 jest.mock('../src/components/SymbolVideoPlayer', () => () => React.createElement('SymbolVideoPlayer'));
+jest.mock('../src/components/DgsVideoPlayer', () => () => React.createElement('DgsVideoPlayer'));
 jest.mock('../src/components/CorrectionPanel', () => () => React.createElement('CorrectionPanel'));
 jest.mock('react-native-svg', () => ({
   __esModule: true,

--- a/app/test/screens/RecognitionScreen.test.tsx
+++ b/app/test/screens/RecognitionScreen.test.tsx
@@ -7,6 +7,7 @@ jest.mock('react-native', () => {
     View: (props: any) => React.createElement('View', props, props.children),
     Text: (props: any) => React.createElement('Text', props, props.children),
     Button: (props: any) => React.createElement('Button', props, props.children),
+    Switch: (props: any) => React.createElement('Switch', props, props.children),
     SafeAreaView: (props: any) => React.createElement('SafeAreaView', props, props.children),
     StyleSheet: { create: (s: any) => s },
     Animated: {
@@ -22,9 +23,12 @@ jest.mock('react-native', () => {
 
 import RecognitionScreen from '../../src/screens/RecognitionScreen';
 
-jest.mock('../../src/components/MediaPipeGestureDetector', () => ({
-  MediaPipeGestureDetector: () => null,
-}));
+jest.mock('../../src/components/MediaPipeGestureDetector', () => {
+  const React = require('react');
+  return {
+    MediaPipeGestureDetector: (props: any) => React.createElement('MediaPipeGestureDetector', props, null),
+  };
+});
 jest.mock('../../src/components/BottomNav', () => () => null);
 jest.mock('../../src/components/AccessibilityContext', () => ({
   useAccessibility: () => ({ largeText: false }),
@@ -33,6 +37,11 @@ jest.mock('../../src/components/CorrectionPanel', () => {
   const React = require('react');
   return (props: any) => React.createElement('CorrectionPanel', props, null);
 });
+jest.mock('../../src/components/DgsVideoPlayer', () => {
+  const React = require('react');
+  return (props: any) => React.createElement('DgsVideoPlayer', props, null);
+});
+jest.mock('expo-haptics', () => ({ impactAsync: jest.fn(), ImpactFeedbackStyle: { Medium: 'Medium' } }));
 jest.mock('../../src/services', () => ({
   audioService: { speak: jest.fn(), playEncouragement: jest.fn(), playSuccessFeedback: jest.fn() },
   triggerSpeakAndShow: jest.fn(),
@@ -47,7 +56,7 @@ jest.mock('../../src/storage', () => ({
   logCorrection: jest.fn(),
 }));
 jest.mock('../../src/model', () => ({
-  gestureModel: { gestures: [] },
+  gestureModel: { gestures: [{ id: 'hello', label: 'Hello', dgsVideoUri: 'video.mp4' }] },
 }));
 jest.mock('../../src/services/HybridRecognizer', () => ({
   useHybridFrameProcessor: () => undefined,
@@ -91,5 +100,22 @@ describe('RecognitionScreen', () => {
     });
     const button = component.root.findByProps({ testID: 'btn-correction' });
     expect(button.props.accessibilityLabel).toBe('Open correction screen');
+  });
+
+  it('shows DGS video when toggle enabled and gesture recognized', async () => {
+    let component!: renderer.ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<RecognitionScreen navigation={{ navigate: jest.fn() }} />);
+    });
+    const toggle = component.root.findByProps({ accessibilityLabel: 'Toggle DGS video' });
+    act(() => {
+      toggle.props.onValueChange(true);
+    });
+    const detector = component.root.findByType('MediaPipeGestureDetector');
+    await act(async () => {
+      detector.props.onGestureDetected('hello', 0.9, []);
+    });
+    const vids = component.root.findAllByType('DgsVideoPlayer');
+    expect(vids.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- allow staff to toggle DGS reference videos during gesture recognition
- overlay DGS videos for last recognized gesture
- test DGS video toggle behavior

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` (fails: fetch failed)
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ab2dbbfcc88322bf5c6a08a9a33728