### PR TITLE
feat: track per-gesture success metrics

### DIFF
--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -20,6 +20,12 @@ export interface InteractionLog {
   caregiverOverrideId?: string;
 }
 
+export interface GestureStats {
+  gestureDefinitionId: string;
+  successCount: number;
+  failureCount: number;
+}
+
 function genId(): string {
   return (
     Date.now().toString(36) + Math.random().toString(36).slice(2)
@@ -56,6 +62,24 @@ export async function loadAnalytics(): Promise<LearningAnalytics> {
     successRate7d: Number(success.toFixed(2)),
     improvementTrend: Number(improvement.toFixed(2)),
   };
+}
+
+export async function getGestureStats(): Promise<GestureStats[]> {
+  const raw = await AsyncStorage.getItem(LOG_KEY);
+  const logs: InteractionLog[] = raw ? JSON.parse(raw) : [];
+  const map: Record<string, { success: number; failure: number }> = {};
+
+  for (const log of logs) {
+    const entry = map[log.gestureDefinitionId] || { success: 0, failure: 0 };
+    if (log.wasSuccessful) entry.success += 1; else entry.failure += 1;
+    map[log.gestureDefinitionId] = entry;
+  }
+
+  return Object.entries(map).map(([gestureDefinitionId, { success, failure }]) => ({
+    gestureDefinitionId,
+    successCount: success,
+    failureCount: failure,
+  }));
 }
 
 export async function uploadAnalytics(

--- a/app/test/gestureStats.test.ts
+++ b/app/test/gestureStats.test.ts
@@ -1,0 +1,47 @@
+const store: Record<string, string> = {};
+const stub = {
+  async getItem(key: string) { return store[key] ?? null; },
+  async setItem(key: string, value: string) { store[key] = value; },
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => stub);
+
+import { logInteractionEvent, getGestureStats } from '../src/services/analytics';
+
+describe('gesture success/failure stats', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(store)) delete store[key];
+  });
+
+  it('aggregates success and failure counts per gesture', async () => {
+    const now = Date.now();
+    await logInteractionEvent({
+      gestureDefinitionId: 'g1',
+      gestureName: 'G1',
+      wasSuccessful: true,
+      confidenceScore: 0.9,
+      timestamp: now,
+      processedBy: 'local',
+    });
+    await logInteractionEvent({
+      gestureDefinitionId: 'g1',
+      gestureName: 'G1',
+      wasSuccessful: false,
+      confidenceScore: 0.2,
+      timestamp: now + 1,
+      processedBy: 'cloud',
+    });
+    await logInteractionEvent({
+      gestureDefinitionId: 'g2',
+      gestureName: 'G2',
+      wasSuccessful: true,
+      confidenceScore: 0.8,
+      timestamp: now + 2,
+      processedBy: 'local',
+    });
+
+    const stats = await getGestureStats();
+    expect(stats).toContainEqual({ gestureDefinitionId: 'g1', successCount: 1, failureCount: 1 });
+    expect(stats).toContainEqual({ gestureDefinitionId: 'g2', successCount: 1, failureCount: 0 });
+  });
+});

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -57,7 +57,7 @@ Troubleshooting
 **Priority: Medium - Data-Driven Improvements**
 - **HIP event tracking system**
   - ✅ Log key interactions across HIP 1-4 workflows (onboarding, practice samples, correction open/submit)
-  - Track gesture recognition success/failure patterns
+  - ✅ Track gesture recognition success/failure patterns
   - ✅ Monitor practice session completion (local logs) and engagement (sessions)
   - ✅ Privacy-compliant telemetry upload (buffered, best-effort, token auth)
 - **Health score trend analysis**


### PR DESCRIPTION
## Summary
- add `getGestureStats` to compute per-gesture success/failure counts
- record gesture stats unit test
- mark telemetry TODO for gesture stats complete

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` (failed: 4 checks failed, directory check fetch failed, found outdated dependencies)
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ab2fd43b948322b46fc18e620d4d81