### PR TITLE
feat: allow scheduling practice days

### DIFF
--- a/app/src/screens/PracticeSchedulerScreen.tsx
+++ b/app/src/screens/PracticeSchedulerScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, StyleSheet, FlatList, TextInput, Switch } from 'react-native';
+import { View, Text, Button, StyleSheet, FlatList, TextInput, Switch, Pressable } from 'react-native';
 import { useAccessibility } from '../components/AccessibilityContext';
 import { COLORS, SPACING } from '../constants/ui';
 import { addSchedule, listSchedules, removeSchedule, setScheduleEnabled, PracticeSchedule } from '../services/practiceScheduler';
@@ -11,6 +11,9 @@ export default function PracticeSchedulerScreen({ navigation }: any) {
   const [gestureId, setGestureId] = useState(gestureModel.gestures[0]?.id || 'hello');
   const [hour, setHour] = useState('17');
   const [minute, setMinute] = useState('0');
+  const [days, setDays] = useState<number[]>([]);
+
+  const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   const load = async () => {
     setSchedules(await listSchedules());
@@ -27,6 +30,16 @@ export default function PracticeSchedulerScreen({ navigation }: any) {
     label: { color: highContrast ? COLORS.highContrastText : COLORS.text, marginRight: SPACING.sm },
     input: { borderWidth: 1, padding: SPACING.xs, minWidth: 50, backgroundColor: COLORS.backgroundStart, color: COLORS.text, marginRight: SPACING.sm },
     listItem: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingVertical: SPACING.xs },
+    dayButton: {
+      padding: SPACING.xs,
+      marginRight: SPACING.xs,
+      borderWidth: 1,
+      borderRadius: 4,
+      borderColor: COLORS.primaryAccent,
+      backgroundColor: COLORS.surface,
+    },
+    dayButtonSelected: { backgroundColor: COLORS.primaryAccent },
+    dayButtonText: { color: highContrast ? COLORS.highContrastText : COLORS.text },
   });
 
   return (
@@ -52,9 +65,34 @@ export default function PracticeSchedulerScreen({ navigation }: any) {
         <Button title="Add" onPress={async () => {
           const h = Math.max(0, Math.min(23, parseInt(hour || '0', 10)));
           const m = Math.max(0, Math.min(59, parseInt(minute || '0', 10)));
-          await addSchedule({ gestureId, hour: h, minute: m, daysOfWeek: [], enabled: true } as any);
+          await addSchedule({ gestureId, hour: h, minute: m, daysOfWeek: days, enabled: true } as any);
+          setDays([]);
           await load();
         }} accessibilityLabel="Add schedule" />
+      </View>
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Days</Text>
+        <FlatList
+          data={dayLabels}
+          horizontal
+          keyExtractor={(d) => d}
+          renderItem={({ item, index }) => (
+            <Pressable
+              onPress={() =>
+                setDays((prev) =>
+                  prev.includes(index) ? prev.filter((d) => d !== index) : [...prev, index],
+                )
+              }
+              style={[styles.dayButton, days.includes(index) && styles.dayButtonSelected]}
+              accessibilityLabel={item}
+              accessibilityState={{ selected: days.includes(index) }}
+            >
+              <Text style={styles.dayButtonText}>{item}</Text>
+            </Pressable>
+          )}
+          style={{ maxHeight: 44 }}
+        />
       </View>
 
       <FlatList
@@ -62,7 +100,12 @@ export default function PracticeSchedulerScreen({ navigation }: any) {
         keyExtractor={(s) => s.id}
         renderItem={({ item }) => (
           <View style={styles.listItem}>
-            <Text style={styles.label}>{item.gestureId} @ {String(item.hour).padStart(2, '0')}:{String(item.minute).padStart(2, '0')}</Text>
+            <Text style={styles.label}>
+              {item.gestureId} @ {String(item.hour).padStart(2, '0')}:{String(item.minute).padStart(2, '0')} (
+              {item.daysOfWeek && item.daysOfWeek.length
+                ? item.daysOfWeek.map((d) => dayLabels[d]).join(',')
+                : 'daily'})
+            </Text>
             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
               <Switch value={item.enabled} onValueChange={async (v) => { await setScheduleEnabled(item.id, v); await load(); }} />
               <Button title="Delete" onPress={async () => { await removeSchedule(item.id); await load(); }} accessibilityLabel="Delete schedule" />

--- a/app/test/practiceScheduler.test.ts
+++ b/app/test/practiceScheduler.test.ts
@@ -1,0 +1,34 @@
+const store: Record<string, string> = {};
+const stubAsync = {
+  async getItem(key: string) {
+    return store[key] ?? null;
+  },
+  async setItem(key: string, value: string) {
+    store[key] = value;
+  },
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => stubAsync);
+
+import { addSchedule, listSchedules, getDueGesture } from '../src/services/practiceScheduler';
+
+beforeEach(() => {
+  for (const k of Object.keys(store)) delete store[k];
+});
+
+describe('practiceScheduler', () => {
+  it('adds and lists schedules with selected days', async () => {
+    await addSchedule({ gestureId: 'hello', hour: 9, minute: 30, daysOfWeek: [1, 3] } as any);
+    const all = await listSchedules();
+    expect(all).toHaveLength(1);
+    expect(all[0].daysOfWeek).toEqual([1, 3]);
+  });
+
+  it('getDueGesture respects day of week', async () => {
+    await addSchedule({ gestureId: 'hello', hour: 9, minute: 30, daysOfWeek: [2] } as any); // Tuesday
+    const tuesday = new Date(Date.UTC(2023, 8, 12, 9, 30)); // Tue
+    const wednesday = new Date(Date.UTC(2023, 8, 13, 9, 30)); // Wed
+    expect(await getDueGesture(tuesday)).toBe('hello');
+    expect(await getDueGesture(wednesday)).toBeNull();
+  });
+});

--- a/docs/CaregiverGuide.md
+++ b/docs/CaregiverGuide.md
@@ -23,6 +23,7 @@ This guide helps caregivers set up and use **Amy's Echo** with a child who commu
 ## Review and Practice
 - Practice banners occasionally appear to rehearse signs. Tap to begin a guided practice session.
 - Each correction and practice improves future recognition automatically.
+- For recurring reminders, open the **Practice Scheduler** from the Parent area to choose days and times for sessions.
 
 ## Tips
 - The app logs corrections and training data; avoid sharing the device without supervision.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -45,7 +45,7 @@ Troubleshooting
 - **Health score-based practice prompts**
   - ✅ Design non-blocking banner UI for practice suggestions
   - ✅ Implement gentle nudges when gesture `healthScore` falls below threshold
-  - Implement caregiver-friendly scheduling for practice sessions
+  - ✅ Implement caregiver-friendly scheduling for practice sessions
   - ✅ Add simple gamification (celebration feedback) after sessions
 - **Practice session workflow**
   - ✅ Build guided practice interface with immediate feedback


### PR DESCRIPTION
## Summary
- add day-of-week selection to Practice Scheduler and show selected days
- document caregiver scheduling workflow and mark task complete
- test practiceScheduler for day-of-week logic

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `npx expo install --check`
- `npx expo-doctor` *(fails: connect ENETUNREACH)*
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ab30d4eff0832286f6ac2add0a9391