### PR TITLE
Fix training endpoint test for centroid model

### DIFF
--- a/server/test/test_train_endpoint.py
+++ b/server/test/test_train_endpoint.py
@@ -51,7 +51,7 @@ def test_train_endpoint(tmp_path):
         url = f'http://localhost:{PORT}/train-model'
         samples = [{
             "gestureDefinitionId": "g1",
-            "landmarkData": [[0.0, 0.0, 0.0]] * 42,
+            "landmarkData": [[0.0, 0.0, 0.0] for _ in range(42)],
         }]
         data = json.dumps({'samples': samples}).encode('utf-8')
         headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer testtoken'}

--- a/server/test/test_train_endpoint.py
+++ b/server/test/test_train_endpoint.py
@@ -85,7 +85,7 @@ def test_train_endpoint(tmp_path):
             assert model.get("type") == "centroid_model"
             assert "g1" in model.get("centroids", {})
             assert len(model["centroids"]["g1"]) == 42
-            assert model["counts"].get("g1") == 1
+            assert model.get("counts", {}).get("g1") == 1
     finally:
         stop_server(proc)
         # cleanup produced model

--- a/server/test/test_train_endpoint.py
+++ b/server/test/test_train_endpoint.py
@@ -49,7 +49,10 @@ def test_train_endpoint(tmp_path):
     proc = start_server()
     try:
         url = f'http://localhost:{PORT}/train-model'
-        samples = [{"gestureDefinitionId": "g1", "landmarkData": [[0.0] * 63]}]
+        samples = [{
+            "gestureDefinitionId": "g1",
+            "landmarkData": [[0.0, 0.0, 0.0]] * 42,
+        }]
         data = json.dumps({'samples': samples}).encode('utf-8')
         headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer testtoken'}
         req = urllib.request.Request(url, data=data, headers=headers)
@@ -78,8 +81,11 @@ def test_train_endpoint(tmp_path):
         )
         with urllib.request.urlopen(model_req) as mresp:
             assert mresp.getcode() == 200
-            data = json.loads(mresp.read().decode())
-            assert data == {"mock": True}
+            model = json.loads(mresp.read().decode())
+            assert model.get("type") == "centroid_model"
+            assert "g1" in model.get("centroids", {})
+            assert len(model["centroids"]["g1"]) == 42
+            assert model["counts"].get("g1") == 1
     finally:
         stop_server(proc)
         # cleanup produced model


### PR DESCRIPTION
## Summary
- update server test to match centroid-based training output

## Testing
- `pip install -r server/requirements.txt`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68ab63dced788322af2cf48069a6f965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated /train-model endpoint tests to use gesture data as 3D landmarks and validate a structured centroid-based model response (including centroids and counts for “g1”).
  - Maintains HTTP 200 checks while strengthening assertions on the returned model structure, improving reliability and confidence in training results without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->