### PR TITLE
docs: add startup steps for server and app

### DIFF
--- a/docs/BUILD_AND_TEST.md
+++ b/docs/BUILD_AND_TEST.md
@@ -29,6 +29,27 @@ npm test
 
 If all tests pass, you should see a success message in the console. This indicates that the core functionality of the application is working as expected.
 
+## Running the Server and App
+
+To exercise the full training and recognition flow, start both the Node server and the Expo client from the repository root:
+
+```bash
+# build and launch the backend on port 5000 with the demo token
+npm run build --prefix server
+API_TOKEN=demo-token npm start --prefix server
+
+# in another terminal, start the mobile app
+EXPO_PUBLIC_API_URL=http://10.0.2.2:5000 ./scripts/dev-run.sh --android
+```
+
+When running on a physical device instead of the Android emulator, you can map the server port with:
+
+```bash
+scripts/adb-reverse.sh 5000 && EXPO_PUBLIC_API_URL=http://localhost:5000 ./scripts/dev-run.sh --android
+```
+
+The server defaults to port `5000`. `scripts/dev-run.sh` wraps Expo's development launcher, so you can pass `--android` or `--ios` to target the appropriate platform.
+
 ## Integration Tests
 
 Integration tests verify that the Node server and app API clients work together correctly. From the repository root run:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -53,7 +53,7 @@
 
 - [ ] **Test App/Server Integration & Document Setup**
   - Test the full app/server integration, ensuring correct data flow and authentication.
-  - Document proper startup procedure for both server (with `API_TOKEN=demo-token npm start --prefix server`) and app (`./scripts/dev-run.sh`).
+  - [x] Document proper startup procedure for both server (with `API_TOKEN=demo-token npm start --prefix server`) and app (`./scripts/dev-run.sh`).
   - Verify training data upload from app to server.
   - Verify model metadata and model download from server to app.
   - Confirm resolution of `training sync failed` and `model metadata request failed` errors.


### PR DESCRIPTION
## Summary
- document how to launch the Node server and Expo client together
- check off startup documentation task in TODO

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration` *(fails: training did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68add83905908322ad3e780145544cfd