### PR TITLE
Translate TeachingScreen UI text to German

### DIFF
--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -45,7 +45,7 @@ export default function TeachingScreen({ navigation }: any) {
       .then(setProfile)
       .catch((e) => {
         logger.error('Failed to load profile', e);
-        setError('Failed to load profile');
+        setError('Profil konnte nicht geladen werden.');
       });
   }, []);
 
@@ -76,7 +76,7 @@ export default function TeachingScreen({ navigation }: any) {
 
   const startSession = async () => {
     if (!gestureLabel.trim()) {
-      setError('Please enter a name for the gesture.');
+      setError('Bitte gib einen Namen für die Geste ein.');
       return;
     }
     try {
@@ -92,7 +92,7 @@ export default function TeachingScreen({ navigation }: any) {
       audioService.speak(`Okay, lass uns lernen, wie man "${gestureLabel}" macht.`);
     } catch (e) {
       logger.error('Failed to start teaching session', e);
-      setError('Failed to start teaching session');
+      setError('Lehr-Sitzung konnte nicht gestartet werden.');
     }
   };
 
@@ -111,7 +111,7 @@ export default function TeachingScreen({ navigation }: any) {
       }
     } catch (e) {
       logger.error('Recording failed', e);
-      setError('Recording failed');
+      setError('Aufnahme fehlgeschlagen');
     } finally {
       setIsRecording(false);
     }
@@ -192,7 +192,7 @@ export default function TeachingScreen({ navigation }: any) {
   return (
     <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
       <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Teach New Gesture</Text>
+      <Text style={styles.title}>Neue Geste beibringen</Text>
       {!isSessionActive ? (
         <View style={styles.inputContainer}>
           <TextInput
@@ -220,10 +220,10 @@ export default function TeachingScreen({ navigation }: any) {
               outputRange: [0.8, 1.2],
             })}]}
           ]}>
-            <Text style={styles.sampleIndicatorText}>Sample Captured!</Text>
+            <Text style={styles.sampleIndicatorText}>Beispiel erfasst!</Text>
           </Animated.View>
           <Text style={styles.prompt}>Zeige die Geste "{gestureLabel}"</Text>
-          <Text style={styles.progress}>{sampleCount} / {SAMPLES_NEEDED} samples</Text>
+          <Text style={styles.progress}>{sampleCount} / {SAMPLES_NEEDED} Beispiele</Text>
           <Button
             title={isRecording ? 'Aufnahme...' : 'Beispiel aufnehmen'}
             onPress={recordSample}
@@ -248,7 +248,7 @@ export default function TeachingScreen({ navigation }: any) {
       )}
       {syncing && (
         <View style={{ width: '100%', padding: SPACING.md }}>
-          <Text>Training model… {Math.round(progress)}%</Text>
+          <Text>Modell wird trainiert… {Math.round(progress)}%</Text>
           <View style={{ height: 8, backgroundColor: COLORS.border, borderRadius: RADIUS, overflow: 'hidden', marginTop: 6 }}>
             <View style={{ height: '100%', width: `${Math.max(0, Math.min(100, progress))}%`, backgroundColor: COLORS.success }} />
           </View>

--- a/app/test/screens/TeachingScreen.test.tsx
+++ b/app/test/screens/TeachingScreen.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock('react-native', () => {
+  const React = require('react');
+  const animated = {
+    View: (p: any) => React.createElement('Animated.View', p, p.children),
+    Value: function () {
+      return { setValue: jest.fn(), interpolate: jest.fn(() => 1) } as any;
+    },
+    timing: () => ({ start: jest.fn() }),
+    sequence: () => ({ start: jest.fn() }),
+  };
+  return {
+    View: (p: any) => React.createElement('View', p, p.children),
+    Text: (p: any) => React.createElement('Text', p, p.children),
+    Button: (p: any) => React.createElement('Button', p, p.children),
+    TextInput: (p: any) => React.createElement('TextInput', p, p.children),
+    SafeAreaView: (p: any) => React.createElement('SafeAreaView', p, p.children),
+    StyleSheet: { create: (s: any) => s },
+    Alert: { alert: jest.fn() },
+    Animated: animated,
+    Easing: { ease: {} },
+  } as any;
+});
+
+jest.mock('expo-linear-gradient', () => ({ LinearGradient: ({ children }: any) => children }));
+jest.mock('../../src/components/AccessibilityContext', () => ({
+  useAccessibility: () => ({ largeText: false, highContrast: false }),
+}));
+jest.mock('../../src/context/MessageContext', () => ({
+  useMessage: () => ({ setMessage: jest.fn() }),
+}));
+jest.mock('../../src/components/BottomNav', () => () => null);
+jest.mock('../../src/services/audioService', () => ({
+  audioService: { speak: jest.fn(), playSound: jest.fn() },
+}));
+jest.mock('../../src/storage', () => ({
+  loadProfile: jest.fn(async () => ({ id: '1', name: 'Amy' })),
+  loadTrainingSampleCount: jest.fn(async () => 0),
+  saveTrainingSample: jest.fn(async () => {}),
+  saveCustomGesture: jest.fn(async () => {}),
+}));
+jest.mock('../../src/services/gestureRecorder', () => ({
+  captureSamples: jest.fn(async () => []),
+}));
+jest.mock('../../src/services', () => ({
+  syncTrainingData: jest.fn(async () => {}),
+}));
+jest.mock('../../src/components/MediaPipeGestureDetector', () => ({
+  MediaPipeGestureDetector: () => null,
+}));
+
+import TeachingScreen from '../../src/screens/TeachingScreen';
+
+describe('TeachingScreen', () => {
+  it('renders German title', async () => {
+    let component!: renderer.ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<TeachingScreen navigation={{ goBack: jest.fn() }} />);
+      await Promise.resolve();
+    });
+    const textNodes = component.root.findAllByType('Text');
+    expect(textNodes.some((n) => n.props.children === 'Neue Geste beibringen')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- localize TeachingScreen labels and error messages to German
- add unit test ensuring TeachingScreen shows German title

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor) # failed: connect ENETUNREACH`

------
https://chatgpt.com/codex/tasks/task_e_68addb2f1bd88322a27c370400359c82