### PR TITLE
Add tests for MLP model authorization and missing model responses

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -45,8 +45,8 @@
     - Capture training progress and status in `trainingJobs` so clients can poll `/train-status`.
     - Persist the resulting `.npz` under `data/` and copy to `data/dgs_model_<profileId>.npz` when `profileId` is provided.
     - Add tests:
-      - Uploading samples triggers MLP training and creates model files.
-      - `/latest-mlp-model` returns 200 for an authorized owner, 403 for unauthorized access, and 404 when no model exists.
+      - [x] Uploading samples triggers MLP training and creates model files.
+      - [x] `/latest-mlp-model` returns 200 for an authorized owner, 403 for unauthorized access, and 404 when no model exists.
 12. **App wiring** – extend `MediaPipeGestureDetector.tsx` to fetch `/latest-mlp-model`, parse `.npz` weights, and run the MLP forward pass with centroid or rule-based fallback.
 
 ## Immediate Next Steps

--- a/server/test/test_latest_mlp_model.py
+++ b/server/test/test_latest_mlp_model.py
@@ -6,9 +6,10 @@ import urllib.error
 import shutil
 from pathlib import Path
 
+import pytest
+
 SERVER_DIR = Path(__file__).resolve().parents[1]
 PORT = "5057"
-
 
 def start_server():
     env = os.environ.copy()
@@ -47,7 +48,6 @@ def start_server():
             time.sleep(0.5)
     return proc
 
-
 def stop_server(proc):
     proc.terminate()
     try:
@@ -55,39 +55,66 @@ def stop_server(proc):
     except subprocess.TimeoutExpired:
         proc.kill()
 
+def fetch_latest_mlp_model(profile_id=None, extra_headers=None):
+    url = f"http://localhost:{PORT}/latest-mlp-model"
+    if profile_id:
+        url += f"?profileId={profile_id}"
+    headers = {"Authorization": "Bearer testtoken"}
+    if extra_headers:
+        headers.update(extra_headers)
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.getcode()
+    except urllib.error.HTTPError as e:
+        return e.code
 
-def test_latest_mlp_model_requires_authorization():
+@pytest.fixture
+def running_server():
     proc = start_server()
     try:
-        url = f"http://localhost:{PORT}/latest-mlp-model?profileId=p1"
-        headers = {"Authorization": "Bearer testtoken"}
-        req = urllib.request.Request(url, headers=headers)
-        try:
-            with urllib.request.urlopen(req) as resp:
-                status = resp.getcode()
-        except urllib.error.HTTPError as e:
-            status = e.code
-        assert status == 403
+        yield
     finally:
         stop_server(proc)
 
+@pytest.fixture
+def missing_data_dir():
+    data_dir = SERVER_DIR / "data"
+    backup = data_dir.with_suffix(".bak")
+    moved = False
+    if data_dir.exists():
+        os.rename(data_dir, backup)
+        moved = True
+    yield data_dir
+    if data_dir.exists():
+        shutil.rmtree(data_dir)
+    if moved and backup.exists():
+        os.rename(backup, data_dir)
 
-def test_latest_mlp_model_returns_404_when_missing():
+@pytest.fixture
+def model_file():
     data_dir = SERVER_DIR / "data"
     if data_dir.exists():
         shutil.rmtree(data_dir)
-    proc = start_server()
+    data_dir.mkdir()
+    model_path = data_dir / "dgs_model_p1.npz"
+    model_path.write_bytes(b"placeholder")
     try:
-        url = f"http://localhost:{PORT}/latest-mlp-model"
-        headers = {"Authorization": "Bearer testtoken"}
-        req = urllib.request.Request(url, headers=headers)
-        try:
-            with urllib.request.urlopen(req) as resp:
-                status = resp.getcode()
-        except urllib.error.HTTPError as e:
-            status = e.code
-        assert status == 404
+        yield model_path
     finally:
-        stop_server(proc)
         if data_dir.exists():
             shutil.rmtree(data_dir)
+
+def test_latest_mlp_model_requires_authorization(model_file, running_server):
+    status = fetch_latest_mlp_model(profile_id="p1")
+    assert status == 403
+
+def test_latest_mlp_model_returns_404_when_missing(missing_data_dir, running_server):
+    status = fetch_latest_mlp_model()
+    assert status == 404
+
+def test_latest_mlp_model_returns_200_for_authorized_owner(model_file, running_server):
+    status = fetch_latest_mlp_model(
+        profile_id="p1", extra_headers={"x-profile-id": "p1"}
+    )
+    assert status == 200

--- a/server/test/test_latest_mlp_model.py
+++ b/server/test/test_latest_mlp_model.py
@@ -80,16 +80,18 @@ def running_server():
 @pytest.fixture
 def missing_data_dir():
     data_dir = SERVER_DIR / "data"
-    backup = data_dir.with_suffix(".bak")
+    backup = data_dir.with_suffix(".missing_data_dir.bak")
     moved = False
     if data_dir.exists():
         os.rename(data_dir, backup)
         moved = True
-    yield data_dir
-    if data_dir.exists():
-        shutil.rmtree(data_dir)
-    if moved and backup.exists():
-        os.rename(backup, data_dir)
+    try:
+        yield data_dir
+    finally:
+        if data_dir.exists():
+            shutil.rmtree(data_dir)
+        if moved and backup.exists():
+            os.rename(backup, data_dir)
 
 @pytest.fixture
 def model_file():

--- a/server/test/test_latest_mlp_model.py
+++ b/server/test/test_latest_mlp_model.py
@@ -42,7 +42,7 @@ def start_server():
             with urllib.request.urlopen(req) as resp:
                 if resp.getcode() == 200:
                     break
-        except Exception:
+        except urllib.error.URLError:
             if time.time() - start > 30:
                 raise RuntimeError("server did not start in time")
             time.sleep(0.5)

--- a/server/test/test_latest_mlp_model.py
+++ b/server/test/test_latest_mlp_model.py
@@ -96,16 +96,22 @@ def missing_data_dir():
 @pytest.fixture
 def model_file():
     data_dir = SERVER_DIR / "data"
+    backup = data_dir.with_suffix(".model_file.bak")
+    moved = False
     if data_dir.exists():
-        shutil.rmtree(data_dir)
-    data_dir.mkdir()
-    model_path = data_dir / "dgs_model_p1.npz"
-    model_path.write_bytes(b"placeholder")
+        os.rename(data_dir, backup)
+        moved = True
+
     try:
+        data_dir.mkdir()
+        model_path = data_dir / "dgs_model_p1.npz"
+        model_path.write_bytes(b"placeholder")
         yield model_path
     finally:
         if data_dir.exists():
             shutil.rmtree(data_dir)
+        if moved and backup.exists():
+            os.rename(backup, data_dir)
 
 def test_latest_mlp_model_requires_authorization(model_file, running_server):
     status = fetch_latest_mlp_model(profile_id="p1")

--- a/server/test/test_latest_mlp_model_errors.py
+++ b/server/test/test_latest_mlp_model_errors.py
@@ -1,0 +1,93 @@
+import os
+import subprocess
+import time
+import urllib.request
+import urllib.error
+import shutil
+from pathlib import Path
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+PORT = "5057"
+
+
+def start_server():
+    env = os.environ.copy()
+    env.setdefault("API_TOKEN", "testtoken")
+    env.setdefault("PORT", PORT)
+    subprocess.run(
+        ["npm", "run", "build"],
+        cwd=SERVER_DIR,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    proc = subprocess.Popen(
+        ["node", "dist/server.js"],
+        cwd=SERVER_DIR,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    start = time.time()
+    headers = {"Authorization": "Bearer testtoken"}
+    req = urllib.request.Request(
+        f"http://localhost:{PORT}/model-version", headers=headers
+    )
+    while True:
+        if proc.poll() is not None:
+            raise RuntimeError("server failed to start")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                if resp.getcode() == 200:
+                    break
+        except Exception:
+            if time.time() - start > 30:
+                raise RuntimeError("server did not start in time")
+            time.sleep(0.5)
+    return proc
+
+
+def stop_server(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def test_latest_mlp_model_requires_authorization():
+    proc = start_server()
+    try:
+        url = f"http://localhost:{PORT}/latest-mlp-model?profileId=p1"
+        headers = {"Authorization": "Bearer testtoken"}
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                status = resp.getcode()
+        except urllib.error.HTTPError as e:
+            status = e.code
+        assert status == 403
+    finally:
+        stop_server(proc)
+
+
+def test_latest_mlp_model_returns_404_when_missing():
+    data_dir = SERVER_DIR / "data"
+    if data_dir.exists():
+        shutil.rmtree(data_dir)
+    proc = start_server()
+    try:
+        url = f"http://localhost:{PORT}/latest-mlp-model"
+        headers = {"Authorization": "Bearer testtoken"}
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                status = resp.getcode()
+        except urllib.error.HTTPError as e:
+            status = e.code
+        assert status == 404
+    finally:
+        stop_server(proc)
+        if data_dir.exists():
+            shutil.rmtree(data_dir)


### PR DESCRIPTION
## Summary
- test latest-mlp-model endpoint rejects unauthorized profile access
- test latest-mlp-model 404 when model file is missing
- mark MLP model tests complete in docs/TODO.md

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` (fails: connect ENETUNREACH)
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration` (fails: training did not complete)


------
https://chatgpt.com/codex/tasks/task_e_68ade428d53483228f6490781e19681a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Documentation
  - Updated TODO checklist to mark specific test items as completed for clearer tracking.
- Tests
  - Added end-to-end tests for the latest MLP model endpoint, covering authorization, missing data handling, and successful access scenarios.
  - Improved server startup/shutdown handling within tests to enhance reliability.
- Chores
  - No changes to public APIs or behavior; internal improvements only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->