### PR TITLE
Refactor latest MLP model tests and cover success case

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -45,8 +45,8 @@
     - Capture training progress and status in `trainingJobs` so clients can poll `/train-status`.
     - Persist the resulting `.npz` under `data/` and copy to `data/dgs_model_<profileId>.npz` when `profileId` is provided.
     - Add tests:
-      - Uploading samples triggers MLP training and creates model files.
-      - `/latest-mlp-model` returns 200 for an authorized owner, 403 for unauthorized access, and 404 when no model exists.
+      - [x] Uploading samples triggers MLP training and creates model files.
+      - [x] `/latest-mlp-model` returns 200 for an authorized owner, 403 for unauthorized access, and 404 when no model exists.
 12. **App wiring** – extend `MediaPipeGestureDetector.tsx` to fetch `/latest-mlp-model`, parse `.npz` weights, and run the MLP forward pass with centroid or rule-based fallback.
 
 ## Immediate Next Steps

--- a/server/db.json
+++ b/server/db.json
@@ -22,7 +22,7 @@
   "gestureDefinitions": [],
   "gestureTrainingData": [
     {
-      "id": "meqx9d81quz44ax5x6a",
+      "id": "meswhuz2twfmaoet8e",
       "gestureDefinitionId": "hello",
       "landmarkData": [
         1,
@@ -56,25 +56,25 @@
   ],
   "vocabularySetSymbols": [
     {
-      "id": "meqx9cygauscbx6vrc",
+      "id": "meswhuqwja96uie3i2",
       "vocabularySetId": "basic",
       "symbolId": "hello"
     },
     {
-      "id": "meqx9cygc3pfedma3g9",
+      "id": "meswhuqw0tswczhs3a1a",
       "vocabularySetId": "basic",
       "symbolId": "drink"
     }
   ],
   "usageStats": [
     {
-      "id": "meqx9cygkw0zz0gh0x",
+      "id": "meswhuqw30n3boefjfx",
       "symbolId": "hello",
       "profileId": "default",
       "count": 0
     },
     {
-      "id": "meqx9cygh3iq9pdfmi",
+      "id": "meswhuqwyrze8nqlr9k",
       "symbolId": "drink",
       "profileId": "default",
       "count": 0

--- a/server/src/tools/train_mlp.py
+++ b/server/src/tools/train_mlp.py
@@ -172,7 +172,8 @@ def main():
     # Atomic write to avoid partial reads
     tmp_path = MODEL_PATH + ".tmp"
     os.makedirs(os.path.dirname(MODEL_PATH), exist_ok=True)
-    np.savez(tmp_path, w1=w1, b1=b1, w2=w2, b2=b2, idx_to_label=idx_to_label)
+    with open(tmp_path, "wb") as f:
+        np.savez(f, w1=w1, b1=b1, w2=w2, b2=b2, idx_to_label=idx_to_label)
     # Replace atomically and set restrictive permissions
     os.replace(tmp_path, MODEL_PATH)
     try:

--- a/server/test/test_latest_mlp_model.py
+++ b/server/test/test_latest_mlp_model.py
@@ -1,0 +1,137 @@
+import os
+import socket
+import subprocess
+import time
+import urllib.request
+import urllib.error
+import shutil
+from pathlib import Path
+
+import pytest
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+
+
+def _get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+PORT = os.environ.get("PORT") or str(_get_free_port())
+HOST = "127.0.0.1"
+BASE_URL = f"http://{HOST}:{PORT}"
+
+def start_server():
+    env = os.environ.copy()
+    env.setdefault("API_TOKEN", "testtoken")
+    env.setdefault("PORT", PORT)
+    env.setdefault("HOST", HOST)
+    subprocess.run(
+        ["npm", "run", "build"],
+        cwd=SERVER_DIR,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    proc = subprocess.Popen(
+        ["node", "dist/server.js"],
+        cwd=SERVER_DIR,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    start = time.time()
+    headers = {"Authorization": "Bearer testtoken"}
+    req = urllib.request.Request(f"{BASE_URL}/model-version", headers=headers)
+    while True:
+        if proc.poll() is not None:
+            raise RuntimeError("server failed to start")
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.getcode() == 200:
+                    break
+        except Exception:
+            if time.time() - start > 30:
+                raise RuntimeError("server did not start in time")
+            time.sleep(0.5)
+    return proc
+
+def stop_server(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+def fetch_latest_mlp_model(profile_id=None, extra_headers=None):
+    url = f"{BASE_URL}/latest-mlp-model"
+    if profile_id:
+        url += f"?profileId={profile_id}"
+    headers = {"Authorization": "Bearer testtoken"}
+    if extra_headers:
+        headers.update(extra_headers)
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.getcode()
+    except urllib.error.HTTPError as e:
+        return e.code
+
+@pytest.fixture
+def running_server():
+    proc = start_server()
+    try:
+        yield
+    finally:
+        stop_server(proc)
+
+@pytest.fixture
+def missing_data_dir():
+    data_dir = SERVER_DIR / "data"
+    backup_dir = None
+    if data_dir.exists():
+        backup_dir = data_dir.with_name(
+            f"{data_dir.name}.bak.{int(time.time())}"
+        )
+        shutil.move(str(data_dir), str(backup_dir))
+    yield data_dir
+    if data_dir.exists():
+        shutil.rmtree(data_dir)
+    if backup_dir is not None and Path(backup_dir).exists():
+        shutil.move(str(backup_dir), str(data_dir))
+
+@pytest.fixture
+def model_file():
+    data_dir = SERVER_DIR / "data"
+    backup_dir = None
+    if data_dir.exists():
+        backup_dir = data_dir.with_name(
+            f"{data_dir.name}.bak.{int(time.time())}"
+        )
+        shutil.move(str(data_dir), str(backup_dir))
+    data_dir.mkdir()
+    model_path = data_dir / "dgs_model_p1.npz"
+    model_path.write_bytes(b"placeholder")
+    try:
+        yield model_path
+    finally:
+        if data_dir.exists():
+            shutil.rmtree(data_dir)
+        if backup_dir is not None and Path(backup_dir).exists():
+            shutil.move(str(backup_dir), str(data_dir))
+
+def test_latest_mlp_model_requires_authorization(model_file, running_server):
+    status = fetch_latest_mlp_model(profile_id="p1")
+    assert status == 403
+
+def test_latest_mlp_model_returns_404_when_missing(missing_data_dir, running_server):
+    status = fetch_latest_mlp_model()
+    assert status == 404
+
+def test_latest_mlp_model_returns_200_for_authorized_owner(model_file, running_server):
+    status = fetch_latest_mlp_model(
+        profile_id="p1", extra_headers={"x-profile-id": "p1"}
+    )
+    assert status == 200

--- a/server/test/test_train_endpoint.py
+++ b/server/test/test_train_endpoint.py
@@ -114,7 +114,10 @@ def test_train_endpoint(tmp_path):
 
         mlp_prof_req = urllib.request.Request(
             f'http://localhost:{PORT}/latest-mlp-model?profileId=p1',
-            headers={'Authorization': 'Bearer testtoken'},
+            headers={
+                'Authorization': 'Bearer testtoken',
+                'x-profile-id': 'p1',
+            },
         )
         with urllib.request.urlopen(mlp_prof_req) as mlp_presp:
             assert mlp_presp.getcode() == 200


### PR DESCRIPTION
## Summary
- refactor /latest-mlp-model tests with dynamic ports and data-dir safety
- fix Python MLP training script to save model atomically
- ensure training endpoint test includes profile authorization header

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `pytest -q server/test`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ade428d53483228f6490781e19681a