### PR TITLE
Validate LLM suggestion response

### DIFF
--- a/server/db.json
+++ b/server/db.json
@@ -22,7 +22,7 @@
   "gestureDefinitions": [],
   "gestureTrainingData": [
     {
-      "id": "meswhuz2twfmaoet8e",
+      "id": "mesxl36g9619t1wtgqd",
       "gestureDefinitionId": "hello",
       "landmarkData": [
         1,
@@ -56,25 +56,25 @@
   ],
   "vocabularySetSymbols": [
     {
-      "id": "meswhuqwja96uie3i2",
+      "id": "mesxl30sdvawrg4d3mm",
       "vocabularySetId": "basic",
       "symbolId": "hello"
     },
     {
-      "id": "meswhuqw0tswczhs3a1a",
+      "id": "mesxl30sqtpkqeq1ois",
       "vocabularySetId": "basic",
       "symbolId": "drink"
     }
   ],
   "usageStats": [
     {
-      "id": "meswhuqw30n3boefjfx",
+      "id": "mesxl30s1p49p9bruq1",
       "symbolId": "hello",
       "profileId": "default",
       "count": 0
     },
     {
-      "id": "meswhuqwyrze8nqlr9k",
+      "id": "mesxl30smrntc5gucug",
       "symbolId": "drink",
       "profileId": "default",
       "count": 0

--- a/server/src/services/dialogEngine.ts
+++ b/server/src/services/dialogEngine.ts
@@ -1,10 +1,17 @@
 
 // LLM Hint: Define a clear type for the expected JSON response from the LLM.
 // This helps with type safety and makes it clear what structure the prompt should request.
+import { z } from 'zod';
+
 export type LLMSuggestionResponse = {
   nextWords: string[];
   caregiverPhrases: string[];
 };
+
+const suggestionSchema = z.object({
+  nextWords: z.array(z.string()),
+  caregiverPhrases: z.array(z.string()),
+});
 
 export interface LLMRequest {
   input: string;
@@ -56,7 +63,8 @@ export async function getLLMSuggestions(req: LLMRequest): Promise<LLMSuggestionR
     if (!response.ok) throw new Error(`API call failed with status: ${response.status}`);
     const data = (await response.json()) as any;
     const content = JSON.parse(data.choices[0].message.content as string);
-    return content as LLMSuggestionResponse;
+    const parsed = suggestionSchema.parse(content);
+    return parsed as LLMSuggestionResponse;
   } catch (error) {
     console.error('LLM suggestion error:', error);
     return { nextWords: [], caregiverPhrases: [] };

--- a/server/test/dialogEngine.test.ts
+++ b/server/test/dialogEngine.test.ts
@@ -1,0 +1,56 @@
+import { getLLMSuggestions, LLMRequest } from '../src/services/dialogEngine';
+
+describe('getLLMSuggestions', () => {
+  const req: LLMRequest = {
+    input: 'Hallo',
+    context: [],
+    language: 'de',
+    age: 5,
+  };
+
+  afterEach(() => {
+    delete (global as any).fetch;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('returns empty arrays when no API key is present', async () => {
+    const res = await getLLMSuggestions(req);
+    expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
+  });
+
+  it('parses and returns suggestions from the API', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                nextWords: ['tschüss'],
+                caregiverPhrases: ['Wie geht es dir?'],
+              }),
+            },
+          },
+        ],
+      }),
+    });
+    const res = await getLLMSuggestions(req);
+    expect(res.nextWords).toContain('tschüss');
+    expect(res.caregiverPhrases).toContain('Wie geht es dir?');
+  });
+
+  it('returns empty arrays on invalid API response', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          { message: { content: '{"foo": "bar"}' } },
+        ],
+      }),
+    });
+    const res = await getLLMSuggestions(req);
+    expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure dialogEngine validates LLM output with zod
- add tests for getLLMSuggestions covering success and failure paths

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `cd app && npx expo install --check`
- `cd app && npx expo-doctor` *(fails: connect ENETUNREACH)*
- `npm run type-check --prefix server`
- `npm test --prefix server`
- `pytest -q server` *(fails: IndentationError in test_latest_mlp_model.py)*
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ae07f8b968832287f6d4d1fb55d977