### PR TITLE
docs: add app-server integration guide

### DIFF
--- a/docs/AppServerIntegrationGuide.md
+++ b/docs/AppServerIntegrationGuide.md
@@ -1,0 +1,35 @@
+# App/Server Integration Guide
+
+This guide explains how to verify end-to-end communication between the Amy's Echo app and the backend server.
+
+## Prerequisites
+- Node.js and npm installed
+- Expo development environment
+- Authentication token for the server (use `demo-token` for local testing)
+
+## Steps
+1. **Start the server**
+   ```bash
+   API_TOKEN=demo-token npm start --prefix server
+   ```
+2. **Start the app**
+   ```bash
+   ./scripts/dev-run.sh
+   ```
+3. **Send training data**  
+   In the app open "Teach New Gesture", record a sample, and submit it.  
+   The server console should log the upload.
+4. **Check training status**
+   ```bash
+   curl -H "Authorization: Bearer demo-token" http://localhost:5000/train-status
+   ```
+5. **Download the model**
+   After training reaches 100%:
+   ```bash
+   curl -H "Authorization: Bearer demo-token" -o dgs_model.npz \
+     http://localhost:5000/latest-mlp-model
+   ```
+6. **Refresh the app**  
+   Reload the app or trigger a refresh so the new model is used.
+
+Completing these steps confirms that authentication, data flow, and model download work end to end.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -51,8 +51,8 @@
 
 ## Immediate Next Steps
 
-- [ ] **Test App/Server Integration & Document Setup**
-  - Test the full app/server integration, ensuring correct data flow and authentication.
+- [x] **Test App/Server Integration & Document Setup**
+  - [x] Test the full app/server integration, ensuring correct data flow and authentication. See [`AppServerIntegrationGuide.md`](AppServerIntegrationGuide.md).
   - [x] Document proper startup procedure for both server (with `API_TOKEN=demo-token npm start --prefix server`) and app (`./scripts/dev-run.sh`).
   - [x] Verify training data upload from app to server.
   - [x] Verify model metadata and model download from server to app.

--- a/integration/package.json
+++ b/integration/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "pretest": "npm ci --include=dev && npm run build --prefix ../server",
-    "test": "tsx --test $(find . -name '*.spec.ts' -o -name '*.test.js')"
+    "test": "tsx --test $(find . -name '*.spec.ts' -o -name '*.test.js' | grep -v node_modules)"
   },
   "devDependencies": {
     "tsx": "^4.20.3"

--- a/integration/test/api.test.js
+++ b/integration/test/api.test.js
@@ -151,6 +151,13 @@ test('POST /train-model processes samples and returns model', async () => {
   assert.strictEqual(profileRes.status, 200);
   const profileModel = await profileRes.json();
   assert.ok(profileModel.counts.g1 >= 1);
+
+  process.env.EXPO_PUBLIC_API_URL = `http://localhost:${PORT}`;
+  process.env.EXPO_PUBLIC_API_TOKEN = 'testtoken';
+  const { fetchMlpModel } = await import('../../app/src/services/dgsModelClient.ts');
+  const b64 = await fetchMlpModel('p1');
+  assert.ok(typeof b64 === 'string' && b64.length > 0);
+  assert.strictEqual(Buffer.from(b64, 'base64').length, mlpBuf.length);
 });
 
 test('GET /model-version returns version and path', async () => {
@@ -217,10 +224,9 @@ test('GET /api/v1/dgs/mlp-model serves file and client caches it', async () => {
 
     process.env.EXPO_PUBLIC_API_URL = `http://localhost:${PORT}`;
     process.env.EXPO_PUBLIC_API_TOKEN = 'testtoken';
-    /** @type {string | null} */
     let b64 = null;
     try {
-      const { fetchMlpModel, getCachedMlpModel } = await import('../../app/dist/services/dgsModelClient.js');
+      const { fetchMlpModel, getCachedMlpModel } = await import('../../app/src/services/dgsModelClient.ts');
       b64 = await fetchMlpModel('p1');
       assert.ok(typeof b64 === 'string' && b64.length > 0);
       const cached = await getCachedMlpModel('p1');


### PR DESCRIPTION
## Summary
- document how to verify end-to-end integration between the app and server
- mark app/server integration task complete in project TODO
- exercise training flow in integration test using app's DGS client

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH 34.110.201.56:443)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ae10783f8c8322b472309ca8310957