### PR TITLE
fix: prevent mirrored camera in MediaPipe webview

### DIFF
--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -117,7 +117,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
     );
   }
   const mlpInstallScript = `const s=document.createElement('script'); s.src='data:application/javascript;base64,${fflateBase64}'; s.onload=()=>{(${installMlp.toString()})();}; document.head.appendChild(s);`;
-
+  const videoTransform = facingMode === 'user' ? 'transform: scaleX(-1);' : '';
   const htmlContent = `
 <!DOCTYPE html>
 <html>
@@ -125,7 +125,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     html, body { margin: 0; padding: 0; background: #000; }
-    video { position: absolute; inset: 0; width: 100vw; height: 100vh; object-fit: cover; transform: scaleX(-1); }
+    video { position: absolute; inset: 0; width: 100vw; height: 100vh; object-fit: cover; ${videoTransform} }
     canvas#overlay { position: absolute; inset: 0; width: 100vw; height: 100vh; pointer-events: none; }
     #tapToStart { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: #fff; background: rgba(0,0,0,0.4); font-family: sans-serif; }
     #tapToStart.hidden { display: none; }

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -118,6 +118,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
   }
   const mlpInstallScript = `const s=document.createElement('script'); s.src='data:application/javascript;base64,${fflateBase64}'; s.onload=()=>{(${installMlp.toString()})();}; document.head.appendChild(s);`;
   const videoTransform = facingMode === 'user' ? 'transform: scaleX(-1);' : '';
+  const mirrorOverlayFlag = facingMode === 'user' ? 'true' : 'false';
   const htmlContent = `
 <!DOCTYPE html>
 <html>
@@ -132,6 +133,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
   </style>
   <script>
     ${mlpInstallScript}
+    const mirrorOverlay = ${mirrorOverlayFlag};
     // Dynamically load MediaPipe Tasks Vision from CDN and wait until it's ready
     async function loadTasksVision() {
       // Resolve a pinned version dynamically if possible, otherwise fall back to generic.
@@ -342,9 +344,11 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
               if (ctx) {
                 ctx.clearRect(0, 0, overlay.width, overlay.height);
                 ctx.save();
-                // Mirror horizontally to match video
-                ctx.scale(-1, 1);
-                ctx.translate(-overlay.width, 0);
+                // Mirror horizontally to match video when using the front camera
+                if (mirrorOverlay) {
+                  ctx.scale(-1, 1);
+                  ctx.translate(-overlay.width, 0);
+                }
                 const HAND_CONNECTIONS = [
                   [0,1],[1,2],[2,3],[3,4],
                   [0,5],[5,6],[6,7],[7,8],

--- a/app/test/MediaPipeGestureDetector.test.tsx
+++ b/app/test/MediaPipeGestureDetector.test.tsx
@@ -234,4 +234,26 @@ describe('MediaPipeGestureDetector', () => {
 
     expect(onWebViewEvent).toHaveBeenCalledWith({ event: 'camera_started', ms: 123, tracks: ['front-camera'] });
   });
+
+  it('wendet eine horizontale Spiegelung nur für die Nutzerkamera an', () => {
+    const onGestureDetected = jest.fn();
+    const onError = jest.fn();
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <MediaPipeGestureDetector onGestureDetected={onGestureDetected} onError={onError} facingMode="user" />,
+      );
+    });
+    const userHtml = (component as renderer.ReactTestRenderer).root.findByType('mock-webview').props.source.html;
+    expect(userHtml).toContain('transform: scaleX(-1);');
+
+    act(() => {
+      component.update(
+        <MediaPipeGestureDetector onGestureDetected={onGestureDetected} onError={onError} facingMode="environment" />,
+      );
+    });
+    const envHtml = (component as renderer.ReactTestRenderer).root.findByType('mock-webview').props.source.html;
+    expect(envHtml).not.toContain('transform: scaleX(-1);');
+  });
 });

--- a/app/test/MediaPipeGestureDetector.test.tsx
+++ b/app/test/MediaPipeGestureDetector.test.tsx
@@ -235,25 +235,31 @@ describe('MediaPipeGestureDetector', () => {
     expect(onWebViewEvent).toHaveBeenCalledWith({ event: 'camera_started', ms: 123, tracks: ['front-camera'] });
   });
 
-  it('wendet eine horizontale Spiegelung nur für die Nutzerkamera an', () => {
+  const renderHtml = (facingMode: 'user' | 'environment') => {
     const onGestureDetected = jest.fn();
     const onError = jest.fn();
-
     let component: renderer.ReactTestRenderer;
     act(() => {
       component = renderer.create(
-        <MediaPipeGestureDetector onGestureDetected={onGestureDetected} onError={onError} facingMode="user" />,
+        <MediaPipeGestureDetector
+          onGestureDetected={onGestureDetected}
+          onError={onError}
+          facingMode={facingMode}
+        />,
       );
     });
-    const userHtml = (component as renderer.ReactTestRenderer).root.findByType('mock-webview').props.source.html;
-    expect(userHtml).toContain('transform: scaleX(-1);');
+    return (component as renderer.ReactTestRenderer).root.findByType('mock-webview').props.source.html as string;
+  };
 
-    act(() => {
-      component.update(
-        <MediaPipeGestureDetector onGestureDetected={onGestureDetected} onError={onError} facingMode="environment" />,
-      );
-    });
-    const envHtml = (component as renderer.ReactTestRenderer).root.findByType('mock-webview').props.source.html;
-    expect(envHtml).not.toContain('transform: scaleX(-1);');
+  it('mirrors video and overlay for the user-facing camera', () => {
+    const html = renderHtml('user');
+    expect(html).toContain('transform: scaleX(-1);');
+    expect(html).toContain('const mirrorOverlay = true');
+  });
+
+  it('does not mirror video or overlay for the rear-facing camera', () => {
+    const html = renderHtml('environment');
+    expect(html).not.toContain('transform: scaleX(-1);');
+    expect(html).toContain('const mirrorOverlay = false');
   });
 });

--- a/server/test/dialogEngine.test.ts
+++ b/server/test/dialogEngine.test.ts
@@ -53,4 +53,36 @@ describe('getLLMSuggestions', () => {
     const res = await getLLMSuggestions(req);
     expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
   });
+
+  it('returns empty arrays when response JSON parsing fails', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error('invalid json');
+      },
+    });
+    const res = await getLLMSuggestions(req);
+    expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns empty arrays when API response is not ok', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+    const res = await getLLMSuggestions(req);
+    expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
+  });
+
+  it('returns empty arrays when fetch throws an error', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    (global as any).fetch = jest.fn().mockRejectedValue(new Error('network'));
+    const res = await getLLMSuggestions(req);
+    expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
+  });
 });

--- a/server/test/dialogEngine.test.ts
+++ b/server/test/dialogEngine.test.ts
@@ -8,6 +8,10 @@ describe('getLLMSuggestions', () => {
     age: 5,
   };
 
+  const mockFetch = (value: unknown) => {
+    (global as any).fetch = jest.fn().mockResolvedValue(value);
+  };
+
   afterEach(() => {
     delete (global as any).fetch;
     delete process.env.OPENAI_API_KEY;
@@ -18,71 +22,72 @@ describe('getLLMSuggestions', () => {
     expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
   });
 
-  it('parses and returns suggestions from the API', async () => {
-    process.env.OPENAI_API_KEY = 'test';
-    (global as any).fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        choices: [
-          {
-            message: {
-              content: JSON.stringify({
-                nextWords: ['tschüss'],
-                caregiverPhrases: ['Wie geht es dir?'],
-              }),
+  describe('with API key', () => {
+    beforeEach(() => {
+      process.env.OPENAI_API_KEY = 'test';
+    });
+
+    it('parses and returns suggestions from the API', async () => {
+      mockFetch({
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  nextWords: ['tschüss'],
+                  caregiverPhrases: ['Wie geht es dir?'],
+                }),
+              },
             },
-          },
-        ],
-      }),
+          ],
+        }),
+      });
+      const res = await getLLMSuggestions(req);
+      expect(res.nextWords).toContain('tschüss');
+      expect(res.caregiverPhrases).toContain('Wie geht es dir?');
     });
-    const res = await getLLMSuggestions(req);
-    expect(res.nextWords).toContain('tschüss');
-    expect(res.caregiverPhrases).toContain('Wie geht es dir?');
-  });
 
-  it('returns empty arrays on invalid API response', async () => {
-    process.env.OPENAI_API_KEY = 'test';
-    (global as any).fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        choices: [
-          { message: { content: '{"foo": "bar"}' } },
-        ],
-      }),
+    it('returns empty arrays on invalid API response', async () => {
+      mockFetch({
+        ok: true,
+        json: async () => ({
+          choices: [
+            { message: { content: '{"foo": "bar"}' } },
+          ],
+        }),
+      });
+      const res = await getLLMSuggestions(req);
+      expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
     });
-    const res = await getLLMSuggestions(req);
-    expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
-  });
 
-  it('returns empty arrays when response JSON parsing fails', async () => {
-    process.env.OPENAI_API_KEY = 'test';
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    (global as any).fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => {
-        throw new Error('invalid json');
-      },
+    it('returns empty arrays when response JSON parsing fails', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockFetch({
+        ok: true,
+        json: async () => {
+          throw new Error('invalid json');
+        },
+      });
+      const res = await getLLMSuggestions(req);
+      expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
     });
-    const res = await getLLMSuggestions(req);
-    expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
-    expect(consoleErrorSpy).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
-  });
 
-  it('returns empty arrays when API response is not ok', async () => {
-    process.env.OPENAI_API_KEY = 'test';
-    (global as any).fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      status: 500,
+    it('returns empty arrays when API response is not ok', async () => {
+      mockFetch({
+        ok: false,
+        status: 500,
+      });
+      const res = await getLLMSuggestions(req);
+      expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
     });
-    const res = await getLLMSuggestions(req);
-    expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
-  });
 
-  it('returns empty arrays when fetch throws an error', async () => {
-    process.env.OPENAI_API_KEY = 'test';
-    (global as any).fetch = jest.fn().mockRejectedValue(new Error('network'));
-    const res = await getLLMSuggestions(req);
-    expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
+    it('returns empty arrays when fetch throws an error', async () => {
+      (global as any).fetch = jest.fn().mockRejectedValue(new Error('network'));
+      const res = await getLLMSuggestions(req);
+      expect(res).toEqual({ nextWords: [], caregiverPhrases: [] });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- mirror user-facing camera only so recordings from back camera aren't reversed
- test webview camera CSS for correct mirroring
- test dialogEngine for non-ok responses and network errors
- ensure empty suggestions on invalid JSON

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ae1c77f3bc83228d30d5b952e84a2b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Camera preview mirroring now applies only for user-facing cameras; rear-facing camera previews and overlays are no longer flipped.

* **Tests**
  * Adds tests verifying mirroring behavior for user vs. environment cameras (video + overlay).
  * Adds server-side tests covering suggestion retrieval error paths to ensure failures return empty results without throwing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->