### PR TITLE
test: verify mlp model response headers

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -47,6 +47,7 @@
     - Add tests:
       - [x] Uploading samples triggers MLP training and creates model files.
       - [x] `/latest-mlp-model` returns 200 for an authorized owner, 403 for unauthorized access, and 404 when no model exists.
+      - [x] `/latest-mlp-model` sets `ETag`, `X-Checksum-SHA256` and `X-Model-Version` headers.
 12. **App wiring** – extend `MediaPipeGestureDetector.tsx` to fetch `/latest-mlp-model`, parse `.npz` weights, and run the MLP forward pass with centroid or rule-based fallback.
 
 ## Immediate Next Steps

--- a/server/test/test_latest_mlp_model.py
+++ b/server/test/test_latest_mlp_model.py
@@ -5,6 +5,7 @@ import time
 import urllib.request
 import urllib.error
 import shutil
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -136,3 +137,20 @@ def test_latest_mlp_model_returns_200_for_authorized_owner(model_file, running_s
         profile_id="p1", extra_headers={"x-profile-id": "p1"}
     )
     assert status == 200
+
+
+def test_latest_mlp_model_sets_headers(model_file, running_server):
+    url = f"{BASE_URL}/latest-mlp-model?profileId=p1"
+    headers = {"Authorization": "Bearer testtoken", "x-profile-id": "p1"}
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        assert resp.getcode() == 200
+        # consume body to ensure headers are final
+        resp.read()
+        expected_sha256 = hashlib.sha256(b"placeholder").hexdigest()
+        assert resp.headers.get("ETag") == f'"sha256-{expected_sha256}"'
+        assert resp.headers.get("X-Checksum-SHA256") == expected_sha256
+        version = resp.headers.get("X-Model-Version")
+        assert version is not None and version.isdigit()
+        cache_control = resp.headers.get("Cache-Control")
+        assert cache_control == "private, max-age=0, must-revalidate"


### PR DESCRIPTION
## Summary
- add test ensuring `/latest-mlp-model` returns ETag, checksum, and version headers
- document completion of header tests in TODO roadmap

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `pytest -q server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ae351ad8688322880196de77dea107