### PR TITLE
chore: localize offline and init messages

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -70,8 +70,8 @@ export default function App() {
       } catch (e) {
         logger.error('Failed to initialize app:', e);
         Alert.alert(
-          'Initialization Error',
-          "Amy's Echo failed to start properly. Please restart the app.",
+          'Fehler beim Start',
+          "Amy's Echo konnte nicht richtig gestartet werden. Bitte starte die App neu.",
           [{ text: 'OK' }],
         );
       } finally {
@@ -91,7 +91,7 @@ export default function App() {
       if (!handledInitial.current) {
         handledInitial.current = true;
         if (offline) {
-          AccessibilityInfo.announceForAccessibility('Offline mode');
+          AccessibilityInfo.announceForAccessibility('Offline-Modus');
         }
       }
     });
@@ -109,7 +109,7 @@ export default function App() {
           size="large"
           color={accessibility.highContrast ? COLORS.highContrastText : COLORS.primaryAccent}
           accessibilityRole="progressbar"
-          accessibilityLabel="Loading Amy's Echo"
+          accessibilityLabel="Amy's Echo wird geladen"
         />
       </LinearGradient>
     );

--- a/app/src/components/OfflineBanner.tsx
+++ b/app/src/components/OfflineBanner.tsx
@@ -26,7 +26,7 @@ export default function OfflineBanner({ visible }: Props) {
       <Text
         style={[styles.text, highContrast && styles.textHC, { fontSize: largeText ? 16 : 14 }]}
       >
-        Offline mode
+        Offline-Modus
       </Text>
     </View>
   );

--- a/app/test/offlineBanner.test.tsx
+++ b/app/test/offlineBanner.test.tsx
@@ -37,7 +37,7 @@ describe('OfflineBanner', () => {
     const tree = component as renderer.ReactTestRenderer;
     const view = tree.root.findByType('View');
     const text = tree.root.findByType('Text');
-    expect(text.props.children).toBe('Offline mode');
+    expect(text.props.children).toBe('Offline-Modus');
     expect(view.props.accessibilityRole).toBe('alert');
   });
 


### PR DESCRIPTION
## Summary
- Localize offline mode banner, accessibility announcement, and startup error messaging in German
- Update tests for German offline banner text

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ae384a80d8832297587b76445aead9