### PR TITLE
feat: unify loading indicator

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -106,7 +106,7 @@ export default function App() {
   if (!isReady) {
     return (
       <LinearGradient colors={gradientColors} style={styles.container}>
-        <LoadingIndicator />
+        <LoadingIndicator label="Amy's Echo wird geladen" />
       </LinearGradient>
     );
   }

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,6 +1,6 @@
 import 'react-native-gesture-handler';
 import React, { useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, StyleSheet, AccessibilityInfo, LogBox } from 'react-native';
+import { Alert, StyleSheet, AccessibilityInfo, LogBox } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import { NavigationContainer } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -19,6 +19,7 @@ import { initCrashReporting, onAppStartCrashFlush } from './src/services/crashRe
 import { PerformanceProvider } from './src/context/PerformanceContext';
 import ChildErrorBoundary from './src/components/ChildErrorBoundary';
 import OfflineBanner from './src/components/OfflineBanner';
+import LoadingIndicator from './src/components/LoadingIndicator';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 export default function App() {
@@ -105,12 +106,7 @@ export default function App() {
   if (!isReady) {
     return (
       <LinearGradient colors={gradientColors} style={styles.container}>
-        <ActivityIndicator
-          size="large"
-          color={accessibility.highContrast ? COLORS.highContrastText : COLORS.primaryAccent}
-          accessibilityRole="progressbar"
-          accessibilityLabel="Amy's Echo wird geladen"
-        />
+        <LoadingIndicator />
       </LinearGradient>
     );
   }

--- a/app/src/components/LoadingIndicator.tsx
+++ b/app/src/components/LoadingIndicator.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { useAccessibility } from './AccessibilityContext';
+import { COLORS, SPACING } from '../constants/ui';
+
+export default function LoadingIndicator() {
+  const { highContrast, largeText } = useAccessibility();
+  const color = highContrast ? COLORS.highContrastText : COLORS.primaryAccent;
+  const fontSize = largeText ? 18 : 16;
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator
+        size="large"
+        color={color}
+        accessibilityRole="progressbar"
+        accessibilityLabel="Wird geladen"
+      />
+      <Text style={[styles.text, highContrast && styles.textHC, { fontSize }]}>Wird geladen...</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: SPACING.md,
+  },
+  text: {
+    marginTop: SPACING.md,
+    color: COLORS.text,
+  },
+  textHC: {
+    color: COLORS.highContrastText,
+  },
+});

--- a/app/src/components/LoadingIndicator.tsx
+++ b/app/src/components/LoadingIndicator.tsx
@@ -3,29 +3,40 @@ import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 import { useAccessibility } from './AccessibilityContext';
 import { COLORS, SPACING } from '../constants/ui';
 
-export default function LoadingIndicator() {
+type LoadingIndicatorProps = {
+  label?: string;
+  fullscreen?: boolean;
+};
+
+export default function LoadingIndicator({
+  label = 'Wird geladen...',
+  fullscreen = true,
+}: LoadingIndicatorProps) {
   const { highContrast, largeText } = useAccessibility();
   const color = highContrast ? COLORS.highContrastText : COLORS.primaryAccent;
   const fontSize = largeText ? 18 : 16;
+  const accessibilityLabel = label.replace(/\.\.\.$/, '');
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, fullscreen && styles.fullscreen]}>
       <ActivityIndicator
         size="large"
         color={color}
         accessibilityRole="progressbar"
-        accessibilityLabel="Wird geladen"
+        accessibilityLabel={accessibilityLabel}
       />
-      <Text style={[styles.text, highContrast && styles.textHC, { fontSize }]}>Wird geladen...</Text>
+      <Text style={[styles.text, highContrast && styles.textHC, { fontSize }]}>{label}</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     padding: SPACING.md,
+  },
+  fullscreen: {
+    flex: 1,
   },
   text: {
     marginTop: SPACING.md,

--- a/app/src/context/AppServicesProvider.tsx
+++ b/app/src/context/AppServicesProvider.tsx
@@ -5,7 +5,7 @@ const LAST_DAILY_JOB_KEY = 'lastDailyJob';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { audioService, backupService, checkForModelUpdate, syncService, syncTrainingData, gestureDataProtector, gdprService } from '../services';
 import { adaptiveLearningService } from '../services/adaptiveLearningService';
-import { ActivityIndicator, View } from 'react-native';
+import LoadingIndicator from '../components/LoadingIndicator';
 import { useMessage } from './MessageContext';
 import { loadCustomModelUri, loadActiveProfileId } from '../storage';
 import {
@@ -96,11 +96,7 @@ export const AppServicesProvider = ({ children, offline = false }: ProviderProps
   }, []);
 
   if (!areServicesReady) {
-    return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <ActivityIndicator size="large" />
-      </View>
-    );
+    return <LoadingIndicator />;
   }
 
   return (

--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -1,9 +1,9 @@
 
 import React, { Suspense, useEffect, useState } from 'react';
-import { ActivityIndicator, View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { RootStackParamList } from './types';
 import { loadProfiles } from '../storage';
+import LoadingIndicator from '../components/LoadingIndicator';
 
 const lazyScreen = (
   factory: () => Promise<any>,
@@ -34,12 +34,6 @@ const CaregiverReportScreen = lazyScreen(() => import('../screens/CaregiverRepor
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
-const Loading = () => (
-  <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-    <ActivityIndicator size="large" />
-  </View>
-);
-
 const RootNavigator = () => {
   const [initialRoute, setInitialRoute] = useState<keyof RootStackParamList | undefined>();
 
@@ -49,10 +43,10 @@ const RootNavigator = () => {
     });
   }, []);
 
-  if (!initialRoute) return <Loading />;
+  if (!initialRoute) return <LoadingIndicator />;
 
   return (
-    <Suspense fallback={<Loading />}>
+    <Suspense fallback={<LoadingIndicator />}>
       <Stack.Navigator initialRouteName={initialRoute}>
       <Stack.Screen
         name="Onboarding"

--- a/app/test/loadingIndicator.test.tsx
+++ b/app/test/loadingIndicator.test.tsx
@@ -1,0 +1,55 @@
+jest.mock('react-native', () => {
+  const React = require('react');
+  return {
+    View: (props: any) => React.createElement('View', props, props.children),
+    Text: (props: any) => React.createElement('Text', props, props.children),
+    ActivityIndicator: (props: any) => React.createElement('ActivityIndicator', props, props.children),
+    StyleSheet: { create: (styles: any) => styles },
+  };
+});
+
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import LoadingIndicator from '../src/components/LoadingIndicator';
+import { AccessibilityContext } from '../src/components/AccessibilityContext';
+import { COLORS } from '../src/constants/ui';
+
+describe('LoadingIndicator', () => {
+  const value = { highContrast: false, largeText: false, update: () => {} };
+
+  it('renders loading text and spinner', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <AccessibilityContext.Provider value={value}>
+          <LoadingIndicator />
+        </AccessibilityContext.Provider>,
+      );
+    });
+    const text = (component as renderer.ReactTestRenderer).root.findByType('Text');
+    const spinner = (component as renderer.ReactTestRenderer).root.findByType('ActivityIndicator');
+    expect(text.props.children).toBe('Wird geladen...');
+    expect(spinner.props.accessibilityRole).toBe('progressbar');
+  });
+
+  it('applies high contrast and large text styles', () => {
+    const hc = { highContrast: true, largeText: true, update: () => {} };
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <AccessibilityContext.Provider value={hc}>
+          <LoadingIndicator />
+        </AccessibilityContext.Provider>,
+      );
+    });
+    const text = (component as renderer.ReactTestRenderer).root.findByType('Text');
+    const spinner = (component as renderer.ReactTestRenderer).root.findByType('ActivityIndicator');
+    expect(text.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ color: COLORS.highContrastText }),
+        expect.objectContaining({ fontSize: 18 }),
+      ]),
+    );
+    expect(spinner.props.color).toBe(COLORS.highContrastText);
+  });
+});

--- a/app/test/loadingIndicator.test.tsx
+++ b/app/test/loadingIndicator.test.tsx
@@ -52,4 +52,44 @@ describe('LoadingIndicator', () => {
     );
     expect(spinner.props.color).toBe(COLORS.highContrastText);
   });
+
+  it('renders a custom label', () => {
+    const customLabel = 'Daten werden geladen...';
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <AccessibilityContext.Provider value={value}>
+          <LoadingIndicator label={customLabel} />
+        </AccessibilityContext.Provider>,
+      );
+    });
+    const text = (component as renderer.ReactTestRenderer).root.findByType('Text');
+    expect(text.props.children).toBe(customLabel);
+  });
+
+  it('is fullscreen by default', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <AccessibilityContext.Provider value={value}>
+          <LoadingIndicator />
+        </AccessibilityContext.Provider>,
+      );
+    });
+    const view = (component as renderer.ReactTestRenderer).root.findByType('View');
+    expect(view.props.style).toEqual(expect.arrayContaining([{ flex: 1 }]));
+  });
+
+  it('is not fullscreen when specified', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <AccessibilityContext.Provider value={value}>
+          <LoadingIndicator fullscreen={false} />
+        </AccessibilityContext.Provider>,
+      );
+    });
+    const view = (component as renderer.ReactTestRenderer).root.findByType('View');
+    expect(view.props.style).not.toContainEqual({ flex: 1 });
+  });
 });


### PR DESCRIPTION
## Summary
- add reusable LoadingIndicator with German text and accessibility-aware styling
- replace inline spinners in navigation, service bootstrap, and app startup
- test LoadingIndicator rendering and high-contrast modes

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: fetch failed; network required)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68ae5fdf35188322a99d5a06afe06938

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a unified LoadingIndicator with spinner and label, used during app startup and lazy-load fallbacks.
  - Improved accessibility: progress role, localized label, high-contrast and large-text support.

- Refactor
  - Replaced scattered loading spinners with a centralized component for consistent appearance across app startup, navigation guards, and Suspense fallbacks.

- Tests
  - Added unit tests validating rendering, accessibility attributes, contrast and large-text behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->