### PR TITLE
feat: localize DGS toggle and avoid duplicate TTS playback

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -457,7 +457,7 @@ export default function RecognitionScreen({ navigation }: any) {
     </View>
 
     <View style={styles.toggleRow}>
-      <Text style={styles.toggleLabel}>Show DGS Video</Text>
+      <Text style={styles.toggleLabel}>DGS-Video anzeigen</Text>
       <Switch
         value={showDgsVideo}
         onValueChange={setShowDgsVideo}

--- a/app/src/services/audioService.ts
+++ b/app/src/services/audioService.ts
@@ -22,6 +22,8 @@ export class AudioService {
   private speechQueue: Array<{ text: string; options: SpeechOptions }> = [];
   private isSpeaking = false;
   private recording: AudioRecorder | null = null;
+  private lastSpokenText = '';
+  private lastSpokenAt = 0;
 
   constructor(config: AudioConfig) {
     this.config = {...config};
@@ -137,6 +139,11 @@ export class AudioService {
       logger.warn('Audio service not initialized');
       return;
     }
+    const now = Date.now();
+    if (text === this.lastSpokenText && now - this.lastSpokenAt < 2000) {
+      logger.debug(`Duplicate speech skipped: ${text}`);
+      return;
+    }
 
     const speechOptions: SpeechOptions = {
       language: this.config.speechLanguage,
@@ -146,9 +153,15 @@ export class AudioService {
       ...options,
     };
 
-    // Add to queue if already speaking
+    this.lastSpokenText = text;
+    this.lastSpokenAt = now;
+
+    // Add to queue if already speaking, avoid duplicate queue entries
     if (this.isSpeaking) {
-      this.speechQueue.push({ text, options: speechOptions });
+      const lastQueued = this.speechQueue[this.speechQueue.length - 1];
+      if (!lastQueued || lastQueued.text !== text) {
+        this.speechQueue.push({ text, options: speechOptions });
+      }
       return;
     }
 

--- a/app/test/audioFeedback.test.ts
+++ b/app/test/audioFeedback.test.ts
@@ -63,6 +63,8 @@ describe('audioService feedback', () => {
     (audioService as any).isInitialized = true;
     (audioService as any).isSpeaking = false;
     (audioService as any).speechQueue = [];
+    (audioService as any).lastSpokenText = '';
+    (audioService as any).lastSpokenAt = 0;
   });
 
   it('plays success sound and speaks guidance when confidence is low', async () => {
@@ -99,6 +101,12 @@ describe('audioService feedback', () => {
       'Lass uns Winken nochmal versuchen!',
       'Wie wäre es mit etwas Übung für Winken?',
     ]).toContain(phrase);
+  });
+
+  it('skips duplicate speech requests in quick succession', async () => {
+    await audioService.speak('Hallo');
+    await audioService.speak('Hallo');
+    expect(Speech.speak).toHaveBeenCalledTimes(1);
   });
 
   it('plays pre-recorded audio when available', async () => {


### PR DESCRIPTION
## Summary
- localize the recognition screen toggle label for showing the DGS video
- track last spoken text to skip rapid duplicate TTS playback and prevent duplicate queue entries
- cover duplicate-speech prevention with a unit test

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68af32d233008322b6bc4a98c03b5c3c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Prevents rapid, duplicate audio announcements when the same text is triggered in quick succession, reducing repeated prompts.
- Style
  - Localized the DGS video toggle label to German (“DGS-Video anzeigen”) in the recognition screen.
- Tests
  - Added tests to ensure duplicate speech requests are skipped when triggered back-to-back.

Note: No changes to public APIs or user workflows; improvements focus on polish and a smoother audio feedback experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->