### PR TITLE
feat: localize DGS toggle and dedupe TTS playback

### DIFF
--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -24,5 +24,9 @@
     "predictionError": "Vorhersagefehler: ",
     "cameraError": "Kamerafehler: ",
     "noLandmarksCaptured": "Keine Landmarken erfasst"
+  },
+  "recognition": {
+    "showDgsVideo": "DGS-Video anzeigen",
+    "toggleDgsVideo": "DGS-Video umschalten"
   }
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -24,5 +24,9 @@
     "predictionError": "Prediction error: ",
     "cameraError": "Camera error: ",
     "noLandmarksCaptured": "No landmarks captured"
+  },
+  "recognition": {
+    "showDgsVideo": "Show DGS Video",
+    "toggleDgsVideo": "Toggle DGS Video"
   }
 }

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -35,6 +35,7 @@ import { OneEuroFilter } from '../services/OneEuroFilter';
 import { SequenceRecognizer, SequenceDefinition } from '../services/sequenceRecognizer';
 import { RecognitionPath } from '../utils/recognitionState';
 import DgsVideoPlayer from '../components/DgsVideoPlayer';
+import { LanguageManager } from '../services/LanguageManager';
 // ExpoCameraDetector removed from default path (server-based); WebView is primary
 
 export default function RecognitionScreen({ navigation }: any) {
@@ -457,11 +458,11 @@ export default function RecognitionScreen({ navigation }: any) {
     </View>
 
     <View style={styles.toggleRow}>
-      <Text style={styles.toggleLabel}>Show DGS Video</Text>
+      <Text style={styles.toggleLabel}>{LanguageManager.t('recognition.showDgsVideo')}</Text>
       <Switch
         value={showDgsVideo}
         onValueChange={setShowDgsVideo}
-        accessibilityLabel="DGS-Video umschalten"
+        accessibilityLabel={LanguageManager.t('recognition.toggleDgsVideo')}
       />
     </View>
 

--- a/app/src/services/audioService.ts
+++ b/app/src/services/audioService.ts
@@ -15,12 +15,16 @@ import { database } from '../../db';
 import { Symbol } from '../../db/models';
 import * as FileSystem from 'expo-file-system';
 
+const DUPLICATE_SPEECH_DEBOUNCE_MS = 2000;
+
 export class AudioService {
   private sounds: Map<string, ReturnType<typeof createAudioPlayer>> = new Map();
   private isInitialized = false;
   private config: AudioConfig;
   private speechQueue: Array<{ text: string; options: SpeechOptions }> = [];
   private isSpeaking = false;
+  private lastSpokenText = '';
+  private lastSpokenAt = 0;
   private recording: AudioRecorder | null = null;
 
   constructor(config: AudioConfig) {
@@ -146,9 +150,21 @@ export class AudioService {
       ...options,
     };
 
+    const now = Date.now();
+    const key = (text ?? '').trim().toLowerCase();
+    if (key === this.lastSpokenText && now - this.lastSpokenAt < DUPLICATE_SPEECH_DEBOUNCE_MS) {
+      logger.debug(`Duplicate speech skipped: ${text}`);
+      return;
+    }
+    this.lastSpokenText = key;
+    this.lastSpokenAt = now;
+
     // Add to queue if already speaking
     if (this.isSpeaking) {
-      this.speechQueue.push({ text, options: speechOptions });
+      const lastQueued = this.speechQueue[this.speechQueue.length - 1];
+      if (!lastQueued || lastQueued.text.trim().toLowerCase() !== this.lastSpokenText) {
+        this.speechQueue.push({ text, options: speechOptions });
+      }
       return;
     }
 

--- a/app/test/audioFeedback.test.ts
+++ b/app/test/audioFeedback.test.ts
@@ -53,8 +53,7 @@ describe('audioService feedback', () => {
     remove: jest.fn(),
   });
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+  const resetService = () => {
     (audioService as any).sounds = new Map([
       ['success', soundMock()],
       ['error', soundMock()],
@@ -63,6 +62,13 @@ describe('audioService feedback', () => {
     (audioService as any).isInitialized = true;
     (audioService as any).isSpeaking = false;
     (audioService as any).speechQueue = [];
+    (audioService as any).lastSpokenText = '';
+    (audioService as any).lastSpokenAt = 0;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetService();
   });
 
   it('plays success sound and speaks guidance when confidence is low', async () => {
@@ -115,6 +121,26 @@ describe('audioService feedback', () => {
 
     (database as any).get = originalGet;
     customSpy.mockRestore();
+  });
+
+  it('skips duplicate speech requests in quick succession', async () => {
+    await audioService.speak('Hallo');
+    await audioService.speak('hallo');
+    expect(Speech.speak).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows repeat after debounce window', async () => {
+    await audioService.speak('Hallo');
+    await new Promise((res) => setTimeout(res, 2100));
+    await audioService.speak('Hallo');
+    expect(Speech.speak).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not enqueue duplicate while speaking', async () => {
+    (audioService as any).isSpeaking = true;
+    await audioService.speak('Hallo');
+    await audioService.speak('  hallo  ');
+    expect((audioService as any).speechQueue.length).toBe(1);
   });
 });
 

--- a/docs/DeviceTesting.md
+++ b/docs/DeviceTesting.md
@@ -56,7 +56,7 @@ cd app/android
 - Perform known gesture:
   - Speak + Show (animation) when confident.
   - “Help Me” + correction flow when uncertain.
-- Toggle “Show DGS Video” to verify playback.
+- Toggle “DGS-Video anzeigen” to verify playback.
 
 ### Env Toggles (before starting Metro)
 ```

--- a/docs/KindergartenWorkflow.md
+++ b/docs/KindergartenWorkflow.md
@@ -23,7 +23,7 @@ This short field guide shows how kindergarten staff who do not understand German
 3. Select the correct symbol. The app responds as if it recognized the gesture and remembers the correction for next time.
 
 ## Step 4: Show DGS Reference Videos
-1. Toggle **Show DGS Video** on the recognition screen to display a short clip for each symbol.
+1. Toggle **DGS-Video anzeigen** on the recognition screen to display a short clip for each symbol.
 2. These videos help staff learn or review the correct sign without leaving recognition mode.
 
 ## Step 5: Review and Practice

--- a/docs/LocalizationLearnings.md
+++ b/docs/LocalizationLearnings.md
@@ -1,0 +1,8 @@
+# Localization Learnings
+
+While wiring the DGS-video toggle through `LanguageManager`, we noted several follow-up ideas:
+
+- Route all user-visible strings through `LanguageManager` instead of hardcoding German text.
+- Simplify the `LanguageManager` so adding new languages is straightforward.
+- Although Amy currently only needs German, design the system so other children can switch to their preferred language in the future.
+

--- a/docs/SpeechDeduplicationLearnings.md
+++ b/docs/SpeechDeduplicationLearnings.md
@@ -1,0 +1,8 @@
+# Speech Deduplication Learnings
+
+While localizing the DGS toggle and adding Text-to-Speech (TTS) de-duplication, we noted a few guidelines for future work:
+
+- Localize UI strings via `LanguageManager` instead of hardcoded text.
+- Normalize speech input (`trim().toLowerCase()`) and track the last spoken phrase with a debounce window to avoid rapid repeats.
+- Tests should assert duplicate suppression, queue de-duplication, and proper behaviour when the debounce window expires.
+- Consider making the debounce window configurable and allowing explicit overrides when repeated speech is desired.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11,6 +11,8 @@
 - [x] Add unit tests ensuring MLP training runs and creates model files
  - [x] Enforce per-profile authorization on `/latest-mlp-model` (403 on unauthorized access; non-enumerable errors)
  - [x] Write models atomically (temp file + rename) and serve with `ETag` + `X-Model-Version`
+- [ ] Review TTS de-duplication window and make it configurable (see `SpeechDeduplicationLearnings.md`)
+- [ ] Reevaluate LanguageManager to simplify localization and allow additional languages (see `LocalizationLearnings.md`)
 
 ## Current Architecture Status
 ✅ **WebView + MediaPipe Integration Complete** (as of 2025-08-21)


### PR DESCRIPTION
## Summary
- localize recognition screen DGS toggle via LanguageManager
- skip rapid duplicate TTS requests and avoid duplicate queue entries
- test speech de-duplication behavior
- document speech de-duplication learnings and track configurable window follow-up
- document localization follow-ups and track LanguageManager simplification for multi-language support

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH 34.110.201.56:443)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68af476b0b88832296aabdb8596a1c03