### PR TITLE
docs: add gesture training blind spot tasks

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,6 +14,16 @@
 - [ ] Review TTS de-duplication window and make it configurable (see `SpeechDeduplicationLearnings.md`)
 - [ ] Reevaluate LanguageManager to simplify localization and allow additional languages (see `LocalizationLearnings.md`)
 
+## Gesture Training Blind Spot Tasks
+*For Amy – voku/AmysEcho*
+
+- [ ] Preserve handedness when saving training samples
+- [ ] Flatten DGS samples before POST
+- [ ] Align MLP label storage with WebView
+- [ ] Unify landmark normalization algorithms
+- [ ] Report basic training metrics
+
+
 ## Current Architecture Status
 ✅ **WebView + MediaPipe Integration Complete** (as of 2025-08-21)
 - Hand landmark extraction via MediaPipe in WebView


### PR DESCRIPTION
## Summary
- track blind spot tasks for gesture training workflow

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68af59bcea808322b0f1dd974c3a6ead