### PR TITLE
feat: retain handedness in gesture samples

### DIFF
--- a/app/src/components/ExpoCameraDetector.tsx
+++ b/app/src/components/ExpoCameraDetector.tsx
@@ -12,7 +12,12 @@ try {
 } catch {}
 
 interface Props {
-  onGestureDetected: (gesture: string, confidence: number, landmarks: number[][][]) => void;
+  onGestureDetected: (
+    gesture: string,
+    confidence: number,
+    landmarks: number[][][],
+    handedness: string[],
+  ) => void;
   onError: (error: string) => void;
   cameraType?: 'front' | 'back';
 }
@@ -63,7 +68,7 @@ const ExpoCameraDetector: React.FC<Props> = ({ onGestureDetected, onError, camer
           const json = await res.json();
           const g = json?.gesture || 'unknown';
           const c = json?.confidence ?? 0;
-          onGestureDetected(g, c, []);
+          onGestureDetected(g, c, [], []);
         }
       } catch (e: any) {
         // only surface once

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -33,6 +33,7 @@ interface Props {
     gesture: string | null,
     confidence: number,
     landmarks: number[][][],
+    handedness: string[],
   ) => void;
   onError: (error: string) => void;
   onWebViewEvent?: (telemetry: WebViewTelemetry) => void;
@@ -279,11 +280,12 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
             let outGesture = null;
             let outScore = 0;
             const perHand = [];
+            const handedArr = (results?.handednesses || []).map(h => (h?.[0]?.categoryName) || 'unknown');
             if (results?.gestures?.length) {
               for (let i=0; i<results.gestures.length; i++) {
                 const handGestures = results.gestures[i] || [];
                 const top = handGestures?.[0];
-                const handed = (results?.handednesses?.[i]?.[0]?.categoryName) || 'unknown';
+                const handed = handedArr[i] || 'unknown';
                 if (top) {
                   perHand.push({ hand: handed, label: top.categoryName, score: top.score });
                   if (top.score > outScore) {
@@ -394,7 +396,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
                     gesture: outGesture || null,
                     confidence,
                     landmarks: allLandmarks,
-                    hands: perHand,
+                    handednesses: handedArr,
                   }),
                 );
               }
@@ -455,7 +457,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
       const data = JSON.parse(event.nativeEvent.data);
       
       if (data.type === 'gesture') {
-        onGestureDetected(data.gesture, data.confidence, data.landmarks);
+        onGestureDetected(data.gesture, data.confidence, data.landmarks, data.handednesses || []);
       } else if (data.type === 'error') {
         onError(data.message);
       } else if (data.type === 'warn') {

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -25,7 +25,7 @@ import { buildLocalCentroids } from '../services/localCentroids';
 import { classifyWithCentroids } from '../services/offlineClassifier';
 import type { CentroidMap } from '../services/dgsModelClient';
 import { LLMSuggestionResponse } from '../services/dialogEngine';
-import { flattenHands } from '../services/handUtils';
+import { flattenHandsWithHandedness } from '../services/handUtils';
 import { OFFLINE_CLASSIFIER_TRIGGER_THRESHOLD } from '../constants/gesture';
 import MaintenanceBanner from '../components/MaintenanceBanner';
 import { logInteractionEvent } from '../services/analytics';
@@ -138,13 +138,14 @@ export default function RecognitionScreen({ navigation }: any) {
     gesture: string | null,
     confidence: number,
     landmarks: number[][][],
+    handedness: string[],
   ) => {
     let g = gesture;
     let c = confidence;
     let path: RecognitionPath = 'local';
 
     if (centroidsRef.current && (!g || c < OFFLINE_CLASSIFIER_TRIGGER_THRESHOLD)) {
-      const flat = flattenHands(landmarks);
+      const flat = flattenHandsWithHandedness(landmarks, handedness);
       const res = classifyWithCentroids(flat, centroidsRef.current);
       if (res && res.confidence > c) {
         g = res.label;

--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -29,6 +29,7 @@ export default function TeachingScreen({ navigation }: any) {
   const sessionId = useRef<string | null>(null);
   const SAMPLES_NEEDED = 5;
   const landmarksRef = useRef<number[][][]>([]);
+  const handednessRef = useRef<string[]>([]);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { setMessage } = useMessage();
@@ -50,8 +51,9 @@ export default function TeachingScreen({ navigation }: any) {
   }, []);
 
   const handleGestureDetected = useCallback(
-    (_gesture: string | null, _confidence: number, lms: number[][][]) => {
+    (_gesture: string | null, _confidence: number, lms: number[][][], hands: string[]) => {
       landmarksRef.current = lms;
+      handednessRef.current = hands;
     },
     []
   );
@@ -101,7 +103,7 @@ export default function TeachingScreen({ navigation }: any) {
     setIsRecording(true);
     setError(null);
     try {
-      const frames = await captureSamples(() => landmarksRef.current);
+      const frames = await captureSamples(() => ({ landmarks: landmarksRef.current, handedness: handednessRef.current }));
       await saveTrainingSample(gestureLabel, frames);
       setSampleCount((c) => c + 1);
       startSampleCaptureAnimation();

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -99,8 +99,7 @@ export default function TrainingScreen({ navigation, route }: any) {
       return;
     }
     try {
-      const frames = recordedFrames;
-      await saveTrainingSample(gestureId, frames, isPractice ? 'HIP_4' : 'HIP_2');
+      await saveTrainingSample(gestureId, recordedFrames, isPractice ? 'HIP_4' : 'HIP_2');
       setCount((c) => c + 1);
       setError(null);
       // HIP 2 or 4: sample saved

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -29,6 +29,7 @@ export default function TrainingScreen({ navigation, route }: any) {
   const [count, setCount] = useState(0);
   const [isRecording, setIsRecording] = useState(false);
   const [recordedLandmarks, setRecordedLandmarks] = useState<number[][][][]>([]);
+  const [recordedHandedness, setRecordedHandedness] = useState<string[][]>([]);
   const [framesCaptured, setFramesCaptured] = useState(0);
   const [lastDetection, setLastDetection] = useState(0);
   const [now, setNow] = useState(Date.now());
@@ -82,6 +83,7 @@ export default function TrainingScreen({ navigation, route }: any) {
     if (!gestureId) return;
     setError(null);
     setRecordedLandmarks([]);
+    setRecordedHandedness([]);
     setFramesCaptured(0);
     setLastDetection(0);
     setIsRecording(true);
@@ -99,7 +101,8 @@ export default function TrainingScreen({ navigation, route }: any) {
       return;
     }
     try {
-      await saveTrainingSample(gestureId, recordedLandmarks, isPractice ? 'HIP_4' : 'HIP_2');
+      const frames = recordedLandmarks.map((lm, i) => ({ landmarks: lm, handedness: recordedHandedness[i] || [] }));
+      await saveTrainingSample(gestureId, frames, isPractice ? 'HIP_4' : 'HIP_2');
       setCount((c) => c + 1);
       setError(null);
       // HIP 2 or 4: sample saved
@@ -213,16 +216,17 @@ export default function TrainingScreen({ navigation, route }: any) {
           })()}
           <View style={styles.cameraContainer}>
             <MediaPipeGestureDetector
-              onGestureDetected={(_g, _c, lm) => {
+              onGestureDetected={(_g, _c, lm, hands) => {
                 setLandmarks(lm);
                 setLastDetection(Date.now());
                 if (isRecordingRef.current) {
-                    setRecordedLandmarks((prev) => [...prev, lm]);
-                    setFramesCaptured((c) => c + 1);
-                  }
-                }}
-                onError={(m) => logger.warn('TrainingScreen detector error:', m)}
-              />
+                  setRecordedLandmarks((prev) => [...prev, lm]);
+                  setRecordedHandedness((prev) => [...prev, hands]);
+                  setFramesCaptured((c) => c + 1);
+                }
+              }}
+              onError={(m) => logger.warn('TrainingScreen detector error:', m)}
+            />
               {landmarks.length > 0 && (
                 <Svg
                   style={StyleSheet.absoluteFill}

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -3,7 +3,7 @@ import { View, Text, Button, StyleSheet, AppState, SafeAreaView } from 'react-na
 import { useIsFocused } from '@react-navigation/native';
 // Camera preview replaced by MediaPipe WebView detector
 import Svg, { Circle } from 'react-native-svg';
-import { saveTrainingSample, loadProfile, Profile } from '../storage';
+import { saveTrainingSample, loadProfile, Profile, TrainingFrame } from '../storage';
 import { sendDgsSample } from '../services/dgsTrainingService';
 import { gestureModel } from '../model';
 import { useAccessibility } from '../components/AccessibilityContext';
@@ -28,8 +28,7 @@ export default function TrainingScreen({ navigation, route }: any) {
   const [gestureId, setGestureId] = useState<string | null>(gestureLabel || null);
   const [count, setCount] = useState(0);
   const [isRecording, setIsRecording] = useState(false);
-  const [recordedLandmarks, setRecordedLandmarks] = useState<number[][][][]>([]);
-  const [recordedHandedness, setRecordedHandedness] = useState<string[][]>([]);
+  const [recordedFrames, setRecordedFrames] = useState<TrainingFrame[]>([]);
   const [framesCaptured, setFramesCaptured] = useState(0);
   const [lastDetection, setLastDetection] = useState(0);
   const [now, setNow] = useState(Date.now());
@@ -82,8 +81,7 @@ export default function TrainingScreen({ navigation, route }: any) {
   const startRecording = () => {
     if (!gestureId) return;
     setError(null);
-    setRecordedLandmarks([]);
-    setRecordedHandedness([]);
+    setRecordedFrames([]);
     setFramesCaptured(0);
     setLastDetection(0);
     setIsRecording(true);
@@ -94,14 +92,14 @@ export default function TrainingScreen({ navigation, route }: any) {
   const stopRecording = async () => {
     setIsRecording(false);
     if (!gestureId) return;
-    const validation = validateLandmarkSequence(recordedLandmarks);
+    const validation = validateLandmarkSequence(recordedFrames.map((f) => f.landmarks));
     if (!validation.ok) {
       const msg = `Sample needs improvement: ${validation.suggestions.join(' ')}`;
       setError(msg);
       return;
     }
     try {
-      const frames = recordedLandmarks.map((lm, i) => ({ landmarks: lm, handedness: recordedHandedness[i] || [] }));
+      const frames = recordedFrames;
       await saveTrainingSample(gestureId, frames, isPractice ? 'HIP_4' : 'HIP_2');
       setCount((c) => c + 1);
       setError(null);
@@ -109,8 +107,12 @@ export default function TrainingScreen({ navigation, route }: any) {
       void logHIPEvent(isPractice ? 'HIP_4' : 'HIP_2', 'sample_saved', { gestureId, frames: framesCaptured });
       // Also send the full sample sequence to the server dataset for DGS
       try {
-        if (recordedLandmarks.length > 0) {
-          void sendDgsSample(gestureId, recordedLandmarks, profile?.id || undefined);
+        if (recordedFrames.length > 0) {
+          void sendDgsSample(
+            gestureId,
+            recordedFrames.map((f) => f.landmarks),
+            profile?.id || undefined,
+          );
         }
       } catch {}
       if (isPractice) {
@@ -220,8 +222,7 @@ export default function TrainingScreen({ navigation, route }: any) {
                 setLandmarks(lm);
                 setLastDetection(Date.now());
                 if (isRecordingRef.current) {
-                  setRecordedLandmarks((prev) => [...prev, lm]);
-                  setRecordedHandedness((prev) => [...prev, hands]);
+                  setRecordedFrames((prev) => [...prev, { landmarks: lm, handedness: hands }]);
                   setFramesCaptured((c) => c + 1);
                 }
               }}

--- a/app/src/services/gestureRecorder.ts
+++ b/app/src/services/gestureRecorder.ts
@@ -1,17 +1,18 @@
 import { LanguageManager } from './LanguageManager';
+import type { TrainingFrame } from '../storage';
 
 export async function captureSamples(
-  getLandmarks: () => number[][][],
+  getFrame: () => { landmarks: number[][][]; handedness: string[] },
   durationMs = 2000,
   intervalMs = 66,
-): Promise<number[][][][]> {
-  const frames: number[][][][] = [];
+): Promise<TrainingFrame[]> {
+  const frames: TrainingFrame[] = [];
   const start = Date.now();
   while (Date.now() - start < durationMs) {
-    const lms = getLandmarks();
-    if (lms.length > 0 && lms.every((h) => h.length === 21)) {
-      const clone = lms.map((hand) => hand.map((pt) => [...pt]));
-      frames.push(clone);
+    const { landmarks, handedness } = getFrame();
+    if (landmarks.length > 0 && landmarks.every((h) => h.length === 21)) {
+      const clone = landmarks.map((hand) => hand.map((pt) => [...pt]));
+      frames.push({ landmarks: clone, handedness: [...handedness] });
     }
     await new Promise((r) => setTimeout(r, intervalMs));
   }

--- a/app/src/services/handUtils.ts
+++ b/app/src/services/handUtils.ts
@@ -36,19 +36,23 @@ export function frameHasAnyLandmarks(frame: number[][][]): boolean {
 }
 
 export function processFramesForUpload(
-  frames: any[],
+  frames: (number[][][] | { landmarks: number[][][]; handedness?: string[] })[],
   gestureDefinitionId: string,
   profileId?: string,
 ): { gestureDefinitionId: string; landmarkData: number[][]; profileId?: string }[] {
   return (Array.isArray(frames) ? frames : [])
-    .filter((f) => frameHasAnyLandmarks((f as any).landmarks || f))
-    .map((f) => ({
-      gestureDefinitionId,
-      landmarkData: flattenHandsWithHandedness(
-        (f as any).landmarks || f,
-        (f as any).handedness || [],
-      ),
-      ...(profileId ? { profileId } : {}),
-    }));
+    .filter((f) =>
+      frameHasAnyLandmarks('landmarks' in f ? f.landmarks : (f as number[][][])),
+    )
+    .map((f) => {
+      const isNewFrame = 'landmarks' in f;
+      const landmarks = isNewFrame ? f.landmarks : (f as number[][][]);
+      const handedness = isNewFrame ? f.handedness || [] : [];
+      return {
+        gestureDefinitionId,
+        landmarkData: flattenHandsWithHandedness(landmarks, handedness),
+        ...(profileId ? { profileId } : {}),
+      };
+    });
 }
 

--- a/app/src/services/handUtils.ts
+++ b/app/src/services/handUtils.ts
@@ -60,7 +60,7 @@ function normalizeFramesInput(
     input.every(
       (f) =>
         (f && typeof f === 'object' && 'landmarks' in (f as any)) ||
-        (Array.isArray(f) && Array.isArray((f as any)[0]) && Array.isArray((f as any)[0][0])),
+        (Array.isArray(f) && (f.length === 0 || Array.isArray(f[0]))),
     )
   ) {
     return input as any[];

--- a/app/src/services/handUtils.ts
+++ b/app/src/services/handUtils.ts
@@ -1,9 +1,20 @@
 export const HAND_LANDMARKS_PER_HAND = 21;
 
-// hands: [left[], right[]], each is an array of 21 [x,y,z]
-export function flattenHands(hands: number[][][]): number[][] {
-  const left = hands?.[0] || [];
-  const right = hands?.[1] || [];
+export function flattenHandsWithHandedness(
+  hands: number[][][],
+  handedness: string[],
+): number[][] {
+  let left: number[][] = [];
+  let right: number[][] = [];
+  if (handedness.length === 0) {
+    left = hands?.[0] || [];
+    right = hands?.[1] || [];
+  } else {
+    const leftIndex = handedness.findIndex((h) => /left/i.test(h));
+    const rightIndex = handedness.findIndex((h) => /right/i.test(h));
+    left = leftIndex >= 0 ? hands[leftIndex] : [];
+    right = rightIndex >= 0 ? hands[rightIndex] : [];
+  }
   const out: number[][] = [];
   for (let i = 0; i < HAND_LANDMARKS_PER_HAND; i++) {
     out.push(left[i] ? [...left[i]] : [0, 0, 0]);
@@ -12,6 +23,11 @@ export function flattenHands(hands: number[][][]): number[][] {
     out.push(right[i] ? [...right[i]] : [0, 0, 0]);
   }
   return out;
+}
+
+// Legacy helper assuming hands array is ordered as [left, right]
+export function flattenHands(hands: number[][][]): number[][] {
+  return flattenHandsWithHandedness(hands, []);
 }
 
 export function frameHasAnyLandmarks(frame: number[][][]): boolean {

--- a/app/src/services/handUtils.ts
+++ b/app/src/services/handUtils.ts
@@ -35,3 +35,20 @@ export function frameHasAnyLandmarks(frame: number[][][]): boolean {
   return frame.some((hand) => Array.isArray(hand) && hand.length > 0);
 }
 
+export function processFramesForUpload(
+  frames: any[],
+  gestureDefinitionId: string,
+  profileId?: string,
+): { gestureDefinitionId: string; landmarkData: number[][]; profileId?: string }[] {
+  return (Array.isArray(frames) ? frames : [])
+    .filter((f) => frameHasAnyLandmarks((f as any).landmarks || f))
+    .map((f) => ({
+      gestureDefinitionId,
+      landmarkData: flattenHandsWithHandedness(
+        (f as any).landmarks || f,
+        (f as any).handedness || [],
+      ),
+      ...(profileId ? { profileId } : {}),
+    }));
+}
+

--- a/app/src/services/handUtils.ts
+++ b/app/src/services/handUtils.ts
@@ -17,15 +17,24 @@ export function flattenHandsWithHandedness(
   }
   const out: number[][] = [];
   for (let i = 0; i < HAND_LANDMARKS_PER_HAND; i++) {
-    out.push(left[i] ? [...left[i]] : [0, 0, 0]);
+    out.push([
+      left[i]?.[0] ?? 0,
+      left[i]?.[1] ?? 0,
+      left[i]?.[2] ?? 0,
+    ]);
   }
   for (let i = 0; i < HAND_LANDMARKS_PER_HAND; i++) {
-    out.push(right[i] ? [...right[i]] : [0, 0, 0]);
+    out.push([
+      right[i]?.[0] ?? 0,
+      right[i]?.[1] ?? 0,
+      right[i]?.[2] ?? 0,
+    ]);
   }
   return out;
 }
 
-// Legacy helper assuming hands array is ordered as [left, right]
+/** @deprecated Legacy helper assuming hands array is ordered as [left, right].
+ * Prefer flattenHandsWithHandedness(hands, []) to make handedness handling explicit. */
 export function flattenHands(hands: number[][][]): number[][] {
   return flattenHandsWithHandedness(hands, []);
 }
@@ -35,19 +44,59 @@ export function frameHasAnyLandmarks(frame: number[][][]): boolean {
   return frame.some((hand) => Array.isArray(hand) && hand.length > 0);
 }
 
+type Triplet = [number, number, number];
+type Frame = { landmarks: number[][][]; handedness?: string[] };
+
+function isTriplet(x: unknown): x is Triplet {
+  return Array.isArray(x) && x.length >= 3 && x.slice(0, 3).every((n) => typeof n === 'number');
+}
+
+function normalizeFramesInput(
+  input: unknown,
+): (number[][][] | { landmarks: number[][][]; handedness?: string[] })[] {
+  if (!Array.isArray(input)) return [];
+
+  if (
+    input.every(
+      (f) =>
+        (f && typeof f === 'object' && 'landmarks' in (f as any)) ||
+        (Array.isArray(f) && Array.isArray((f as any)[0]) && Array.isArray((f as any)[0][0])),
+    )
+  ) {
+    return input as any[];
+  }
+
+  if (input.every(isTriplet)) {
+    const arr = input as Triplet[];
+    const perFrame = HAND_LANDMARKS_PER_HAND * 2;
+    if (arr.length % perFrame !== 0) return [];
+    const out: Frame[] = [];
+    for (let i = 0; i < arr.length; i += perFrame) {
+      const block = arr.slice(i, i + perFrame);
+      const left = block.slice(0, HAND_LANDMARKS_PER_HAND);
+      const right = block.slice(HAND_LANDMARKS_PER_HAND, perFrame);
+      out.push({ landmarks: [left, right], handedness: [] });
+    }
+    return out;
+  }
+
+  return [];
+}
+
 export function processFramesForUpload(
   frames: (number[][][] | { landmarks: number[][][]; handedness?: string[] })[],
   gestureDefinitionId: string,
   profileId?: string,
 ): { gestureDefinitionId: string; landmarkData: number[][]; profileId?: string }[] {
-  return (Array.isArray(frames) ? frames : [])
+  const normalized = normalizeFramesInput(frames);
+  return normalized
     .filter((f) =>
       frameHasAnyLandmarks('landmarks' in f ? f.landmarks : (f as number[][][])),
     )
     .map((f) => {
       const isNewFrame = 'landmarks' in f;
       const landmarks = isNewFrame ? f.landmarks : (f as number[][][]);
-      const handedness = isNewFrame ? f.handedness || [] : [];
+      const handedness = isNewFrame ? f.handedness ?? [] : [];
       return {
         gestureDefinitionId,
         landmarkData: flattenHandsWithHandedness(landmarks, handedness),

--- a/app/src/services/localCentroids.ts
+++ b/app/src/services/localCentroids.ts
@@ -16,10 +16,10 @@ export async function buildLocalCentroids(): Promise<CentroidMap> {
   for (const sample of data) {
     const label = sample.gestureDefinitionId;
     const framesAny = sample.frames || sample.landmarkData;
-    const frames: FrameData[] = Array.isArray(framesAny) ? framesAny : [];
+  const frames: (FrameData | number[][][])[] = Array.isArray(framesAny) ? framesAny : [];
     for (const f of frames) {
-      const lms = Array.isArray(f) ? f : (f as any)?.landmarks || [];
-      const handed = Array.isArray(f) ? [] : (f as any)?.handedness || [];
+      const lms = Array.isArray(f) ? f : f.landmarks || [];
+      const handed = Array.isArray(f) ? [] : f.handedness || [];
       if (!frameHasAnyLandmarks(lms)) continue;
       const flat = flattenHandsWithHandedness(lms, handed);
       if (!sums[label]) {

--- a/app/src/services/localCentroids.ts
+++ b/app/src/services/localCentroids.ts
@@ -18,8 +18,8 @@ export async function buildLocalCentroids(): Promise<CentroidMap> {
     const framesAny = sample.frames || sample.landmarkData;
     const frames: FrameData[] = Array.isArray(framesAny) ? framesAny : [];
     for (const f of frames) {
-      const lms = (f as any).landmarks || f;
-      const handed = (f as any).handedness || [];
+      const lms = Array.isArray(f) ? f : (f as any)?.landmarks || [];
+      const handed = Array.isArray(f) ? [] : (f as any)?.handedness || [];
       if (!frameHasAnyLandmarks(lms)) continue;
       const flat = flattenHandsWithHandedness(lms, handed);
       if (!sums[label]) {

--- a/app/src/services/localCentroids.ts
+++ b/app/src/services/localCentroids.ts
@@ -1,26 +1,27 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { CentroidMap } from './dgsModelClient';
-import { flattenHands, frameHasAnyLandmarks } from './handUtils';
+import { flattenHandsWithHandedness, frameHasAnyLandmarks } from './handUtils';
 
 const TRAINING_KEY = 'gestureTrainingData';
 
-type Frame = number[][][]; // hands -> 21x3
+interface FrameData { landmarks: number[][][]; handedness: string[] }
 
 export async function buildLocalCentroids(): Promise<CentroidMap> {
   const raw = await AsyncStorage.getItem(TRAINING_KEY);
   if (!raw) return {};
-  let data: Array<{ gestureDefinitionId: string; landmarkData: Frame[] }> = [];
+  let data: Array<{ gestureDefinitionId: string; frames?: FrameData[]; landmarkData?: any }>; // backward compat
   try { data = JSON.parse(raw); } catch { return {}; }
 
   const sums: Record<string, { sum: number[][]; count: number }> = {};
   for (const sample of data) {
     const label = sample.gestureDefinitionId;
-    const framesAny = sample.landmarkData as any;
-    const frames: Frame[] = Array.isArray(framesAny) ? framesAny : [];
-    for (const frame of frames) {
-      // Skip frames with no landmarks to avoid skewing centroids
-      if (!frameHasAnyLandmarks(frame)) continue;
-      const flat = flattenHands(frame);
+    const framesAny = sample.frames || sample.landmarkData;
+    const frames: FrameData[] = Array.isArray(framesAny) ? framesAny : [];
+    for (const f of frames) {
+      const lms = (f as any).landmarks || f;
+      const handed = (f as any).handedness || [];
+      if (!frameHasAnyLandmarks(lms)) continue;
+      const flat = flattenHandsWithHandedness(lms, handed);
       if (!sums[label]) {
         sums[label] = { sum: flat.map(() => [0, 0, 0]), count: 0 };
       }
@@ -45,7 +46,7 @@ export async function buildLocalCentroids(): Promise<CentroidMap> {
 export async function getLocalCentroidSummary(): Promise<Record<string, number>> {
   const raw = await AsyncStorage.getItem(TRAINING_KEY);
   if (!raw) return {};
-  let data: Array<{ gestureDefinitionId: string; landmarkData: Frame[] }> = [];
+  let data: Array<{ gestureDefinitionId: string }> = [];
   try { data = JSON.parse(raw); } catch { return {}; }
 
   const counts: Record<string, number> = {};

--- a/app/src/services/syncService.ts
+++ b/app/src/services/syncService.ts
@@ -3,6 +3,7 @@ import { GestureTrainingData } from '../../db/models';
 import { API_URL, API_TOKEN } from '../constants';
 import { logger } from '../utils/logger';
 import { loadActiveProfileId, loadProfile } from '../storage';
+import { flattenHandsWithHandedness, frameHasAnyLandmarks } from './handUtils';
 import { Q } from '@nozbe/watermelondb';
 import { uploadTelemetry } from './analytics';
 import { telemetry } from '../telemetry/recorder';
@@ -50,10 +51,19 @@ export const syncService = {
       logger.info(`Found ${pendingSamples.length} pending training samples.`);
 
       try {
-        const payload = pendingSamples.map((s) => ({
-          gestureDefinitionId: s.gestureDefinition.id,
-          landmarkData: JSON.parse(s.landmarkData),
-        }));
+        const payload = pendingSamples.flatMap((s) => {
+          let frames: any[] = [];
+          try { frames = JSON.parse(s.landmarkData); } catch {}
+          return (Array.isArray(frames) ? frames : [])
+            .filter((f) => frameHasAnyLandmarks((f as any).landmarks || f))
+            .map((f) => ({
+              gestureDefinitionId: s.gestureDefinition.id,
+              landmarkData: flattenHandsWithHandedness(
+                (f as any).landmarks || f,
+                (f as any).handedness || [],
+              ),
+            }));
+        });
         const response = await fetch(`${API_URL}/train-model`, {
           method: 'POST',
           headers: {

--- a/app/src/services/syncService.ts
+++ b/app/src/services/syncService.ts
@@ -3,7 +3,7 @@ import { GestureTrainingData } from '../../db/models';
 import { API_URL, API_TOKEN } from '../constants';
 import { logger } from '../utils/logger';
 import { loadActiveProfileId, loadProfile } from '../storage';
-import { flattenHandsWithHandedness, frameHasAnyLandmarks } from './handUtils';
+import { processFramesForUpload } from './handUtils';
 import { Q } from '@nozbe/watermelondb';
 import { uploadTelemetry } from './analytics';
 import { telemetry } from '../telemetry/recorder';
@@ -54,15 +54,7 @@ export const syncService = {
         const payload = pendingSamples.flatMap((s) => {
           let frames: any[] = [];
           try { frames = JSON.parse(s.landmarkData); } catch {}
-          return (Array.isArray(frames) ? frames : [])
-            .filter((f) => frameHasAnyLandmarks((f as any).landmarks || f))
-            .map((f) => ({
-              gestureDefinitionId: s.gestureDefinition.id,
-              landmarkData: flattenHandsWithHandedness(
-                (f as any).landmarks || f,
-                (f as any).handedness || [],
-              ),
-            }));
+          return processFramesForUpload(frames, s.gestureDefinition.id);
         });
         const response = await fetch(`${API_URL}/train-model`, {
           method: 'POST',

--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -4,7 +4,7 @@ import { loadProfile, TrainingSample, loadBackendApiToken } from '../storage';
 import { API_URL } from '../constants';
 import { logger } from '../utils/logger';
 import { fetchCentroids } from './dgsModelClient';
-import { flattenHandsWithHandedness, frameHasAnyLandmarks } from './handUtils';
+import { processFramesForUpload } from './handUtils';
 
 const TRAINING_KEY = 'gestureTrainingData';
 
@@ -32,16 +32,7 @@ export async function syncTrainingData(opts?: SyncProgressOptions): Promise<void
     const samples = pending.flatMap((p) => {
       const framesAny = (p as any).frames || (p as any).landmarkData;
       const frames = Array.isArray(framesAny) ? framesAny : [];
-      return frames
-        .filter((f) => frameHasAnyLandmarks((f as any).landmarks || f))
-        .map((f) => ({
-          gestureDefinitionId: p.gestureDefinitionId,
-          landmarkData: flattenHandsWithHandedness(
-            (f as any).landmarks || f,
-            (f as any).handedness || [],
-          ),
-          profileId: profile?.id,
-        }));
+      return processFramesForUpload(frames, p.gestureDefinitionId, profile?.id);
     });
     if (samples.length === 0) return;
     const response = await fetch(`${API_URL}/train-model`, {

--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -4,7 +4,7 @@ import { loadProfile, TrainingSample, loadBackendApiToken } from '../storage';
 import { API_URL } from '../constants';
 import { logger } from '../utils/logger';
 import { fetchCentroids } from './dgsModelClient';
-import { flattenHands, frameHasAnyLandmarks } from './handUtils';
+import { flattenHandsWithHandedness, frameHasAnyLandmarks } from './handUtils';
 
 const TRAINING_KEY = 'gestureTrainingData';
 
@@ -29,15 +29,16 @@ export async function syncTrainingData(opts?: SyncProgressOptions): Promise<void
   if (pending.length === 0) return;
   try {
     const token = await loadBackendApiToken();
-    const samples = pending.flatMap((p) =>
-      (p.landmarkData as number[][][][])
-        .filter(frameHasAnyLandmarks)
-        .map((frame) => ({
+    const samples = pending.flatMap((p) => {
+      const frames = p.frames as any;
+      return (Array.isArray(frames) ? frames : [])
+        .filter((f) => frameHasAnyLandmarks(f.landmarks))
+        .map((f) => ({
           gestureDefinitionId: p.gestureDefinitionId,
-          landmarkData: flattenHands(frame),
+          landmarkData: flattenHandsWithHandedness(f.landmarks, f.handedness || []),
           profileId: profile?.id,
-        })),
-    );
+        }));
+    });
     if (samples.length === 0) return;
     const response = await fetch(`${API_URL}/train-model`, {
       method: 'POST',

--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -30,8 +30,8 @@ export async function syncTrainingData(opts?: SyncProgressOptions): Promise<void
   try {
     const token = await loadBackendApiToken();
     const samples = pending.flatMap((p) => {
-      const framesAny = (p as any).frames || (p as any).landmarkData;
-      const frames = Array.isArray(framesAny) ? framesAny : [];
+      // Handle both new `frames` and legacy `landmarkData` fields for backward compatibility.
+      const frames = (p as any).frames || (p as any).landmarkData || [];
       return processFramesForUpload(frames, p.gestureDefinitionId, profile?.id);
     });
     if (samples.length === 0) return;

--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -30,12 +30,16 @@ export async function syncTrainingData(opts?: SyncProgressOptions): Promise<void
   try {
     const token = await loadBackendApiToken();
     const samples = pending.flatMap((p) => {
-      const frames = p.frames as any;
-      return (Array.isArray(frames) ? frames : [])
-        .filter((f) => frameHasAnyLandmarks(f.landmarks))
+      const framesAny = (p as any).frames || (p as any).landmarkData;
+      const frames = Array.isArray(framesAny) ? framesAny : [];
+      return frames
+        .filter((f) => frameHasAnyLandmarks((f as any).landmarks || f))
         .map((f) => ({
           gestureDefinitionId: p.gestureDefinitionId,
-          landmarkData: flattenHandsWithHandedness(f.landmarks, f.handedness || []),
+          landmarkData: flattenHandsWithHandedness(
+            (f as any).landmarks || f,
+            (f as any).handedness || [],
+          ),
           profileId: profile?.id,
         }));
     });

--- a/app/src/storage.ts
+++ b/app/src/storage.ts
@@ -153,6 +153,7 @@ export async function saveTrainingSample(
   await database.write(async () => {
     await collection.create((record) => {
       record.gestureDefinition.id = gestureDefinitionId;
+      // Stores stringified TrainingFrame[]; legacy field name maintained for compatibility
       record.landmarkData = JSON.stringify(frames);
       record.source = source;
       record.qualityScore = 1;

--- a/app/src/storage.ts
+++ b/app/src/storage.ts
@@ -18,10 +18,15 @@ const ACTIVE_PROFILE_KEY = 'activeProfileId';
 const TRAINING_KEY = 'gestureTrainingData';
 const LOG_KEY = 'interactionLogs';
 
+export interface TrainingFrame {
+  landmarks: number[][][];
+  handedness: string[];
+}
+
 export interface TrainingSample {
   id: string;
   gestureDefinitionId: string;
-  landmarkData: unknown;
+  frames: TrainingFrame[];
   source: 'HIP_2' | 'HIP_3' | 'HIP_4';
   syncStatus: 'pending' | 'synced';
 }
@@ -109,7 +114,7 @@ export async function logCorrection(correctId: string): Promise<void> {
   training.push({
     id: genId(),
     gestureDefinitionId: correctId,
-    landmarkData: null,
+    frames: [],
     source: 'HIP_3',
     syncStatus: 'pending',
   });
@@ -130,7 +135,7 @@ export async function logCorrection(correctId: string): Promise<void> {
 
 export async function saveTrainingSample(
   gestureDefinitionId: string,
-  landmarkData: unknown,
+  frames: TrainingFrame[],
   source: 'HIP_2' | 'HIP_4' = 'HIP_2',
 ): Promise<void> {
   const raw = await AsyncStorage.getItem(TRAINING_KEY);
@@ -138,7 +143,7 @@ export async function saveTrainingSample(
   data.push({
     id: genId(),
     gestureDefinitionId,
-    landmarkData,
+    frames,
     source,
     syncStatus: 'pending',
   });
@@ -148,7 +153,7 @@ export async function saveTrainingSample(
   await database.write(async () => {
     await collection.create((record) => {
       record.gestureDefinition.id = gestureDefinitionId;
-      record.landmarkData = JSON.stringify(landmarkData);
+      record.landmarkData = JSON.stringify(frames);
       record.source = source;
       record.qualityScore = 1;
       record.frameMetadata = '';

--- a/app/test/MediaPipeGestureDetector.test.tsx
+++ b/app/test/MediaPipeGestureDetector.test.tsx
@@ -67,12 +67,13 @@ describe('MediaPipeGestureDetector', () => {
             gesture: 'thumbs_up',
             confidence: 0.9,
             landmarks: [[[1, 2, 3]]],
+            handednesses: ['Left'],
           }),
         },
       });
     });
 
-    expect(onGestureDetected).toHaveBeenCalledWith('thumbs_up', 0.9, [[[1, 2, 3]]]);
+    expect(onGestureDetected).toHaveBeenCalledWith('thumbs_up', 0.9, [[[1, 2, 3]]], ['Left']);
     expect(onError).not.toHaveBeenCalled();
   });
 
@@ -135,12 +136,12 @@ describe('MediaPipeGestureDetector', () => {
     act(() => {
       webview.props.onMessage({
         nativeEvent: {
-          data: JSON.stringify({ type: 'gesture', gesture: null, confidence: 0, landmarks: [[[1, 2, 3]]] }),
+          data: JSON.stringify({ type: 'gesture', gesture: null, confidence: 0, landmarks: [[[1, 2, 3]]], handednesses: ['Left'] }),
         },
       });
     });
 
-    expect(onGestureDetected).toHaveBeenCalledWith(null, 0, [[[1, 2, 3]]]);
+    expect(onGestureDetected).toHaveBeenCalledWith(null, 0, [[[1, 2, 3]]], ['Left']);
     expect(onError).not.toHaveBeenCalled();
   });
 

--- a/app/test/handUtils.test.ts
+++ b/app/test/handUtils.test.ts
@@ -1,0 +1,23 @@
+import { flattenHandsWithHandedness, HAND_LANDMARKS_PER_HAND } from '../src/services/handUtils';
+
+describe('flattenHandsWithHandedness', () => {
+  const makeHand = (offset: number) =>
+    Array.from({ length: HAND_LANDMARKS_PER_HAND }, (_, i) => [i + offset, i + offset, i + offset]);
+
+  it('orders hands according to handedness array', () => {
+    const left = makeHand(0);
+    const right = makeHand(100);
+    const out = flattenHandsWithHandedness([right, left], ['Right', 'Left']);
+    expect(out.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(left);
+    expect(out.slice(HAND_LANDMARKS_PER_HAND)).toEqual(right);
+  });
+
+  it('pads missing hands with zeros', () => {
+    const right = makeHand(100);
+    const out = flattenHandsWithHandedness([right], ['Right']);
+    const zeros = Array.from({ length: HAND_LANDMARKS_PER_HAND }, () => [0, 0, 0]);
+    expect(out.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(zeros);
+    expect(out.slice(HAND_LANDMARKS_PER_HAND)).toEqual(right);
+  });
+});
+

--- a/app/test/handUtils.test.ts
+++ b/app/test/handUtils.test.ts
@@ -44,5 +44,15 @@ describe('processFramesForUpload', () => {
     const out = processFramesForUpload(frames, 'g1');
     expect(out).toHaveLength(0);
   });
+
+  it('supports legacy frame format', () => {
+    const left = makeHand(0);
+    const right = makeHand(100);
+    const frames = [[left, right]];
+    const out = processFramesForUpload(frames, 'g1');
+    expect(out).toHaveLength(1);
+    expect(out[0].landmarkData.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(left);
+    expect(out[0].landmarkData.slice(HAND_LANDMARKS_PER_HAND)).toEqual(right);
+  });
 });
 

--- a/app/test/handUtils.test.ts
+++ b/app/test/handUtils.test.ts
@@ -1,4 +1,8 @@
-import { flattenHandsWithHandedness, HAND_LANDMARKS_PER_HAND } from '../src/services/handUtils';
+import {
+  flattenHandsWithHandedness,
+  HAND_LANDMARKS_PER_HAND,
+  processFramesForUpload,
+} from '../src/services/handUtils';
 
 describe('flattenHandsWithHandedness', () => {
   const makeHand = (offset: number) =>
@@ -18,6 +22,27 @@ describe('flattenHandsWithHandedness', () => {
     const zeros = Array.from({ length: HAND_LANDMARKS_PER_HAND }, () => [0, 0, 0]);
     expect(out.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(zeros);
     expect(out.slice(HAND_LANDMARKS_PER_HAND)).toEqual(right);
+  });
+});
+
+describe('processFramesForUpload', () => {
+  const makeHand = (offset: number) =>
+    Array.from({ length: HAND_LANDMARKS_PER_HAND }, (_, i) => [i + offset, i + offset, i + offset]);
+
+  it('flattens frames and attaches ids', () => {
+    const left = makeHand(0);
+    const frames = [{ landmarks: [left], handedness: ['Left'] }];
+    const out = processFramesForUpload(frames, 'g1', 'p1');
+    expect(out).toHaveLength(1);
+    expect(out[0].gestureDefinitionId).toBe('g1');
+    expect(out[0].profileId).toBe('p1');
+    expect(out[0].landmarkData.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(left);
+  });
+
+  it('filters frames without landmarks', () => {
+    const frames = [{ landmarks: [], handedness: [] }];
+    const out = processFramesForUpload(frames, 'g1');
+    expect(out).toHaveLength(0);
   });
 });
 

--- a/app/test/handUtils.test.ts
+++ b/app/test/handUtils.test.ts
@@ -23,6 +23,20 @@ describe('flattenHandsWithHandedness', () => {
     expect(out.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(zeros);
     expect(out.slice(HAND_LANDMARKS_PER_HAND)).toEqual(right);
   });
+
+  it('coerces landmarks to 3D triplets', () => {
+    const left = Array.from({ length: HAND_LANDMARKS_PER_HAND }, () => [0, 0, 0]);
+    const right = Array.from({ length: HAND_LANDMARKS_PER_HAND }, () => [0, 0, 0]);
+    left[0] = [1, 2, 3, 4];
+    left[1] = [5, 6];
+    right[0] = [7, 8, 9, 10];
+    right[1] = [11, 12];
+    const out = flattenHandsWithHandedness([left, right], ['Left', 'Right']);
+    expect(out[0]).toEqual([1, 2, 3]);
+    expect(out[1]).toEqual([5, 6, 0]);
+    expect(out[HAND_LANDMARKS_PER_HAND]).toEqual([7, 8, 9]);
+    expect(out[HAND_LANDMARKS_PER_HAND + 1]).toEqual([11, 12, 0]);
+  });
 });
 
 describe('processFramesForUpload', () => {
@@ -50,6 +64,16 @@ describe('processFramesForUpload', () => {
     const right = makeHand(100);
     const frames = [[left, right]];
     const out = processFramesForUpload(frames, 'g1');
+    expect(out).toHaveLength(1);
+    expect(out[0].landmarkData.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(left);
+    expect(out[0].landmarkData.slice(HAND_LANDMARKS_PER_HAND)).toEqual(right);
+  });
+
+  it('normalizes flattened legacy arrays', () => {
+    const left = makeHand(0);
+    const right = makeHand(100);
+    const flattened = [...left, ...right];
+    const out = processFramesForUpload(flattened, 'g1');
     expect(out).toHaveLength(1);
     expect(out[0].landmarkData.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(left);
     expect(out[0].landmarkData.slice(HAND_LANDMARKS_PER_HAND)).toEqual(right);

--- a/app/test/practiceStorage.test.ts
+++ b/app/test/practiceStorage.test.ts
@@ -29,7 +29,7 @@ jest.mock('../db', () => ({
 
 jest.mock('../db/models', () => ({}));
 
-import { saveTrainingSample } from '../src/storage';
+import { saveTrainingSample, TrainingFrame } from '../src/storage';
 
 describe('saveTrainingSample', () => {
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe('saveTrainingSample', () => {
   });
 
   it('stores samples with default HIP_2 source', async () => {
-    await saveTrainingSample('gesture1', []);
+    await saveTrainingSample('gesture1', [] as TrainingFrame[]);
     const raw = store['gestureTrainingData'];
     expect(raw).toBeTruthy();
     const data = JSON.parse(raw as string);
@@ -46,7 +46,7 @@ describe('saveTrainingSample', () => {
   });
 
   it('stores samples with HIP_4 source when specified', async () => {
-    await saveTrainingSample('gesture1', [], 'HIP_4');
+    await saveTrainingSample('gesture1', [] as TrainingFrame[], 'HIP_4');
     const raw = store['gestureTrainingData'];
     expect(raw).toBeTruthy();
     const data = JSON.parse(raw as string);

--- a/app/test/screens/RecognitionScreen.test.tsx
+++ b/app/test/screens/RecognitionScreen.test.tsx
@@ -113,7 +113,7 @@ describe('RecognitionScreen', () => {
     });
     const detector = component.root.findByType('MediaPipeGestureDetector');
     await act(async () => {
-      detector.props.onGestureDetected('hello', 0.9, []);
+      detector.props.onGestureDetected('hello', 0.9, [], []);
     });
     const vids = component.root.findAllByType('DgsVideoPlayer');
     expect(vids.length).toBe(1);

--- a/app/test/screens/TrainingScreen.test.tsx
+++ b/app/test/screens/TrainingScreen.test.tsx
@@ -86,13 +86,13 @@ describe('TrainingScreen', () => {
     });
     const detector = component.root.findByType('MediaPipeGestureDetector');
     act(() => {
-      detector.props.onGestureDetected(null, 0.9, [[[1, 2, 3]]]);
+      detector.props.onGestureDetected(null, 0.9, [[[1, 2, 3]]], ['Left']);
     });
     await act(async () => {
       button.props.onPress();
       await Promise.resolve();
     });
-    expect(saveTrainingSample).toHaveBeenCalledWith('hello', [[[[1, 2, 3]]]], 'HIP_2');
+    expect(saveTrainingSample).toHaveBeenCalledWith('hello', [{ landmarks: [[[1, 2, 3]]], handedness: ['Left'] }], 'HIP_2');
   });
 });
 

--- a/app/test/services/gestureRecorder.test.ts
+++ b/app/test/services/gestureRecorder.test.ts
@@ -13,20 +13,24 @@ describe('captureSamples', () => {
   it('collects frames and clones landmark data', async () => {
     const hand = Array.from({ length: 21 }, (_, i) => [i, i, i]);
     let current = hand;
-    const getter = () => [current];
+    const handed = ['Left'];
+    const getter = () => ({ landmarks: [current], handedness: handed });
 
     const promise = captureSamples(getter, 100, 50);
     jest.advanceTimersByTime(100);
     const frames = await promise;
 
-    // mutate original after capture
+    // mutate originals after capture
     current[0][0] = 999;
+    handed[0] = 'Right';
+
     expect(frames.length).toBeGreaterThan(0);
-    expect(frames[0][0][0][0]).toBe(0);
+    expect(frames[0].landmarks[0][0][0]).toBe(0);
+    expect(frames[0].handedness[0]).toBe('Left');
   });
 
   it('throws an error when no landmarks are captured', async () => {
-    const getter = () => [] as number[][][];
+    const getter = () => ({ landmarks: [] as number[][][], handedness: [] });
     const promise = captureSamples(getter, 100, 50);
     jest.advanceTimersByTime(100);
     await expect(promise).rejects.toThrow(LanguageManager.t('mediapipe.noLandmarksCaptured'));

--- a/app/test/trainingSamples.test.ts
+++ b/app/test/trainingSamples.test.ts
@@ -23,7 +23,7 @@ const dbMock = {
 jest.mock('../db', () => ({ database: dbMock }));
 jest.mock('../db/models', () => ({ GestureTrainingData: {} }));
 
-import { saveTrainingSample, loadTrainingSampleCount } from '../src/storage';
+import { saveTrainingSample, loadTrainingSampleCount, TrainingFrame } from '../src/storage';
 
 describe('training sample persistence', () => {
   beforeEach(() => {
@@ -32,8 +32,9 @@ describe('training sample persistence', () => {
   });
 
   it('saves samples and counts them', async () => {
-    await saveTrainingSample('g1', [1, 2, 3]);
-    await saveTrainingSample('g1', [4, 5, 6]);
+    const frame: TrainingFrame = { landmarks: [[[1, 2, 3]]], handedness: ['Left'] } as any;
+    await saveTrainingSample('g1', [frame]);
+    await saveTrainingSample('g1', [frame]);
     const count = await loadTrainingSampleCount('g1');
     expect(count).toBe(2);
     expect(createMock).toHaveBeenCalledTimes(2);

--- a/app/test/trainingSync.test.ts
+++ b/app/test/trainingSync.test.ts
@@ -70,6 +70,39 @@ describe('syncTrainingData', () => {
     expect(updated[0].syncStatus).toBe('synced');
   });
 
+  it('uploads legacy samples stored under landmarkData', async () => {
+    await AsyncStorage.setItem(
+      TRAINING_KEY,
+      JSON.stringify([
+        {
+          id: '1',
+          gestureDefinitionId: 'g1',
+          landmarkData: [
+            {
+              landmarks: [
+                [[1, 2, 3]],
+                [],
+              ],
+              handedness: ['Left', 'Right'],
+            },
+          ],
+          source: 'HIP_2',
+          syncStatus: 'pending',
+        },
+      ]),
+    );
+
+    await syncTrainingData();
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.samples[0].gestureDefinitionId).toBe('g1');
+    expect(body.samples[0].landmarkData[0]).toEqual([1, 2, 3]);
+    const updated = JSON.parse((await AsyncStorage.getItem(TRAINING_KEY))!);
+    expect(updated[0].syncStatus).toBe('synced');
+  });
+
   it('orders landmarks using handedness when hands are reversed', async () => {
     const left = Array.from({ length: 21 }, (_, i) => [i, i, i]);
     const right = Array.from({ length: 21 }, (_, i) => [i + 100, i + 100, i + 100]);

--- a/app/test/trainingSync.test.ts
+++ b/app/test/trainingSync.test.ts
@@ -41,11 +41,14 @@ describe('syncTrainingData', () => {
         {
           id: '1',
           gestureDefinitionId: 'g1',
-          landmarkData: [
-            [
-              [[1, 2, 3]],
-              [],
-            ],
+          frames: [
+            {
+              landmarks: [
+                [[1, 2, 3]],
+                [],
+              ],
+              handedness: ['Left', 'Right'],
+            },
           ],
           source: 'HIP_2',
           syncStatus: 'pending',
@@ -67,6 +70,35 @@ describe('syncTrainingData', () => {
     expect(updated[0].syncStatus).toBe('synced');
   });
 
+  it('orders landmarks using handedness when hands are reversed', async () => {
+    const left = Array.from({ length: 21 }, (_, i) => [i, i, i]);
+    const right = Array.from({ length: 21 }, (_, i) => [i + 100, i + 100, i + 100]);
+    await AsyncStorage.setItem(
+      TRAINING_KEY,
+      JSON.stringify([
+        {
+          id: '1',
+          gestureDefinitionId: 'g1',
+          frames: [
+            {
+              landmarks: [right, left],
+              handedness: ['Right', 'Left'],
+            },
+          ],
+          source: 'HIP_2',
+          syncStatus: 'pending',
+        },
+      ]),
+    );
+
+    await syncTrainingData();
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.samples[0].landmarkData[0]).toEqual([0, 0, 0]);
+    expect(body.samples[0].landmarkData[21]).toEqual([100, 100, 100]);
+  });
+
   it('logs warning and keeps samples pending on failure', async () => {
     await AsyncStorage.setItem(
       TRAINING_KEY,
@@ -74,7 +106,9 @@ describe('syncTrainingData', () => {
         {
           id: '1',
           gestureDefinitionId: 'g1',
-          landmarkData: [[[1, 2, 3]], []],
+          frames: [
+            { landmarks: [[[1, 2, 3]], []], handedness: ['Left', 'Right'] },
+          ],
           source: 'HIP_2',
           syncStatus: 'pending',
         },

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,14 +13,15 @@
  - [x] Write models atomically (temp file + rename) and serve with `ETag` + `X-Model-Version`
 - [ ] Review TTS de-duplication window and make it configurable (see `SpeechDeduplicationLearnings.md`)
 - [ ] Reevaluate LanguageManager to simplify localization and allow additional languages (see `LocalizationLearnings.md`)
+- [ ] Address gesture training blind spot tasks (see section below)
 
 ## Gesture Training Blind Spot Tasks
 *For Amy – voku/AmysEcho*
 
-- [ ] Preserve handedness when saving training samples
-- [ ] Flatten DGS samples before POST
-- [ ] Align MLP label storage with WebView
-- [ ] Unify landmark normalization algorithms
+- [x] Preserve handedness when saving training samples (`app/src/components/MediaPipeGestureDetector.tsx`, `app/src/services/dgsTrainingService.ts`)
+- [ ] Flatten DGS samples before POST (`app/src/services/dgsTrainingService.ts`)
+- [ ] Align MLP label storage with WebView (`server/src/amyserver_tools/train_mlp.py`, `app/src/webview/installMlp.ts`)
+- [ ] Unify landmark normalization algorithms (`app/src/services/landmarkNormalizer.ts`, `app/src/webview/installMlp.ts`, `server/src/amyserver_tools/train_mlp.py`, `server/src/services/dgsModelService.ts`)
 - [ ] Report basic training metrics
 
 


### PR DESCRIPTION
## Summary
- track per-hand handedness in captured gesture frames
- flatten training data with handedness for accurate upload and recognition
- mark handedness preservation task complete in TODO
- add tests covering handedness flattening and training sync ordering

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68af5b0aa748832282ede425f81f8445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Gesture detectors now include per-frame handedness; training samples, recording, and sync payloads use a new per-frame format that preserves handedness.
- Bug Fixes
  - Hand ordering when left/right are reversed fixed, improving recognition, training, and upload consistency.
- Documentation
  - Roadmap/TODO updated to reflect handedness support and related follow-ups.
- Tests
  - Unit and integration tests extended to cover handedness-aware flows and legacy formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->