### PR TITLE
refactor: improve frame handling

### DIFF
--- a/app/src/services/handUtils.ts
+++ b/app/src/services/handUtils.ts
@@ -1,3 +1,5 @@
+import type { FrameData } from '../types/frames';
+
 export const HAND_LANDMARKS_PER_HAND = 21;
 
 export function flattenHandsWithHandedness(
@@ -45,15 +47,14 @@ export function frameHasAnyLandmarks(frame: number[][][]): boolean {
 }
 
 type Triplet = [number, number, number];
-type Frame = { landmarks: number[][][]; handedness?: string[] };
 
 function isTriplet(x: unknown): x is Triplet {
-  return Array.isArray(x) && x.length >= 3 && x.slice(0, 3).every((n) => typeof n === 'number');
+  return Array.isArray(x) && x.length === 3 && x.every((n) => typeof n === 'number');
 }
 
 function normalizeFramesInput(
   input: unknown,
-): (number[][][] | { landmarks: number[][][]; handedness?: string[] })[] {
+): (number[][][] | FrameData)[] {
   if (!Array.isArray(input)) return [];
 
   if (
@@ -69,9 +70,10 @@ function normalizeFramesInput(
   if (input.every(isTriplet)) {
     const arr = input as Triplet[];
     const perFrame = HAND_LANDMARKS_PER_HAND * 2;
-    if (arr.length % perFrame !== 0) return [];
-    const out: Frame[] = [];
-    for (let i = 0; i < arr.length; i += perFrame) {
+    const usableFrames = Math.floor(arr.length / perFrame);
+    if (usableFrames === 0) return [];
+    const out: FrameData[] = [];
+    for (let i = 0; i < usableFrames * perFrame; i += perFrame) {
       const block = arr.slice(i, i + perFrame);
       const left = block.slice(0, HAND_LANDMARKS_PER_HAND);
       const right = block.slice(HAND_LANDMARKS_PER_HAND, perFrame);
@@ -84,7 +86,7 @@ function normalizeFramesInput(
 }
 
 export function processFramesForUpload(
-  frames: (number[][][] | { landmarks: number[][][]; handedness?: string[] })[],
+  frames: (number[][][] | FrameData)[],
   gestureDefinitionId: string,
   profileId?: string,
 ): { gestureDefinitionId: string; landmarkData: number[][]; profileId?: string }[] {

--- a/app/src/services/localCentroids.ts
+++ b/app/src/services/localCentroids.ts
@@ -1,10 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { CentroidMap } from './dgsModelClient';
+import type { FrameData } from '../types/frames';
 import { flattenHandsWithHandedness, frameHasAnyLandmarks } from './handUtils';
 
 const TRAINING_KEY = 'gestureTrainingData';
-
-interface FrameData { landmarks: number[][][]; handedness: string[] }
 
 export async function buildLocalCentroids(): Promise<CentroidMap> {
   const raw = await AsyncStorage.getItem(TRAINING_KEY);
@@ -16,10 +15,12 @@ export async function buildLocalCentroids(): Promise<CentroidMap> {
   for (const sample of data) {
     const label = sample.gestureDefinitionId;
     const framesAny = sample.frames || sample.landmarkData;
-  const frames: (FrameData | number[][][])[] = Array.isArray(framesAny) ? framesAny : [];
+    const frames: (FrameData | number[][][])[] = Array.isArray(framesAny) ? framesAny : [];
     for (const f of frames) {
-      const lms = Array.isArray(f) ? f : f.landmarks || [];
-      const handed = Array.isArray(f) ? [] : f.handedness || [];
+      // Check if it's a new format frame with landmarks property
+      const isNewFormat = f && typeof f === 'object' && 'landmarks' in f;
+      const lms = isNewFormat ? (f as FrameData).landmarks || [] : (f as number[][][]);
+      const handed = isNewFormat ? (f as FrameData).handedness || [] : [];
       if (!frameHasAnyLandmarks(lms)) continue;
       const flat = flattenHandsWithHandedness(lms, handed);
       if (!sums[label]) {
@@ -34,7 +35,7 @@ export async function buildLocalCentroids(): Promise<CentroidMap> {
       s.count += 1;
     }
   }
-  const centroids: CentroidMap = {} as any;
+  const centroids: CentroidMap = {};
   for (const [label, { sum, count }] of Object.entries(sums)) {
     if (count > 0) {
       centroids[label] = sum.map(([x,y,z]) => [x/count, y/count, z/count]);

--- a/app/src/types/frames.ts
+++ b/app/src/types/frames.ts
@@ -1,0 +1,4 @@
+export interface FrameData {
+  landmarks: number[][][];
+  handedness?: string[];
+}

--- a/app/test/handUtils.test.ts
+++ b/app/test/handUtils.test.ts
@@ -78,5 +78,15 @@ describe('processFramesForUpload', () => {
     expect(out[0].landmarkData.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(left);
     expect(out[0].landmarkData.slice(HAND_LANDMARKS_PER_HAND)).toEqual(right);
   });
+
+  it('drops incomplete trailing landmarks in flattened legacy arrays', () => {
+    const left = makeHand(0);
+    const right = makeHand(100);
+    const flattened = [...left, ...right, [1, 2, 3]];
+    const out = processFramesForUpload(flattened, 'g1');
+    expect(out).toHaveLength(1);
+    expect(out[0].landmarkData.slice(0, HAND_LANDMARKS_PER_HAND)).toEqual(left);
+    expect(out[0].landmarkData.slice(HAND_LANDMARKS_PER_HAND)).toEqual(right);
+  });
 });
 


### PR DESCRIPTION
## Summary
- extract FrameData interface to shared types file
- improve frame format handling for local centroids
- handle partial flattened frame arrays

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH 34.110.201.56:443)*
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm run type-check --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68affb0d7aec83228bf666802e2c5b1b