### PR TITLE
test: cover hand, centroid, sync helpers, and training sync

### DIFF
--- a/app/test/handUtils.test.ts
+++ b/app/test/handUtils.test.ts
@@ -2,6 +2,7 @@ import {
   flattenHandsWithHandedness,
   HAND_LANDMARKS_PER_HAND,
   processFramesForUpload,
+  frameHasAnyLandmarks,
 } from '../src/services/handUtils';
 
 describe('flattenHandsWithHandedness', () => {
@@ -36,6 +37,19 @@ describe('flattenHandsWithHandedness', () => {
     expect(out[1]).toEqual([5, 6, 0]);
     expect(out[HAND_LANDMARKS_PER_HAND]).toEqual([7, 8, 9]);
     expect(out[HAND_LANDMARKS_PER_HAND + 1]).toEqual([11, 12, 0]);
+  });
+});
+
+describe('frameHasAnyLandmarks', () => {
+  it('returns false for non-array input', () => {
+    // @ts-expect-error intentionally passing invalid input
+    expect(frameHasAnyLandmarks(null)).toBe(false);
+  });
+
+  it('detects presence of landmarks', () => {
+    expect(frameHasAnyLandmarks([])).toBe(false);
+    expect(frameHasAnyLandmarks([[]])).toBe(false);
+    expect(frameHasAnyLandmarks([[[1, 2, 3]], []])).toBe(true);
   });
 });
 

--- a/app/test/localCentroids.test.ts
+++ b/app/test/localCentroids.test.ts
@@ -1,0 +1,50 @@
+const store: Record<string, string> = {};
+const asyncStub = {
+  async getItem(key: string) {
+    return store[key] ?? null;
+  },
+  async setItem(key: string, value: string) {
+    store[key] = value;
+  },
+  async removeItem(key: string) {
+    delete store[key];
+  },
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => asyncStub);
+
+import { buildLocalCentroids, getLocalCentroidSummary } from '../src/services/localCentroids';
+
+beforeEach(() => {
+  for (const k of Object.keys(store)) delete store[k];
+});
+
+describe('local centroids', () => {
+  it('builds centroids from mixed frame formats and skips invalid frames', async () => {
+    const makeHand = (val: number) => Array.from({ length: 21 }, () => [val, val, val]);
+    const frameNew = { landmarks: [makeHand(1), makeHand(1)], handedness: ['left', 'right'] };
+    const frameOld = [makeHand(3), makeHand(3)];
+    const data = [
+      { gestureDefinitionId: 'g1', frames: [frameNew, null as any, { landmarks: [], handedness: [] }] },
+      { gestureDefinitionId: 'g1', landmarkData: [frameOld] },
+    ];
+    await asyncStub.setItem('gestureTrainingData', JSON.stringify(data));
+    const centroids = await buildLocalCentroids();
+    expect(Object.keys(centroids)).toEqual(['g1']);
+    expect(centroids.g1.length).toBe(42);
+    for (const p of centroids.g1) {
+      expect(p).toEqual([2, 2, 2]);
+    }
+  });
+
+  it('summarizes sample counts per gesture', async () => {
+    const samples = [
+      { gestureDefinitionId: 'g1' },
+      { gestureDefinitionId: 'g1' },
+      { gestureDefinitionId: 'g2' },
+    ];
+    await asyncStub.setItem('gestureTrainingData', JSON.stringify(samples));
+    const summary = await getLocalCentroidSummary();
+    expect(summary).toEqual({ g1: 2, g2: 1 });
+  });
+});

--- a/app/test/syncService.test.ts
+++ b/app/test/syncService.test.ts
@@ -1,0 +1,70 @@
+const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+const mockDatabase = {
+  get: jest.fn(),
+  write: jest.fn(async (fn: any) => { await fn(); }),
+};
+let mockSamples: any[] = [];
+
+jest.mock('../db', () => ({
+  database: mockDatabase,
+  GestureTrainingData: class {},
+}));
+
+jest.mock('../src/storage', () => ({
+  loadActiveProfileId: jest.fn(async () => 'p1'),
+  loadProfile: jest.fn(async () => ({ id: 'p1', consentHelpMeGetSmarter: true })),
+}));
+
+jest.mock('../src/constants', () => ({
+  API_URL: 'https://api.example',
+  API_TOKEN: 'token',
+}));
+
+jest.mock('../src/utils/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { syncService } from '../src/services/syncService';
+
+beforeEach(() => {
+  mockSamples = [
+    {
+      landmarkData: JSON.stringify([
+        { landmarks: [[[1, 2, 3]], []], handedness: ['Left', 'Right'] },
+      ]),
+      gestureDefinition: { id: 'g1' },
+      customSyncStatus: 'pending',
+      update: jest.fn(function (fn: any) { fn(this); }),
+    },
+  ];
+  mockDatabase.get.mockReturnValue({
+    query: jest.fn(() => ({ fetch: jest.fn().mockResolvedValue(mockSamples) })),
+  });
+  mockDatabase.write.mockImplementation(async (fn: any) => { await fn(); });
+  (global as any).fetch = jest.fn(async () => ({ ok: true }));
+  jest.clearAllMocks();
+});
+
+describe('syncService.uploadPendingTrainingData', () => {
+  it('uploads samples and marks them synced', async () => {
+    await syncService.uploadPendingTrainingData();
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.example/train-model',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.samples).toHaveLength(1);
+    expect(body.samples[0].gestureDefinitionId).toBe('g1');
+    expect(body.samples[0].landmarkData[0]).toEqual([1, 2, 3]);
+    expect(mockSamples[0].customSyncStatus).toBe('synced');
+  });
+
+  it('logs error and leaves samples pending on failure', async () => {
+    (global as any).fetch = jest.fn(async () => ({ ok: false, status: 500, statusText: 'fail' }));
+    await syncService.uploadPendingTrainingData();
+    expect(mockLogger.error).toHaveBeenCalledWith('Failed to upload training data: 500 fail');
+    expect(mockSamples[0].customSyncStatus).toBe('pending');
+    expect(mockDatabase.write).not.toHaveBeenCalled();
+  });
+});
+

--- a/app/test/trainingSync.test.ts
+++ b/app/test/trainingSync.test.ts
@@ -1,5 +1,10 @@
+const mockNetInfoFetch = jest.fn(async () => ({
+  isConnected: true,
+  isInternetReachable: true,
+  type: 'wifi',
+}));
 jest.mock('@react-native-community/netinfo', () => ({
-  fetch: async () => ({ isConnected: true, isInternetReachable: true, type: 'wifi' }),
+  fetch: mockNetInfoFetch,
 }));
 
 jest.mock('../src/storage', () => ({
@@ -26,6 +31,11 @@ describe('syncTrainingData', () => {
   beforeEach(() => {
     (AsyncStorage as any).clear();
     jest.clearAllMocks();
+    mockNetInfoFetch.mockResolvedValue({
+      isConnected: true,
+      isInternetReachable: true,
+      type: 'wifi',
+    });
     (global as any).fetch = jest.fn(async (url: string) => {
       if (url.includes('/train-model')) {
         return { ok: true, json: async () => ({ jobId: '1' }) } as any;
@@ -158,5 +168,57 @@ describe('syncTrainingData', () => {
     );
     const updated = JSON.parse((await AsyncStorage.getItem(TRAINING_KEY))!);
     expect(updated[0].syncStatus).toBe('pending');
+  });
+
+  it('skips syncing when network is not wifi', async () => {
+    await AsyncStorage.setItem(
+      TRAINING_KEY,
+      JSON.stringify([
+        {
+          id: '1',
+          gestureDefinitionId: 'g1',
+          frames: [
+            { landmarks: [[[1, 2, 3]], []], handedness: ['Left', 'Right'] },
+          ],
+          source: 'HIP_2',
+          syncStatus: 'pending',
+        },
+      ]),
+    );
+
+    mockNetInfoFetch.mockResolvedValueOnce({
+      isConnected: true,
+      isInternetReachable: true,
+      type: 'cellular',
+    });
+
+    await syncTrainingData();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    const stored = JSON.parse((await AsyncStorage.getItem(TRAINING_KEY))!);
+    expect(stored[0].syncStatus).toBe('pending');
+  });
+
+  it('reports progress via callback', async () => {
+    await AsyncStorage.setItem(
+      TRAINING_KEY,
+      JSON.stringify([
+        {
+          id: '1',
+          gestureDefinitionId: 'g1',
+          frames: [
+            { landmarks: [[[1, 2, 3]], []], handedness: ['Left', 'Right'] },
+          ],
+          source: 'HIP_2',
+          syncStatus: 'pending',
+        },
+      ]),
+    );
+
+    const progress = jest.fn();
+    await syncTrainingData({ onProgress: progress });
+
+    expect(progress).toHaveBeenCalledWith(0);
+    expect(progress).toHaveBeenCalledWith(100);
   });
 });


### PR DESCRIPTION
## Summary
- add tests for buildLocalCentroids and getLocalCentroidSummary
- add tests for hand utilities: flattenHandsWithHandedness, frameHasAnyLandmarks, processFramesForUpload
- add tests for syncService.uploadPendingTrainingData
- add tests for syncTrainingData network guard and progress callback

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: fetch failed)*
- `pip install -r server/requirements.txt`
- `npm run type-check --prefix server`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b007170f048322b7df9a80c1003b38