### PR TITLE
test: cover training sync error paths

### DIFF
--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -68,11 +68,12 @@ export async function syncTrainingData(opts?: SyncProgressOptions): Promise<void
         const s = await fetch(`${API_URL}/train-status/${jobId}`, { headers });
         if (s.ok) {
           const info = await s.json().catch(() => null);
-          const isObject = info && typeof info === 'object' && !Array.isArray(info);
-          if (isObject) {
+          if (info && typeof info === 'object' && !Array.isArray(info)) {
             let useful = false;
-            const progress = (info as any).progress;
-            const status = (info as any).status as string | undefined;
+            const { progress, status } = info as {
+              progress?: unknown;
+              status?: unknown;
+            };
             if (typeof progress === 'number') {
               opts?.onProgress?.(Math.max(0, Math.min(100, progress)));
               useful = true;

--- a/app/test/trainingSync.test.ts
+++ b/app/test/trainingSync.test.ts
@@ -242,14 +242,8 @@ describe('syncTrainingData', () => {
     });
 
     it('keeps samples pending when polling fails repeatedly', async () => {
-      const original = setTimeout;
+      jest.useFakeTimers();
       try {
-        // Execute timers immediately to avoid long waits
-        (global as any).setTimeout = (fn: any) => {
-          fn();
-          return 0 as any;
-        };
-
         await setupPendingSample();
 
         let polls = 0;
@@ -261,10 +255,12 @@ describe('syncTrainingData', () => {
           return { ok: false, status: 500 } as any;
         });
 
-        await syncTrainingData();
+        const syncPromise = syncTrainingData();
+        await jest.advanceTimersByTimeAsync(3000);
+        await syncPromise;
         expect(polls).toBeGreaterThanOrEqual(3);
       } finally {
-        (global as any).setTimeout = original;
+        jest.useRealTimers();
       }
 
       expect(logger.warn).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- add tests for invalid JSON responses so training samples still sync
- add tests that repeated polling failures keep samples pending and log the failure

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fail: fetch failed; network required)*
- `pip install -r server/requirements.txt`
- `npm run type-check --prefix server`
- `npm test --prefix server`
- `ruff check server && ruff format --check server`
- `npm test --prefix integration`
- `npm test --prefix app -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b09da0db8483229a5c2470bbb84f3f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of training sync with robust polling, clearer error handling, and proper timeouts.
  * More accurate progress updates (0–100), avoiding duplicate 100% notifications and handling completion cleanly.
  * Graceful handling of invalid server responses; limits retries and reports failures after repeated errors.
  * Ensures pending items remain pending if syncing fails and marks items synced upon completion.

* **Refactor**
  * Streamlined polling flow for greater stability and consistency.

* **Tests**
  * Added coverage for invalid server JSON and repeated polling failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->