### PR TITLE
Fix training screen layout

### DIFF
--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -91,7 +91,7 @@ const RootNavigator = () => {
       <Stack.Screen
         name="Training"
         component={TrainingScreen}
-        options={{ presentation: 'modal', headerShown: false }}
+        options={{ headerShown: false }}
       />
       <Stack.Screen
         name="Parent"


### PR DESCRIPTION
## Summary
- remove modal presentation so Training screen uses standard navigation and bottom bar spans the width

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: fetch failed)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b0b9af7aac8322b1b5ba481da81f04