### PR TITLE
docs: expand blind spot guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ For guidelines specific to the application or server, see the `AGENTS.md` files 
 
 For complex, iterative tasks like fixing a large number of type errors or refactoring a module, an automated agent script is available. This script, `scripts/auto-agent.sh`, runs the Gemini CLI in a loop, feeding the results of one run into the prompt for the next. This creates a continuous feedback cycle that allows the agent to work towards a goal autonomously.
 
+**Prerequisite**: The workflow requires the Gemini CLI to be installed and configured on the host machine. Container-only environments may not include Gemini, so confirm availability with the user before attempting to run `scripts/auto-agent.sh`.
+
 ### How it Works
 
 1.  **Initial Prompt**: The loop starts with a high-level goal defined in a prompt file (by default, `docs/TODO.md`).
@@ -158,3 +160,15 @@ Before starting implementation, consider:
 - "What patterns are already established for this type of change?"
 - "Are there any integration points I need to be aware of?"
 
+
+## AI Assistant Blind Spots and Mitigations
+
+- **Local environment unknown** – tools like Gemini or `auto-agent.sh` may not be installed. Confirm with the user before relying on them.
+- **External configuration assumptions** – hardware, permissions, or OS differences can affect outcomes. Ask users to highlight special constraints.
+- **Hidden dependencies** – undocumented packages or services may be required. Request explicit dependency lists or installation steps.
+- **Opaque runtime failures** – some commands may fail silently. Encourage verbose logging and sharing of error output.
+- **User-specific settings** – API keys or environment variables can change behavior. Ask which configuration values are needed (without requesting secrets).
+- **Incomplete validation steps** – missing tests or manual checks lead to gaps. Verify instructions and request clarification when necessary.
+- **Context drift** – documentation and code can become unsynchronized. Prompt contributors to keep them aligned.
+- **Time-limited visibility** – uncommitted or in-progress work is invisible. Ask about relevant WIP.
+- **Need for human oversight** – automated checks cannot replace human judgment. Ensure final review and real-world testing.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -85,12 +85,4 @@ Amy's Echo is a multimodal communication platform for non-verbal children. The p
 
 ## Known Blind Spots and Mitigations
 
-- The `scripts/auto-agent.sh` workflow depends on the Gemini CLI being installed and configured on the host machine. Container environments may not have Gemini, so confirm availability before using the script.
-- External configuration differences (hardware, permissions, OS) may lead to unexpected results. Ask users to highlight special constraints.
-- Missing or undocumented dependencies can cause failures. Request explicit dependency lists or installation instructions.
-- Commands may fail silently. Encourage verbose logging and sharing of error output.
-- API keys or environment variables remain invisible to the agent. Clarify required settings without sharing secrets.
-- Test coverage or manual checks may be incomplete. Verify instructions and seek clarification when steps are unclear.
-- Documentation can drift from code. Prompt maintainers to keep both synchronized.
-- Uncommitted or in-progress work is not visible. Ask about relevant WIP that might impact the task.
-- Human review and real-world testing are essential for production readiness.
+For a list of known blind spots and mitigations when working with AI assistants, please refer to the [AI Assistant Blind Spots and Mitigations section in AGENTS.md](./AGENTS.md#ai-assistant-blind-spots-and-mitigations).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -82,3 +82,15 @@ Amy's Echo is a multimodal communication platform for non-verbal children. The p
 - Start the server (if needed for non-gesture features): `npm run build && node dist/server.js`
 - Gesture recognition does not require the backend.
 - Update analytics or other data pipelines as needed: `npm run build && node dist/tools/updateAnalytics.js <path/to/db.json>`
+
+## Known Blind Spots and Mitigations
+
+- The `scripts/auto-agent.sh` workflow depends on the Gemini CLI being installed and configured on the host machine. Container environments may not have Gemini, so confirm availability before using the script.
+- External configuration differences (hardware, permissions, OS) may lead to unexpected results. Ask users to highlight special constraints.
+- Missing or undocumented dependencies can cause failures. Request explicit dependency lists or installation instructions.
+- Commands may fail silently. Encourage verbose logging and sharing of error output.
+- API keys or environment variables remain invisible to the agent. Clarify required settings without sharing secrets.
+- Test coverage or manual checks may be incomplete. Verify instructions and seek clarification when steps are unclear.
+- Documentation can drift from code. Prompt maintainers to keep both synchronized.
+- Uncommitted or in-progress work is not visible. Ask about relevant WIP that might impact the task.
+- Human review and real-world testing are essential for production readiness.


### PR DESCRIPTION
## Summary
- note Gemini CLI prerequisite for `scripts/auto-agent.sh`
- expand blind spot mitigations for agents and GEMINI workflow

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`

------
https://chatgpt.com/codex/tasks/task_e_68b0c3abc8088322885d1551543106c8