### PR TITLE
refactor: improve landmark types and validation

### DIFF
--- a/app/src/services/landmarkNormalizer.ts
+++ b/app/src/services/landmarkNormalizer.ts
@@ -1,12 +1,12 @@
 // Utilities for normalizing hand landmarks before classification
-// Strategy: translate to wrist, scale by max(|x| + |y|) to match server/WebView logic
+// Strategy: translate to wrist; scale all axes by max(|x| + |y|) over translated points (matches server/WebView)
 
 const WRIST_INDEX = 0;
 
 export function normalizeLandmarks(
   landmarks: number[][],
 ): number[][] {
-  if (!landmarks || landmarks.length < 21) return landmarks;
+  if (!landmarks || landmarks.length < 21) return [];
 
   const [wx, wy, wz] = landmarks[WRIST_INDEX];
   const translated = landmarks.map((p) => [
@@ -25,6 +25,7 @@ export function normalizeLandmarks(
 }
 
 export function normalizeLandmarksToFlat(landmarks: number[][]): Float32Array {
+  if (!landmarks || landmarks.length < 21) return new Float32Array(0);
   const norm = normalizeLandmarks(landmarks);
   const out = new Float32Array(norm.length * 3);
   let k = 0;

--- a/app/src/webview/installMlp.ts
+++ b/app/src/webview/installMlp.ts
@@ -168,11 +168,10 @@ export function installMlp() {
       const centered: Landmark[] = hand.map(
         (p) => [p[0] - wx, p[1] - wy, p[2] - wz] as Landmark,
       );
-      let maxd = 0;
-      for (let i = 0; i < centered.length; i++) {
-        const d = Math.abs(centered[i][0]) + Math.abs(centered[i][1]);
-        if (d > maxd) maxd = d;
-      }
+      const maxd = centered.reduce(
+        (currentMax, [x, y]) => Math.max(currentMax, Math.abs(x) + Math.abs(y)),
+        0,
+      );
       if (maxd === 0) return null;
       return centered.map(([x, y, z]) => [x / maxd, y / maxd, z / maxd] as Landmark);
     }

--- a/app/src/webview/installMlp.ts
+++ b/app/src/webview/installMlp.ts
@@ -1,5 +1,9 @@
 export function installMlp() {
   type Tensor = { data: Float64Array; shape: number[] };
+  type Landmark = readonly [number, number, number];
+  type Hand = ReadonlyArray<Landmark>;
+  type HandednessEntry = ReadonlyArray<{ categoryName: 'Left' | 'Right' }>;
+  type Handedness = ReadonlyArray<HandednessEntry>;
   type MlpModel = {
     w1: Tensor;
     b1: Tensor;
@@ -115,7 +119,7 @@ export function installMlp() {
       };
       return true;
     } catch (e: any) {
-      console.warn('mlp load failed', e?.message || e);
+      console.warn('mlp load failed', e?.message ?? e);
       mlp = null;
       return false;
     }
@@ -154,26 +158,23 @@ export function installMlp() {
     }
     return out;
   }
-  const EMPTY_HAND = new Array(21).fill(0).map(() => [0, 0, 0]);
+  const EMPTY_HAND: Hand = new Array(21).fill(0).map(() => [0, 0, 0] as Landmark);
 
-  function normalizeLandmarks(all: any[], handednesses: any[]) {
+  function normalizeLandmarks(all: Hand[], handednesses: Handedness) {
     const flat: number[] = [];
-    function normHand(hand: any[]) {
+    function normHand(hand: Hand | null): Hand | null {
       if (!hand || hand.length < 21) return null;
       const wrist = hand[0];
-      const centered = hand.map((p) => [p[0] - wrist[0], p[1] - wrist[1], (p[2] || 0) - (wrist[2] || 0)]);
+      const centered: Landmark[] = hand.map(
+        (p) => [p[0] - wrist[0], p[1] - wrist[1], (p[2] ?? 0) - (wrist[2] ?? 0)] as Landmark,
+      );
       let maxd = 0;
       for (let i = 0; i < centered.length; i++) {
         const d = Math.abs(centered[i][0]) + Math.abs(centered[i][1]);
         if (d > maxd) maxd = d;
       }
       if (maxd === 0) return null;
-      for (let i = 0; i < centered.length; i++) {
-        centered[i][0] /= maxd;
-        centered[i][1] /= maxd;
-        centered[i][2] /= maxd;
-      }
-      return centered;
+      return centered.map(([x, y, z]) => [x / maxd, y / maxd, z / maxd] as Landmark);
     }
 
     const leftHandIndex = handednesses?.findIndex((h) => h?.[0]?.categoryName === 'Left');
@@ -186,14 +187,14 @@ export function installMlp() {
     if (!left) return null; // Model expects left hand
 
     const right = normHand(rightHand);
-    const r = right || EMPTY_HAND;
+    const r = right ?? EMPTY_HAND;
     const both = left.concat(r);
     for (const p of both) {
-      flat.push(p[0], p[1], p[2] || 0);
+      flat.push(p[0], p[1], p[2] ?? 0);
     }
     return new Float64Array(flat);
   }
-  function mlpPredict(all: any, handednesses: any[]) {
+  function mlpPredict(all: Hand[], handednesses: Handedness) {
     if (!mlp) return null;
     const x = normalizeLandmarks(all, handednesses);
     if (!x) return null;
@@ -217,7 +218,7 @@ export function installMlp() {
         bestI = i;
       }
     }
-    const label = (mlp.labels && (mlp.labels as any)[bestI]) || String(bestI);
+    const label = mlp.labels?.[bestI] ?? String(bestI);
     return { label, score: best };
   }
   (window as any).__setMlpModelB64 = (b64: string) => {

--- a/app/src/webview/installMlp.ts
+++ b/app/src/webview/installMlp.ts
@@ -164,13 +164,7 @@ export function installMlp() {
     const flat: number[] = [];
     function normHand(hand: Hand | null): Hand | null {
       if (!hand || hand.length < 21) return null;
-      const wrist = hand[0];
-      const rawX = Number(wrist?.[0]);
-      const rawY = Number(wrist?.[1]);
-      const rawZ = Number(wrist?.[2]);
-      const wx = Number.isFinite(rawX) ? rawX : 0;
-      const wy = Number.isFinite(rawY) ? rawY : 0;
-      const wz = Number.isFinite(rawZ) ? rawZ : 0;
+      const [wx, wy, wz] = hand[0];
       const centered: Landmark[] = hand.map(
         (p) => [p[0] - wx, p[1] - wy, p[2] - wz] as Landmark,
       );

--- a/app/src/webview/installMlp.ts
+++ b/app/src/webview/installMlp.ts
@@ -158,7 +158,7 @@ export function installMlp() {
     }
     return out;
   }
-  const EMPTY_HAND: Hand = new Array(21).fill(0).map(() => [0, 0, 0] as Landmark);
+  const EMPTY_HAND = new Array(21).fill(0).map(() => [0, 0, 0] as const);
 
   function normalizeLandmarks(all: Hand[], handednesses: Handedness) {
     const flat: number[] = [];

--- a/app/src/webview/installMlp.ts
+++ b/app/src/webview/installMlp.ts
@@ -165,8 +165,14 @@ export function installMlp() {
     function normHand(hand: Hand | null): Hand | null {
       if (!hand || hand.length < 21) return null;
       const wrist = hand[0];
+      const rawX = Number(wrist?.[0]);
+      const rawY = Number(wrist?.[1]);
+      const rawZ = Number(wrist?.[2]);
+      const wx = Number.isFinite(rawX) ? rawX : 0;
+      const wy = Number.isFinite(rawY) ? rawY : 0;
+      const wz = Number.isFinite(rawZ) ? rawZ : 0;
       const centered: Landmark[] = hand.map(
-        (p) => [p[0] - wrist[0], p[1] - wrist[1], (p[2] ?? 0) - (wrist[2] ?? 0)] as Landmark,
+        (p) => [p[0] - wx, p[1] - wy, p[2] - wz] as Landmark,
       );
       let maxd = 0;
       for (let i = 0; i < centered.length; i++) {
@@ -190,7 +196,7 @@ export function installMlp() {
     const r = right ?? EMPTY_HAND;
     const both = left.concat(r);
     for (const p of both) {
-      flat.push(p[0], p[1], p[2] ?? 0);
+      flat.push(p[0], p[1], p[2]);
     }
     return new Float64Array(flat);
   }

--- a/app/test/landmarkNormalizer.test.ts
+++ b/app/test/landmarkNormalizer.test.ts
@@ -34,3 +34,13 @@ test('normalizeLandmarksToFlat returns a flattened float array of length 63', ()
   // z of middle tip is scaled to 1
   expect(flat[12 * 3 + 2]).toBeCloseTo(1, 5);
 });
+
+test('normalizeLandmarks returns empty array for short input', () => {
+  expect(normalizeLandmarks([])).toEqual([]);
+});
+
+test('normalizeLandmarksToFlat returns empty array for short input', () => {
+  const flat = normalizeLandmarksToFlat([]);
+  expect(flat).toBeInstanceOf(Float32Array);
+  expect(flat.length).toBe(0);
+});

--- a/app/test/landmarkNormalizer.test.ts
+++ b/app/test/landmarkNormalizer.test.ts
@@ -37,10 +37,14 @@ test('normalizeLandmarksToFlat returns a flattened float array of length 63', ()
 
 test('normalizeLandmarks returns empty array for short input', () => {
   expect(normalizeLandmarks([])).toEqual([]);
+  expect(normalizeLandmarks([[1, 2, 3]])).toEqual([]);
 });
 
 test('normalizeLandmarksToFlat returns empty array for short input', () => {
-  const flat = normalizeLandmarksToFlat([]);
+  let flat = normalizeLandmarksToFlat([]);
+  expect(flat).toBeInstanceOf(Float32Array);
+  expect(flat.length).toBe(0);
+  flat = normalizeLandmarksToFlat([[1, 2, 3]]);
   expect(flat).toBeInstanceOf(Float32Array);
   expect(flat.length).toBe(0);
 });


### PR DESCRIPTION
## Summary
- add strict Landmark/Hand types to webview MLP installer and use nullish coalescing for z values
- guard landmark normalization against short inputs and clarify scaling docs
- extend unit tests for normalization helpers to cover invalid input cases

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b160cbbdb48322a9049962401b7465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Consistent handling of invalid/short landmark input: returns empty arrays / empty Float32Array instead of propagating input.

- Refactor
  - Stronger type safety and null-safety for 3D landmark processing and normalization flow.
  - Reworked normalization to use map-based transformations and safer label/error handling.

- Documentation
  - Clarified normalization strategy: translate to the wrist and uniformly scale across axes.

- Tests
  - Added edge-case tests ensuring empty/short inputs produce empty outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->