### PR TITLE
refactor: infer readonly tuples in hand normalization

### DIFF
--- a/app/src/webview/installMlp.ts
+++ b/app/src/webview/installMlp.ts
@@ -165,20 +165,15 @@ export function installMlp() {
     function normHand(hand: Hand | null): Hand | null {
       if (!hand || hand.length < 21) return null;
       const [wx, wy, wz] = hand[0];
-      const maxd = hand.reduce(
-        (currentMax, p) => {
-          const x = p[0] - wx;
-          const y = p[1] - wy;
-          return Math.max(currentMax, Math.abs(x) + Math.abs(y));
-        },
+      const centered = hand.map(
+        (p) => [p[0] - wx, p[1] - wy, p[2] - wz] as const,
+      );
+      const maxd = centered.reduce(
+        (currentMax, [x, y]) => Math.max(currentMax, Math.abs(x) + Math.abs(y)),
         0,
       );
       if (maxd === 0) return null;
-      return hand.map((p) => [
-        (p[0] - wx) / maxd,
-        (p[1] - wy) / maxd,
-        (p[2] - wz) / maxd,
-      ] as const);
+      return centered.map(([x, y, z]) => [x / maxd, y / maxd, z / maxd] as const);
     }
 
     const leftHandIndex = handednesses?.findIndex((h) => h?.[0]?.categoryName === 'Left');


### PR DESCRIPTION
## Summary
- use `as const` for empty hand and normalization results
- simplify hand landmark normalization to infer readonly tuples

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`


------
https://chatgpt.com/codex/tasks/task_e_68b1b089e6fc8322a2e7482e0ab35c2f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety and immutability for 3D point/gesture handling, tightening inferred types and reducing casts. No behavioral or performance changes.
* **Chores**
  * Minor typing and code-quality adjustments to aid maintainability and future development.

No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->