### PR TITLE
Persist telemetry events between sessions

### DIFF
--- a/app/src/context/AppServicesProvider.tsx
+++ b/app/src/context/AppServicesProvider.tsx
@@ -72,9 +72,11 @@ export const AppServicesProvider = ({ children, offline = false }: ProviderProps
           syncService.uploadPendingTrainingData().catch(() => {});
 
           // Lightweight periodic telemetry upload
-          telemetryInterval = setInterval(() => {
-            const events = telemetry.dump();
-            if (events.length) uploadTelemetry(events).catch(() => {});
+          telemetryInterval = setInterval(async () => {
+            const events = await telemetry.dump();
+            if (events.length) {
+              uploadTelemetry(events).catch(() => {});
+            }
           }, 30 * 1000);
         } else {
           logger.info('Starting in offline mode; skipping cloud sync');

--- a/app/src/services/syncService.ts
+++ b/app/src/services/syncService.ts
@@ -12,7 +12,7 @@ export const syncService = {
   async syncTelemetry(): Promise<void> {
     logger.info('Attempting to sync telemetry data...');
     try {
-      const events = telemetry.dump();
+      const events = await telemetry.dump();
       if (events.length > 0) {
         await uploadTelemetry(events);
         logger.info(`Uploaded ${events.length} telemetry events.`);

--- a/app/src/telemetry/recorder.ts
+++ b/app/src/telemetry/recorder.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export interface TelemetryEvent {
   timestamp: number;
@@ -6,20 +7,51 @@ export interface TelemetryEvent {
   source?: string;
 }
 
-class Telemetry {
+/**
+ * Lightweight telemetry recorder that buffers events in memory and persists
+ * them to AsyncStorage so they survive app restarts. The buffer is capped at a
+ * small size to avoid unbounded growth.
+ */
+export class Telemetry {
   private buffer: TelemetryEvent[] = [];
   private readonly MAX = 500;
+  private readonly KEY = 'telemetryEvents';
+  private ready: Promise<void>;
 
-  add(event: string, latencyMs: number, source?: string) {
+  constructor() {
+    this.ready = AsyncStorage.getItem(this.KEY)
+      .then((raw) => {
+        if (raw) {
+          try {
+            this.buffer = JSON.parse(raw) as TelemetryEvent[];
+          } catch {}
+        }
+      })
+      .catch(() => {});
+  }
+
+  async add(event: string, latencyMs: number, source?: string) {
+    await this.ready;
     this.buffer.push({ timestamp: Date.now(), latencyMs, event, source });
     if (this.buffer.length > this.MAX) {
       this.buffer.shift();
     }
+    try {
+      await AsyncStorage.setItem(this.KEY, JSON.stringify(this.buffer));
+    } catch {
+      // Best-effort persistence; ignore storage errors
+    }
   }
 
-  dump() {
+  async dump(): Promise<TelemetryEvent[]> {
+    await this.ready;
     const data = this.buffer;
     this.buffer = [];
+    try {
+      await AsyncStorage.removeItem(this.KEY);
+    } catch {
+      // ignore storage errors
+    }
     return data;
   }
 }

--- a/app/test/telemetryRecorder.test.ts
+++ b/app/test/telemetryRecorder.test.ts
@@ -1,0 +1,35 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Telemetry } from '../src/telemetry/recorder';
+
+jest.mock('@react-native-async-storage/async-storage');
+
+describe('Telemetry recorder', () => {
+  beforeEach(() => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('persists events to AsyncStorage', async () => {
+    const recorder = new Telemetry();
+    await recorder.add('foo', 12, 'test');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'telemetryEvents',
+      expect.any(String),
+    );
+    const dump = await recorder.dump();
+    expect(dump).toHaveLength(1);
+    expect(dump[0].event).toBe('foo');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('telemetryEvents');
+  });
+
+  it('loads existing events from storage', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify([{ timestamp: 1, latencyMs: 5, event: 'stored' }]),
+    );
+    const recorder = new Telemetry();
+    const events = await recorder.dump();
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe('stored');
+  });
+});


### PR DESCRIPTION
## Summary
- persist telemetry events in AsyncStorage to survive app restarts
- periodically upload stored telemetry using async intervals
- add unit tests for telemetry recorder persistence

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b1c516b4ec8322874fd1c11a7c3d4d