### PR TITLE
feat: add child-friendly video controls

### DIFF
--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -28,5 +28,13 @@
   "recognition": {
     "showDgsVideo": "DGS-Video anzeigen",
     "toggleDgsVideo": "DGS-Video umschalten"
+  },
+  "videoPlayer": {
+    "dgsVideo": "DGS-Video",
+    "noVideo": "Kein Video vorhanden",
+    "play": "Abspielen",
+    "pause": "Pause",
+    "playVideo": "Video abspielen",
+    "pauseVideo": "Video pausieren"
   }
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -28,5 +28,13 @@
   "recognition": {
     "showDgsVideo": "Show DGS Video",
     "toggleDgsVideo": "Toggle DGS Video"
+  },
+  "videoPlayer": {
+    "dgsVideo": "DGS Video",
+    "noVideo": "No video available",
+    "play": "Play",
+    "pause": "Pause",
+    "playVideo": "Play video",
+    "pauseVideo": "Pause video"
   }
 }

--- a/app/src/components/DgsVideoPlayer.tsx
+++ b/app/src/components/DgsVideoPlayer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, ActivityIndicator, Text } from 'react-native';
+import { View, StyleSheet, ActivityIndicator, Text, Pressable } from 'react-native';
 import { VideoView, useVideoPlayer } from 'expo-video';
 
 import { logger } from '../utils/logger';
@@ -13,6 +13,11 @@ interface DgsVideoPlayerProps {
 
 export default function DgsVideoPlayer({ videoSource, style, shouldPlay }: DgsVideoPlayerProps) {
   const player = useVideoPlayer(videoSource);
+  const [isPlaying, setIsPlaying] = React.useState(shouldPlay);
+
+  React.useEffect(() => {
+    setIsPlaying(shouldPlay);
+  }, [shouldPlay]);
 
   React.useEffect(() => {
     if (!player) return;
@@ -30,17 +35,28 @@ export default function DgsVideoPlayer({ videoSource, style, shouldPlay }: DgsVi
   React.useEffect(() => {
     if (player) {
       const isLoaded = player.status !== 'loading' && player.status !== 'error' && player.duration > 0;
-      if (shouldPlay && !player.playing) {
+      if (isPlaying && !player.playing) {
         if (isLoaded && player.currentTime < player.duration) {
           player.play();
         } else if (isLoaded && player.currentTime >= player.duration) {
           player.replay();
         }
-      } else if (!shouldPlay && player.playing) {
+      } else if (!isPlaying && player.playing) {
         player.pause();
       }
     }
-  }, [player, shouldPlay, player?.status]);
+  }, [player, isPlaying, player?.status]);
+
+  const togglePlayback = React.useCallback(() => {
+    if (!player) return;
+    if (isPlaying) {
+      player.pause();
+      setIsPlaying(false);
+    } else {
+      player.play();
+      setIsPlaying(true);
+    }
+  }, [player, isPlaying]);
 
   return (
     <View style={[styles.container, style]}>
@@ -63,6 +79,17 @@ export default function DgsVideoPlayer({ videoSource, style, shouldPlay }: DgsVi
         <View style={styles.loadingOverlay}>
           <ActivityIndicator size="large" color={COLORS.highContrastText} />
         </View>
+      )}
+      {player && (
+        <Pressable
+          onPress={togglePlayback}
+          style={styles.controlButton}
+          accessibilityLabel={isPlaying ? 'Video pausieren' : 'Video abspielen'}
+        >
+          <Text style={styles.controlText}>
+            {isPlaying ? 'Pause' : 'Abspielen'}
+          </Text>
+        </Pressable>
       )}
     </View>
   );
@@ -89,6 +116,19 @@ const styles = StyleSheet.create({
   },
   placeholderText: {
     color: COLORS.highContrastText,
+  },
+  controlButton: {
+    position: 'absolute',
+    bottom: 16,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    backgroundColor: COLORS.highContrastBackground,
+    borderRadius: RADIUS,
+  },
+  controlText: {
+    color: COLORS.highContrastText,
+    fontSize: 18,
+    fontWeight: 'bold',
   },
 });
 

--- a/app/src/components/DgsVideoPlayer.tsx
+++ b/app/src/components/DgsVideoPlayer.tsx
@@ -4,6 +4,7 @@ import { VideoView, useVideoPlayer } from 'expo-video';
 
 import { logger } from '../utils/logger';
 import { COLORS, RADIUS } from '../constants/ui';
+import { LanguageManager } from '../services/LanguageManager';
 
 interface DgsVideoPlayerProps {
   videoSource?: any;
@@ -28,6 +29,14 @@ export default function DgsVideoPlayer({ videoSource, style, shouldPlay }: DgsVi
       // Status change can be used to update UI if needed
     });
     return () => subscription.remove();
+  }, [player]);
+
+  React.useEffect(() => {
+    if (!player) return;
+    const sub = player.addListener('playToEnd', () => {
+      setIsPlaying(false);
+    });
+    return () => sub.remove();
   }, [player]);
 
   const isBuffering = player?.status === 'loading';
@@ -59,14 +68,14 @@ export default function DgsVideoPlayer({ videoSource, style, shouldPlay }: DgsVi
           player={player}
           style={styles.video}
           contentFit={'contain'}
-          accessibilityLabel="DGS-Video"
+          accessibilityLabel={LanguageManager.t('videoPlayer.dgsVideo')}
         />
       ) : (
         <Text
           style={styles.placeholderText}
-          accessibilityLabel="Kein Video vorhanden"
+          accessibilityLabel={LanguageManager.t('videoPlayer.noVideo')}
         >
-          Kein Video vorhanden
+          {LanguageManager.t('videoPlayer.noVideo')}
         </Text>
       )}
       {isBuffering && (
@@ -78,10 +87,16 @@ export default function DgsVideoPlayer({ videoSource, style, shouldPlay }: DgsVi
         <Pressable
           onPress={togglePlayback}
           style={styles.controlButton}
-          accessibilityLabel={isPlaying ? 'Video pausieren' : 'Video abspielen'}
+          accessibilityLabel={
+            isPlaying
+              ? LanguageManager.t('videoPlayer.pauseVideo')
+              : LanguageManager.t('videoPlayer.playVideo')
+          }
         >
           <Text style={styles.controlText}>
-            {isPlaying ? 'Pause' : 'Abspielen'}
+            {isPlaying
+              ? LanguageManager.t('videoPlayer.pause')
+              : LanguageManager.t('videoPlayer.play')}
           </Text>
         </Pressable>
       )}

--- a/app/src/components/DgsVideoPlayer.tsx
+++ b/app/src/components/DgsVideoPlayer.tsx
@@ -49,14 +49,8 @@ export default function DgsVideoPlayer({ videoSource, style, shouldPlay }: DgsVi
 
   const togglePlayback = React.useCallback(() => {
     if (!player) return;
-    if (isPlaying) {
-      player.pause();
-      setIsPlaying(false);
-    } else {
-      player.play();
-      setIsPlaying(true);
-    }
-  }, [player, isPlaying]);
+    setIsPlaying((prev) => !prev);
+  }, [player]);
 
   return (
     <View style={[styles.container, style]}>

--- a/app/test/dgsVideoPlayer.test.tsx
+++ b/app/test/dgsVideoPlayer.test.tsx
@@ -92,11 +92,6 @@ describe('DgsVideoPlayer performance', () => {
     expect(play).toHaveBeenCalled();
 
     mockPlayer.playing = true;
-    act(() => {
-      (component as renderer.ReactTestRenderer).update(
-        <DgsVideoPlayer videoSource={{ uri: 'foo' }} shouldPlay={false} />
-      );
-    });
 
     const pauseBtn = (component as renderer.ReactTestRenderer).root.findByProps({
       accessibilityLabel: 'Video pausieren',

--- a/app/test/dgsVideoPlayer.test.tsx
+++ b/app/test/dgsVideoPlayer.test.tsx
@@ -7,6 +7,7 @@ jest.mock('react-native', () => {
     ActivityIndicator: (props: any) => React.createElement('ActivityIndicator', props),
     View: (props: any) => React.createElement('View', props, props.children),
     Text: (props: any) => React.createElement('Text', props, props.children),
+    Pressable: (props: any) => React.createElement('Pressable', props, props.children),
     StyleSheet: { create: () => ({}) },
   };
 });
@@ -19,13 +20,14 @@ jest.mock('../src/utils/logger', () => ({
 }));
 
 const play = jest.fn();
+const pause = jest.fn();
 const mockPlayer: any = {
   status: 'loading',
   duration: 10,
   currentTime: 0,
   playing: false,
   play,
-  pause: jest.fn(),
+  pause,
   replay: jest.fn(),
   addListener: jest.fn(() => ({ remove: jest.fn() })),
 };
@@ -71,5 +73,37 @@ describe('DgsVideoPlayer performance', () => {
     expect(play).toHaveBeenCalled();
     const elapsed = Date.now() - start;
     expect(elapsed).toBeLessThan(500);
+  });
+
+  it('allows manual play and pause', () => {
+    mockPlayer.status = 'ready';
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <DgsVideoPlayer videoSource={{ uri: 'foo' }} shouldPlay={false} />
+      );
+    });
+    const playBtn = (component as renderer.ReactTestRenderer).root.findByProps({
+      accessibilityLabel: 'Video abspielen',
+    });
+    act(() => {
+      playBtn.props.onPress();
+    });
+    expect(play).toHaveBeenCalled();
+
+    mockPlayer.playing = true;
+    act(() => {
+      (component as renderer.ReactTestRenderer).update(
+        <DgsVideoPlayer videoSource={{ uri: 'foo' }} shouldPlay={false} />
+      );
+    });
+
+    const pauseBtn = (component as renderer.ReactTestRenderer).root.findByProps({
+      accessibilityLabel: 'Video pausieren',
+    });
+    act(() => {
+      pauseBtn.props.onPress();
+    });
+    expect(pause).toHaveBeenCalled();
   });
 });

--- a/app/test/dgsVideoPlayer.test.tsx
+++ b/app/test/dgsVideoPlayer.test.tsx
@@ -14,6 +14,7 @@ jest.mock('react-native', () => {
 import { ActivityIndicator } from 'react-native';
 
 import DgsVideoPlayer from '../src/components/DgsVideoPlayer';
+import { LanguageManager } from '../src/services/LanguageManager';
 
 jest.mock('../src/utils/logger', () => ({
   logger: { error: jest.fn() },
@@ -21,6 +22,7 @@ jest.mock('../src/utils/logger', () => ({
 
 const play = jest.fn();
 const pause = jest.fn();
+const listeners: Record<string, Function> = {};
 const mockPlayer: any = {
   status: 'loading',
   duration: 10,
@@ -29,7 +31,10 @@ const mockPlayer: any = {
   play,
   pause,
   replay: jest.fn(),
-  addListener: jest.fn(() => ({ remove: jest.fn() })),
+  addListener: jest.fn((event: string, cb: Function) => {
+    listeners[event] = cb;
+    return { remove: jest.fn() };
+  }),
 };
 
 jest.mock('expo-video', () => ({
@@ -43,6 +48,8 @@ describe('DgsVideoPlayer performance', () => {
     mockPlayer.status = 'loading';
     mockPlayer.playing = false;
     mockPlayer.currentTime = 0;
+    mockPlayer.replay.mockClear();
+    Object.keys(listeners).forEach((key) => delete listeners[key]);
   });
 
   it('shows a loading indicator while buffering', () => {
@@ -84,7 +91,7 @@ describe('DgsVideoPlayer performance', () => {
       );
     });
     const playBtn = (component as renderer.ReactTestRenderer).root.findByProps({
-      accessibilityLabel: 'Video abspielen',
+      accessibilityLabel: LanguageManager.t('videoPlayer.playVideo'),
     });
     act(() => {
       playBtn.props.onPress();
@@ -94,11 +101,32 @@ describe('DgsVideoPlayer performance', () => {
     mockPlayer.playing = true;
 
     const pauseBtn = (component as renderer.ReactTestRenderer).root.findByProps({
-      accessibilityLabel: 'Video pausieren',
+      accessibilityLabel: LanguageManager.t('videoPlayer.pauseVideo'),
     });
     act(() => {
       pauseBtn.props.onPress();
     });
     expect(pause).toHaveBeenCalled();
+  });
+
+  it('stops playback when the video ends', () => {
+    mockPlayer.status = 'ready';
+    mockPlayer.playing = true;
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <DgsVideoPlayer videoSource={{ uri: 'foo' }} shouldPlay />
+      );
+    });
+    // simulate video ending
+    act(() => {
+      mockPlayer.playing = false;
+      listeners['playToEnd']();
+    });
+    expect(mockPlayer.replay).not.toHaveBeenCalled();
+    const playBtn = (component as renderer.ReactTestRenderer).root.findByProps({
+      accessibilityLabel: LanguageManager.t('videoPlayer.playVideo'),
+    });
+    expect(playBtn).toBeDefined();
   });
 });

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -160,7 +160,7 @@ Troubleshooting
 - **DGS video integration**
   - ✅ Complete video playback system for learning mode (DgsVideoPlayer)
   - ✅ Implement gesture demonstration in practice/training flow
-  - [ ] Add simplified video controls optimized for child interaction
+  - [x] Add simplified video controls optimized for child interaction
 
 ### 2.3 Core User Flows (HIP Protocol)
 **Priority: High**


### PR DESCRIPTION
## Summary
- add accessible play/pause controls to DgsVideoPlayer for children
- test manual play/pause behavior
- mark video control task complete in TODO

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: fetch failed)*
- `npm run type-check --prefix server`
- `npm test --prefix server`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b216304c3c8322ae5d2792988ddf8c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an on-video play/pause control with localized (German/English) labels, accessibility labels, and updated UI styles for the control.
- Tests
  - Added a test verifying manual play and pause via the new on-video control.
- Documentation
  - Marked the simplified video controls for child interaction as completed in the troubleshooting notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->