### PR TITLE
feat: add haptic feedback cues

### DIFF
--- a/app/src/services/audioService.ts
+++ b/app/src/services/audioService.ts
@@ -127,6 +127,13 @@ export class AudioService {
       sound.seekTo(0);
       sound.play();
       logger.debug(`Played sound: ${soundName}`);
+      if (this.config.enableHaptics && soundName === 'confirmation') {
+        try {
+          await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        } catch (error) {
+          logger.warn('Haptics confirmation feedback failed:', error);
+        }
+      }
     } catch (error) {
       logger.error(`Failed to play sound ${soundName}:`, error);
     }
@@ -298,6 +305,13 @@ export class AudioService {
    */
   async playCelebrationFeedback(): Promise<void> {
     await this.playSound('celebration');
+    if (this.config.enableHaptics) {
+      try {
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      } catch (error) {
+        logger.warn('Haptics celebration feedback failed:', error);
+      }
+    }
     await this.speak('Toll gemacht, Amy!', {
       pitch: 1.2,
       rate: 0.9,
@@ -322,6 +336,13 @@ export class AudioService {
         ];
 
     const phrase = phrases[Math.floor(Math.random() * phrases.length)];
+    if (this.config.enableHaptics) {
+      try {
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      } catch (error) {
+        logger.warn('Haptics encouragement feedback failed:', error);
+      }
+    }
     await this.speak(phrase, { pitch: 1.1, rate: 0.9 });
   }
 

--- a/app/test/audioFeedback.test.ts
+++ b/app/test/audioFeedback.test.ts
@@ -21,7 +21,9 @@ jest.mock('expo-speech', () => ({
 
 jest.mock('expo-haptics', () => ({
   notificationAsync: jest.fn().mockResolvedValue(undefined),
+  impactAsync: jest.fn().mockResolvedValue(undefined),
   NotificationFeedbackType: { Success: 'success', Error: 'error' },
+  ImpactFeedbackStyle: { Medium: 'medium' },
 }));
 
 jest.mock('expo-file-system', () => ({
@@ -59,6 +61,7 @@ describe('audioService feedback', () => {
       ['success', soundMock()],
       ['error', soundMock()],
       ['confirmation', soundMock()],
+      ['celebration', soundMock()],
     ]);
     (audioService as any).isInitialized = true;
     (audioService as any).isSpeaking = false;
@@ -98,7 +101,14 @@ describe('audioService feedback', () => {
     expect(Haptics.notificationAsync).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Error);
   });
 
-  it('speaks gentle encouragement for a gesture', async () => {
+  it('plays confirmation sound with haptic success', async () => {
+    await audioService.playSound('confirmation');
+    const confirmationSound = (audioService as any).sounds.get('confirmation');
+    expect(confirmationSound.play).toHaveBeenCalled();
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Success);
+  });
+
+  it('speaks gentle encouragement for a gesture with haptic feedback', async () => {
     await audioService.playEncouragement('Winken');
     const phrase = (Speech.speak as jest.Mock).mock.calls[0][0];
     expect([
@@ -106,6 +116,18 @@ describe('audioService feedback', () => {
       'Lass uns Winken nochmal versuchen!',
       'Wie wäre es mit etwas Übung für Winken?',
     ]).toContain(phrase);
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+  });
+
+  it('plays celebration feedback with haptic success', async () => {
+    await audioService.playCelebrationFeedback();
+    const celebrationSound = (audioService as any).sounds.get('celebration');
+    expect(celebrationSound.play).toHaveBeenCalled();
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Success);
+    expect(Speech.speak).toHaveBeenCalledWith(
+      'Toll gemacht, Amy!',
+      expect.objectContaining({ pitch: 1.2, rate: 0.9 })
+    );
   });
 
   it('plays pre-recorded audio when available', async () => {

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -156,7 +156,7 @@ Troubleshooting
 - **Rich feedback implementation**
   - [ ] Complete audioService.ts with contextual sound design
   - [ ] Implement visual confirmation system with accessibility support
-  - [ ] Add haptic feedback for tactile confirmation
+  - [x] Add haptic feedback for tactile confirmation
 - **DGS video integration**
   - ✅ Complete video playback system for learning mode (DgsVideoPlayer)
   - ✅ Implement gesture demonstration in practice/training flow
@@ -191,7 +191,7 @@ Troubleshooting
   - [ ] Add contextual celebration animations for successful gestures
   - [ ] Implement ambient sound design that responds to Amy's mood and energy
   - [ ] Create visual themes that can be customized by caregivers
-  - [ ] Add haptic feedback patterns that reinforce learning
+  - [x] Add haptic feedback patterns that reinforce learning
 - **Multi-modal interaction support**
   - [ ] Implement voice commands for navigation assistance
   - [ ] Add switch/button accessibility options for motor limitations


### PR DESCRIPTION
## Summary
- add haptic feedback when playing confirmation and celebration sounds
- trigger medium impact haptics for encouragement phrases
- mark TODO items for haptic feedback as complete and extend audio feedback tests

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH 34.110.201.56:443)*
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b22d47682c832295218ca7414edb0e