### PR TITLE
feat: gentle feedback on unrecognized gestures

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -244,7 +244,7 @@ export default function RecognitionScreen({ navigation }: any) {
           uncertainCountRef.current = 0;
         }
         // Gentle feedback when the gesture wasn't recognized
-        try { await audioService.playErrorFeedback(); } catch {}
+        try { await audioService.playErrorFeedback(); } catch (error) { logger.warn('Failed to play error feedback:', error); }
         // HIP 3: opened correction/uncertainty path
         void logHIPEvent('HIP_3', 'help_me_opened', { suggestionFor: finalGesture });
         // Log failure for the incoming gesture id (could be 'unknown')

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -243,8 +243,8 @@ export default function RecognitionScreen({ navigation }: any) {
           setShowCorrection(true);
           uncertainCountRef.current = 0;
         }
-        // Gentle nudge to retry
-        try { await audioService.playEncouragement(); } catch {}
+        // Gentle feedback when the gesture wasn't recognized
+        try { await audioService.playErrorFeedback(); } catch {}
         // HIP 3: opened correction/uncertainty path
         void logHIPEvent('HIP_3', 'help_me_opened', { suggestionFor: finalGesture });
         // Log failure for the incoming gesture id (could be 'unknown')

--- a/app/test/screens/RecognitionScreen.test.tsx
+++ b/app/test/screens/RecognitionScreen.test.tsx
@@ -22,6 +22,7 @@ jest.mock('react-native', () => {
 });
 
 import RecognitionScreen from '../../src/screens/RecognitionScreen';
+import { audioService } from '../../src/services';
 
 jest.mock('../../src/components/MediaPipeGestureDetector', () => {
   const React = require('react');
@@ -43,7 +44,12 @@ jest.mock('../../src/components/DgsVideoPlayer', () => {
 });
 jest.mock('expo-haptics', () => ({ impactAsync: jest.fn(), ImpactFeedbackStyle: { Medium: 'Medium' } }));
 jest.mock('../../src/services', () => ({
-  audioService: { speak: jest.fn(), playEncouragement: jest.fn(), playSuccessFeedback: jest.fn() },
+  audioService: {
+    speak: jest.fn(),
+    playEncouragement: jest.fn(),
+    playSuccessFeedback: jest.fn(),
+    playErrorFeedback: jest.fn(),
+  },
   triggerSpeakAndShow: jest.fn(),
   correctionService: { logCorrection: jest.fn() },
   dialogEngine: { getSuggestions: jest.fn() },
@@ -100,6 +106,18 @@ describe('RecognitionScreen', () => {
     });
     const button = component.root.findByProps({ testID: 'btn-correction' });
     expect(button.props.accessibilityLabel).toBe('Korrekturseite öffnen');
+  });
+
+  it('provides gentle feedback when gesture is not recognized', async () => {
+    let component!: renderer.ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<RecognitionScreen navigation={{ navigate: jest.fn() }} />);
+    });
+    const detector = component.root.findByType('MediaPipeGestureDetector');
+    await act(async () => {
+      await detector.props.onGestureDetected(null, 0.1, [], []);
+    });
+    expect(audioService.playErrorFeedback).toHaveBeenCalled();
   });
 
   it('shows DGS video when toggle enabled and gesture recognized', async () => {

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -171,7 +171,7 @@ Troubleshooting
 - **HIP 3: Correction flow implementation**
   - [ ] Build "Help Me" repair interface
   - [ ] Implement correction logging for model improvement
-  - [ ] Add gentle feedback for incorrect recognition
+  - [x] Add gentle feedback for incorrect recognition
   - ✅ Log HIP 3 events and provide encouragement cues
 
 ## Phase 3: Advanced Features & Optimization (Weeks 6-7)


### PR DESCRIPTION
## Summary
- play error feedback when a gesture isn't recognized
- cover gentle feedback behavior with a new test
- check off TODO item for gentle incorrect-gesture feedback

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b22f7875dc83228d4a4df584f51bad