### PR TITLE
feat(app): add celebration animation

### DIFF
--- a/app/src/components/Celebration.tsx
+++ b/app/src/components/Celebration.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text } from 'react-native';
+import { useAccessibility } from './AccessibilityContext';
+import { COLORS } from '../constants/ui';
+
+interface CelebrationProps {
+  visible: boolean;
+}
+
+export default function Celebration({ visible }: CelebrationProps) {
+  const { largeText } = useAccessibility();
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout | undefined;
+    if (visible) {
+      opacity.setValue(0);
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }).start(() => {
+        timeout = setTimeout(() => {
+          Animated.timing(opacity, {
+            toValue: 0,
+            duration: 300,
+            useNativeDriver: true,
+          }).start();
+        }, 700);
+      });
+    } else {
+      opacity.setValue(0);
+    }
+    return () => timeout && clearTimeout(timeout);
+  }, [visible, opacity]);
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      accessibilityRole="alert"
+      accessibilityLabel="Gut gemacht!"
+      style={[styles.overlay, { opacity }]}
+    >
+      <Text style={[styles.text, { fontSize: largeText ? 48 : 40 }]}>🎉</Text>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: COLORS.primaryAccent,
+  },
+});

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -36,6 +36,7 @@ import { SequenceRecognizer, SequenceDefinition } from '../services/sequenceReco
 import { RecognitionPath } from '../utils/recognitionState';
 import DgsVideoPlayer from '../components/DgsVideoPlayer';
 import { LanguageManager } from '../services/LanguageManager';
+import Celebration from '../components/Celebration';
 // ExpoCameraDetector removed from default path (server-based); WebView is primary
 
 export default function RecognitionScreen({ navigation }: any) {
@@ -62,6 +63,7 @@ export default function RecognitionScreen({ navigation }: any) {
   const [webviewKey, setWebviewKey] = useState(0);
   const [recognitionPath, setRecognitionPath] = useState<RecognitionPath>('local');
   const [showDgsVideo, setShowDgsVideo] = useState(false);
+  const [showCelebration, setShowCelebration] = useState(false);
 
   const fadeAnim = useRef(new Animated.Value(1)).current;
   const symbolScaleAnim = useRef(new Animated.Value(0)).current;
@@ -73,6 +75,8 @@ export default function RecognitionScreen({ navigation }: any) {
   const seqRef = useRef(new SequenceRecognizer(seqDefsRef.current));
   const uncertainCountRef = useRef(0);
   const lastUncertainAtRef = useRef<number>(0);
+  const lastSuccessAtRef = useRef<number>(0);
+  const lastGestureIdRef = useRef<string | null>(null);
   const centroidsRef = useRef<CentroidMap>({});
 
   useEffect(() => {
@@ -132,6 +136,9 @@ export default function RecognitionScreen({ navigation }: any) {
       tension: 80,
       useNativeDriver: true,
     }).start();
+
+    setShowCelebration(true);
+    setTimeout(() => setShowCelebration(false), 1000);
   }, [fadeAnim, symbolScaleAnim]);
 
   const handleGestureDetected = useCallback(async (
@@ -183,11 +190,21 @@ export default function RecognitionScreen({ navigation }: any) {
 
       if (smoothed > 0.7 && stableGesture !== 'unknown') {
         const entry = (gestureModel.gestures.find((g) => g.id === stableGesture) || { id: stableGesture, label: stableGesture }) as GestureModelEntry;
+        const now = Date.now();
+        const shouldProvideFeedback =
+          lastGestureIdRef.current !== entry.id ||
+          now - lastSuccessAtRef.current > 2000;
+
+        lastGestureIdRef.current = entry.id;
         setLastRecognizedGesture(entry);
         setStatus(entry.label);
-        triggerSpeakAndShow(entry.label, smoothed, () => {});
-        startFeedbackAnimation();
-        void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+
+        if (shouldProvideFeedback) {
+          lastSuccessAtRef.current = now;
+          triggerSpeakAndShow(entry.label, smoothed, () => {});
+          startFeedbackAnimation();
+          void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+        }
 
         // Log success
         logInteractionEvent({
@@ -428,6 +445,8 @@ export default function RecognitionScreen({ navigation }: any) {
         </View>
       )}
     </View>
+
+    <Celebration visible={showCelebration} />
 
     {showCorrection && (
       <CorrectionPanel

--- a/app/test/components/Celebration.test.tsx
+++ b/app/test/components/Celebration.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import Celebration from '../../src/components/Celebration';
+
+jest.mock('react-native', () => {
+  const React = require('react');
+  return {
+    Animated: {
+      Value: class { constructor(public v: any) {} setValue(_: any) {} },
+      timing: () => ({ start: jest.fn() }),
+      View: (p: any) => React.createElement('Animated.View', p, p.children),
+    },
+    StyleSheet: { create: (s: any) => s },
+    Text: (p: any) => React.createElement('Text', p, p.children),
+  } as any;
+});
+
+jest.mock('../../src/components/AccessibilityContext', () => ({
+  useAccessibility: () => ({ largeText: false }),
+}));
+
+describe('Celebration', () => {
+  it('renders with German accessibility label when visible', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<Celebration visible={true} />);
+    });
+    const view = component.root.findByType('Animated.View');
+    expect(view.props.accessibilityLabel).toBe('Gut gemacht!');
+    const text = component.root.findByType('Text');
+    expect(text.props.children).toBe('🎉');
+  });
+});

--- a/app/test/screens/RecognitionScreen.test.tsx
+++ b/app/test/screens/RecognitionScreen.test.tsx
@@ -22,7 +22,7 @@ jest.mock('react-native', () => {
 });
 
 import RecognitionScreen from '../../src/screens/RecognitionScreen';
-import { audioService } from '../../src/services';
+import { audioService, triggerSpeakAndShow } from '../../src/services';
 
 jest.mock('../../src/components/MediaPipeGestureDetector', () => {
   const React = require('react');
@@ -41,6 +41,10 @@ jest.mock('../../src/components/CorrectionPanel', () => {
 jest.mock('../../src/components/DgsVideoPlayer', () => {
   const React = require('react');
   return (props: any) => React.createElement('DgsVideoPlayer', props, null);
+});
+jest.mock('../../src/components/Celebration', () => {
+  const React = require('react');
+  return (props: any) => React.createElement('Celebration', props, null);
 });
 jest.mock('expo-haptics', () => ({ impactAsync: jest.fn(), ImpactFeedbackStyle: { Medium: 'Medium' } }));
 jest.mock('../../src/services', () => ({
@@ -135,5 +139,32 @@ describe('RecognitionScreen', () => {
     });
     const vids = component.root.findAllByType('DgsVideoPlayer');
     expect(vids.length).toBe(1);
+  });
+
+  it('shows celebration when gesture recognized with high confidence', async () => {
+    let component!: renderer.ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<RecognitionScreen navigation={{ navigate: jest.fn() }} />);
+    });
+    const detector = component.root.findByType('MediaPipeGestureDetector');
+    await act(async () => {
+      detector.props.onGestureDetected('hello', 0.9, [], []);
+    });
+    const celebration = component.root.findByType('Celebration');
+    expect(celebration.props.visible).toBe(true);
+    expect(triggerSpeakAndShow).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not spam celebration for repeated gestures', async () => {
+    let component!: renderer.ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<RecognitionScreen navigation={{ navigate: jest.fn() }} />);
+    });
+    const detector = component.root.findByType('MediaPipeGestureDetector');
+    await act(async () => {
+      detector.props.onGestureDetected('hello', 0.9, [], []);
+      detector.props.onGestureDetected('hello', 0.95, [], []);
+    });
+    expect(triggerSpeakAndShow).toHaveBeenCalledTimes(1);
   });
 });

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -155,7 +155,7 @@ Troubleshooting
 **Priority: High**
 - **Rich feedback implementation**
   - [ ] Complete audioService.ts with contextual sound design
-  - [ ] Implement visual confirmation system with accessibility support
+  - [x] Implement visual confirmation system with accessibility support
   - [x] Add haptic feedback for tactile confirmation
 - **DGS video integration**
   - ✅ Complete video playback system for learning mode (DgsVideoPlayer)
@@ -188,7 +188,7 @@ Troubleshooting
 ### 3.2 Enhanced User Experience Features
 **Priority: Medium - User Delight**
 - **Rich audio-visual feedback expansion**
-  - [ ] Add contextual celebration animations for successful gestures
+  - [x] Add contextual celebration animations for successful gestures
   - [ ] Implement ambient sound design that responds to Amy's mood and energy
   - [ ] Create visual themes that can be customized by caregivers
   - [x] Add haptic feedback patterns that reinforce learning


### PR DESCRIPTION
## Summary
- add accessible celebration overlay component
- trigger celebration on successful gesture recognition
- prevent repeated celebration feedback
- document completed visual feedback tasks

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: connect ENETUNREACH)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b28c4cbd548322a4d7d18ee4f226a2