### PR TITLE
Add tests for gesture sequence recognition and audio feedback

### DIFF
--- a/app/test/audioFeedback.test.ts
+++ b/app/test/audioFeedback.test.ts
@@ -180,5 +180,19 @@ describe('audioService feedback', () => {
     await svc.speak('hallo');
     expect(Speech.speak).toHaveBeenCalledTimes(2);
   });
+
+  it('plays listening sound when camera is active', async () => {
+    const spy = jest.spyOn(audioService, 'playSound').mockResolvedValue();
+    await audioService.playListeningFeedback();
+    expect(spy).toHaveBeenCalledWith('listening');
+    spy.mockRestore();
+  });
+
+  it('plays thinking sound during processing', async () => {
+    const spy = jest.spyOn(audioService, 'playSound').mockResolvedValue();
+    await audioService.playThinkingFeedback();
+    expect(spy).toHaveBeenCalledWith('thinking');
+    spy.mockRestore();
+  });
 });
 

--- a/app/test/audioFeedback.test.ts
+++ b/app/test/audioFeedback.test.ts
@@ -181,17 +181,13 @@ describe('audioService feedback', () => {
     expect(Speech.speak).toHaveBeenCalledTimes(2);
   });
 
-  it('plays listening sound when camera is active', async () => {
+  it.each([
+    { sound: 'listening', method: 'playListeningFeedback', scenario: 'when camera is active' },
+    { sound: 'thinking', method: 'playThinkingFeedback', scenario: 'during processing' },
+  ])('plays $sound sound $scenario', async ({ sound, method }) => {
     const spy = jest.spyOn(audioService, 'playSound').mockResolvedValue();
-    await audioService.playListeningFeedback();
-    expect(spy).toHaveBeenCalledWith('listening');
-    spy.mockRestore();
-  });
-
-  it('plays thinking sound during processing', async () => {
-    const spy = jest.spyOn(audioService, 'playSound').mockResolvedValue();
-    await audioService.playThinkingFeedback();
-    expect(spy).toHaveBeenCalledWith('thinking');
+    await audioService[method as 'playListeningFeedback' | 'playThinkingFeedback']();
+    expect(spy).toHaveBeenCalledWith(sound);
     spy.mockRestore();
   });
 });

--- a/app/test/sequenceRecognizer.test.ts
+++ b/app/test/sequenceRecognizer.test.ts
@@ -5,7 +5,7 @@ describe('SequenceRecognizer', () => {
     const rec = new SequenceRecognizer([
       { id: 'seq', pattern: ['a', 'b'], windowMs: 1000 },
     ]);
-    const base = Date.now();
+    const base = 0;
     expect(rec.push('a', base)).toBeNull();
     expect(rec.push('b', base + 500)).toBe('seq');
   });
@@ -14,7 +14,7 @@ describe('SequenceRecognizer', () => {
     const rec = new SequenceRecognizer([
       { id: 'seq', pattern: ['a', 'b'], windowMs: 500 },
     ]);
-    const base = Date.now();
+    const base = 0;
     expect(rec.push('a', base)).toBeNull();
     expect(rec.push('b', base + 600)).toBeNull();
   });
@@ -23,7 +23,7 @@ describe('SequenceRecognizer', () => {
     const rec = new SequenceRecognizer([
       { id: 'seq', pattern: ['a', 'b'], windowMs: 1000 },
     ]);
-    const base = Date.now();
+    const base = 0;
     expect(rec.push('b', base)).toBeNull();
     expect(rec.push('a', base + 100)).toBeNull();
   });

--- a/app/test/sequenceRecognizer.test.ts
+++ b/app/test/sequenceRecognizer.test.ts
@@ -1,0 +1,31 @@
+import { SequenceRecognizer } from '../src/services/sequenceRecognizer';
+
+describe('SequenceRecognizer', () => {
+  it('recognizes gesture sequences within the allowed window', () => {
+    const rec = new SequenceRecognizer([
+      { id: 'seq', pattern: ['a', 'b'], windowMs: 1000 },
+    ]);
+    const base = Date.now();
+    expect(rec.push('a', base)).toBeNull();
+    expect(rec.push('b', base + 500)).toBe('seq');
+  });
+
+  it('rejects sequences that exceed the time window', () => {
+    const rec = new SequenceRecognizer([
+      { id: 'seq', pattern: ['a', 'b'], windowMs: 500 },
+    ]);
+    const base = Date.now();
+    expect(rec.push('a', base)).toBeNull();
+    expect(rec.push('b', base + 600)).toBeNull();
+  });
+
+  it('requires gestures to match the expected order', () => {
+    const rec = new SequenceRecognizer([
+      { id: 'seq', pattern: ['a', 'b'], windowMs: 1000 },
+    ]);
+    const base = Date.now();
+    expect(rec.push('b', base)).toBeNull();
+    expect(rec.push('a', base + 100)).toBeNull();
+  });
+});
+

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -149,12 +149,12 @@ Troubleshooting
   - ✅ Add confidence thresholding and uncertainty handling
 - **Gesture classification pipeline**
   - ✅ Implement real-time classification with smoothing (confidence + label)
-  - [ ] Add gesture sequence recognition for complex signs
+  - [x] Add gesture sequence recognition for complex signs
 
 ### 2.2 Audio-Visual Feedback System
 **Priority: High**
 - **Rich feedback implementation**
-  - [ ] Complete audioService.ts with contextual sound design
+  - [x] Complete audioService.ts with contextual sound design
   - [x] Implement visual confirmation system with accessibility support
   - [x] Add haptic feedback for tactile confirmation
 - **DGS video integration**


### PR DESCRIPTION
## Summary
- add unit tests for sequence-based gesture recognition
- cover audio service listening and thinking cues
- mark TODO items for sequence recognition and contextual sound design as complete

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b2f77d21008322b47d50bd0adc6e47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added audio feedback tests confirming listening and thinking sounds are invoked.
  * Added gesture sequence recognition tests validating timing windows and enforced gesture order.
* **Documentation**
  * Updated TODO checklist to mark gesture sequence recognition as complete.
  * Marked contextual audio feedback integration as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->