### PR TITLE
refactor: remove unused heavy packages

### DIFF
--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -2,9 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: [
-      ['react-native-worklets-core/plugin'],
-      'react-native-reanimated/plugin',
-    ],
+    plugins: ['react-native-reanimated/plugin'],
   };
 };

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,13 +8,11 @@
       "name": "amys-echo-app",
       "version": "1.0.0",
       "dependencies": {
-        "@babel/runtime": "7.28.2",
         "@nozbe/watermelondb": "0.28.0",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-community/netinfo": "11.4.1",
         "@react-navigation/native": "6.1.18",
-        "@react-navigation/native-stack": "6.11.0",
-        "@shopify/react-native-skia": "2.0.0-next.4",
+        "@react-navigation/stack": "6.4.1",
         "crypto-js": "4.2.0",
         "expo": "53.0.22",
         "expo-audio": "0.4.9",
@@ -25,16 +23,13 @@
         "expo-secure-store": "14.2.4",
         "expo-speech": "13.1.7",
         "expo-video": "2.2.2",
-        "lucide-react-native": "0.535.0",
         "react": "19.0.0",
         "react-native": "0.79.5",
         "react-native-gesture-handler": "2.24.0",
         "react-native-reanimated": "3.17.4",
         "react-native-safe-area-context": "5.4.0",
-        "react-native-screens": "4.11.1",
         "react-native-svg": "15.11.2",
-        "react-native-webview": "13.13.5",
-        "react-native-worklets-core": "1.6.0"
+        "react-native-webview": "13.13.5"
       },
       "devDependencies": {
         "@babel/core": "7.28.0",
@@ -47,7 +42,6 @@
         "jest": "29.7.0",
         "jest-expo": "^53.0.10",
         "ts-jest": "29.4.0",
-        "ts-node": "10.9.2",
         "typescript": "5.8.3"
       }
     },
@@ -1545,30 +1539,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
     },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
@@ -4000,23 +3970,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@react-navigation/native-stack": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.11.0.tgz",
-      "integrity": "sha512-U5EcUB9Q2NQspCFwYGGNJm0h6wBCOv7T30QjndmvlawLkNt7S7KWbpWyxS9XBHSIKF57RgWjfxuJNTgTstpXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-navigation/elements": "^1.3.31",
-        "warn-once": "^0.1.0"
-      },
-      "peerDependencies": {
-        "@react-navigation/native": "^6.0.0",
-        "react": "*",
-        "react-native": "*",
-        "react-native-safe-area-context": ">= 3.0.0",
-        "react-native-screens": ">= 3.0.0"
-      }
-    },
     "node_modules/@react-navigation/routers": {
       "version": "6.1.9",
       "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-6.1.9.tgz",
@@ -4026,30 +3979,23 @@
         "nanoid": "^3.1.23"
       }
     },
-    "node_modules/@shopify/react-native-skia": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.0.0-next.4.tgz",
-      "integrity": "sha512-NzvdgryRz6tkKMHgCChCKa3wXfN9TZhlV0/LrfIU/wKLC1uKgGXkoZgNz7Is0wwdhtao1JJJJ81fqHCGHgzk9g==",
+    "node_modules/@react-navigation/stack": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-6.4.1.tgz",
+      "integrity": "sha512-upMEHOKMtuMu4c9gmoPlO/JqI6mDlSqwXg1aXKOTQLXAF8H5koOLRfrmi7AkdiE9A7lDXWUAZoGuD9O88cYvDQ==",
       "license": "MIT",
       "dependencies": {
-        "canvaskit-wasm": "0.40.0",
-        "react-reconciler": "0.31.0"
-      },
-      "bin": {
-        "setup-skia-web": "scripts/setup-canvaskit.js"
+        "@react-navigation/elements": "^1.3.31",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
       },
       "peerDependencies": {
-        "react": ">=19.0",
-        "react-native": ">=0.78",
-        "react-native-reanimated": "^3.0"
-      },
-      "peerDependenciesMeta": {
-        "react-native": {
-          "optional": true
-        },
-        "react-native-reanimated": {
-          "optional": true
-        }
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 1.0.0",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4085,34 +4031,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4293,12 +4211,6 @@
       "peerDependencies": {
         "@urql/core": "^5.0.0"
       }
-    },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
-      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
@@ -5031,15 +4943,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canvaskit-wasm": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.40.0.tgz",
-      "integrity": "sha512-Od2o+ZmoEw9PBdN/yCGvzfu0WVqlufBPEWNG452wY7E9aT8RBE+ChpZF526doOlg7zumO4iCS+RAeht4P0Gbpw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@webgpu/types": "0.1.21"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5223,6 +5126,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5240,6 +5156,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5375,13 +5301,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5638,16 +5557,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -8607,17 +8516,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lucide-react-native": {
-      "version": "0.535.0",
-      "resolved": "https://registry.npmjs.org/lucide-react-native/-/lucide-react-native-0.535.0.tgz",
-      "integrity": "sha512-mp9EBE1sotDztpZyjXCMo0F9oJ1u9dG4zF0UPhb6qjLahuKGhd6y2B/D7J9CPVhEII0FfeGlDOzrO/ZEPZYrEw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-native": "*",
-        "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -10020,18 +9918,6 @@
         }
       }
     },
-    "node_modules/react-freeze": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
-      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -10167,21 +10053,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native-screens": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.11.1.tgz",
-      "integrity": "sha512-F0zOzRVa3ptZfLpD0J8ROdo+y1fEPw+VBFq1MTY/iyDu08al7qFUO5hLMd+EYMda5VXGaTFCa8q7bOppUszhJw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-freeze": "^1.0.0",
-        "react-native-is-edge-to-edge": "^1.1.7",
-        "warn-once": "^0.1.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-svg": {
       "version": "15.11.2",
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.11.2.tgz",
@@ -10205,19 +10076,6 @@
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-worklets-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-native-worklets-core/-/react-native-worklets-core-1.6.0.tgz",
-      "integrity": "sha512-IRu8UUROsRklFdeqmZdWxeCq+EYYSCV8zj4S9mdPwm1K72OehptoYbZCU3+2NjINF4I8Q+Z+z5TwaJQpKQBYmg==",
-      "license": "MIT",
-      "dependencies": {
-        "string-hash-64": "^1.0.3"
       },
       "peerDependencies": {
         "react": "*",
@@ -10286,21 +10144,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/react-reconciler": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
-      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.25.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -10903,6 +10746,21 @@
         "node": ">= 5.10.0"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11093,12 +10951,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/string-hash-64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
-      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==",
-      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -11665,57 +11517,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -11926,13 +11727,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -12417,16 +12211,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/app/package.json
+++ b/app/package.json
@@ -18,13 +18,11 @@
     "build:webview": "esbuild webview/gestureDetector.ts --bundle --format=iife --outfile=assets/gestureDetector.js"
   },
   "dependencies": {
-    "@babel/runtime": "7.28.2",
     "@nozbe/watermelondb": "0.28.0",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/native": "6.1.18",
-    "@react-navigation/native-stack": "6.11.0",
-    "@shopify/react-native-skia": "2.0.0-next.4",
+    "@react-navigation/stack": "6.4.1",
     "crypto-js": "4.2.0",
     "expo": "53.0.22",
     "expo-audio": "0.4.9",
@@ -35,16 +33,13 @@
     "expo-secure-store": "14.2.4",
     "expo-speech": "13.1.7",
     "expo-video": "2.2.2",
-    "lucide-react-native": "0.535.0",
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-gesture-handler": "2.24.0",
     "react-native-reanimated": "3.17.4",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "4.11.1",
     "react-native-svg": "15.11.2",
-    "react-native-webview": "13.13.5",
-    "react-native-worklets-core": "1.6.0"
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@babel/core": "7.28.0",
@@ -55,7 +50,6 @@
     "jest": "29.7.0",
     "jest-expo": "^53.0.10",
     "ts-jest": "29.4.0",
-    "ts-node": "10.9.2",
     "typescript": "5.8.3",
     "esbuild": "^0.21.5",
     "fflate": "^0.8.2"
@@ -70,8 +64,7 @@
     "doctor": {
       "reactNativeDirectoryCheck": {
         "exclude": [
-          "@nozbe/watermelondb",
-          "lucide-react-native"
+          "@nozbe/watermelondb"
         ],
         "listUnknownPackages": false
       }

--- a/app/src/components/BottomNav.tsx
+++ b/app/src/components/BottomNav.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Pressable, Text, StyleSheet } from 'react-native';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
-import { Hand, BookOpen, Settings } from 'lucide-react-native';
+import Svg, { Path, Circle } from 'react-native-svg';
 import type { RootStackParamList } from '../navigation/types';
 import { COLORS, SPACING } from '../constants/ui';
 import { useAccessibility } from './AccessibilityContext';
@@ -32,7 +32,7 @@ export default function BottomNav({ active, profileId }: Props) {
         accessibilityRole="button"
         accessibilityHint="Gestenerkennung starten"
       >
-        <Hand
+        <HandIcon
           size={24}
           color={
             highContrast
@@ -69,7 +69,7 @@ export default function BottomNav({ active, profileId }: Props) {
         accessibilityRole="button"
         accessibilityHint="Gesten aufnehmen oder üben"
       >
-        <BookOpen
+        <BookIcon
           size={24}
           color={
             highContrast
@@ -106,7 +106,7 @@ export default function BottomNav({ active, profileId }: Props) {
         accessibilityRole="button"
         accessibilityHint="Profil- und Einstellungsmenü öffnen"
       >
-        <Settings
+        <SettingsIcon
           size={24}
           color={
             highContrast
@@ -171,3 +171,68 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
+
+interface IconProps {
+  size: number;
+  color: string;
+  style?: any;
+}
+
+function HandIcon({ size, color, style }: IconProps) {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={style}
+    >
+      <Path d="M18 11V6a2 2 0 0 0-2-2a2 2 0 0 0-2 2" />
+      <Path d="M14 10V4a2 2 0 0 0-2-2a2 2 0 0 0-2 2v2" />
+      <Path d="M10 10.5V6a2 2 0 0 0-2-2a2 2 0 0 0-2 2v8" />
+      <Path d="M18 8a2 2 0 1 1 4 0v6a8 8 0 0 1-8 8h-2c-2.8 0-4.5-.86-5.99-2.34l-3.6-3.6a2 2 0 0 1 2.83-2.82L7 15" />
+    </Svg>
+  );
+}
+
+function BookIcon({ size, color, style }: IconProps) {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={style}
+    >
+      <Path d="M12 7v14" />
+      <Path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+    </Svg>
+  );
+}
+
+function SettingsIcon({ size, color, style }: IconProps) {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={style}
+    >
+      <Path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+      <Circle cx="12" cy="12" r="3" />
+    </Svg>
+  );
+}

--- a/app/src/components/PulsingCircle.tsx
+++ b/app/src/components/PulsingCircle.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect } from 'react';
-import { Canvas, Circle } from '@shopify/react-native-skia';
-import { useSharedValue, withTiming, withRepeat, useDerivedValue } from 'react-native-reanimated';
+import { View } from 'react-native';
+import Animated, {
+  useSharedValue,
+  withTiming,
+  withRepeat,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
 
 import { usePerformance } from '../context/PerformanceContext';
 
@@ -19,20 +24,38 @@ export default function PulsingCircle({ size, color = '#ffffff' }: PulsingCircle
     }
   }, [progress, isLowPerformanceMode]);
 
-  const radius = useDerivedValue(() => (size / 2) * progress.value);
-  const opacity = useDerivedValue(() => 1 - progress.value);
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: 1 - progress.value,
+    transform: [{ scale: progress.value }],
+  }));
 
   if (isLowPerformanceMode) {
     return (
-      <Canvas style={{ width: size, height: size, position: 'absolute' }}>
-        <Circle cx={size / 2} cy={size / 2} r={size / 2} color={color} opacity={0.5} />
-      </Canvas>
+      <View
+        style={{
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor: color,
+          opacity: 0.5,
+          position: 'absolute',
+        }}
+      />
     );
   }
 
   return (
-    <Canvas style={{ width: size, height: size, position: 'absolute' }}>
-      <Circle cx={size / 2} cy={size / 2} r={radius} color={color} opacity={opacity} />
-    </Canvas>
+    <Animated.View
+      style={[
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor: color,
+          position: 'absolute',
+        },
+        animatedStyle,
+      ]}
+    />
   );
 }

--- a/app/src/declarations.d.ts
+++ b/app/src/declarations.d.ts
@@ -1,4 +1,3 @@
-declare module '@shopify/react-native-skia';
 declare module 'crypto-js';
 declare module 'react-native-webview';
 declare module 'expo-crypto' {

--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -1,6 +1,6 @@
 
 import React, { Suspense, useEffect, useState } from 'react';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createStackNavigator } from '@react-navigation/stack';
 import { RootStackParamList } from './types';
 import { loadProfiles } from '../storage';
 import LoadingIndicator from '../components/LoadingIndicator';
@@ -32,7 +32,7 @@ const ProgressChartScreen = lazyScreen(() => import('../screens/ProgressChartScr
 const PracticeSchedulerScreen = lazyScreen(() => import('../screens/PracticeSchedulerScreen'));
 const CaregiverReportScreen = lazyScreen(() => import('../screens/CaregiverReportScreen'));
 
-const Stack = createNativeStackNavigator<RootStackParamList>();
+const Stack = createStackNavigator<RootStackParamList>();
 
 const RootNavigator = () => {
   const [initialRoute, setInitialRoute] = useState<keyof RootStackParamList | undefined>();

--- a/app/test/bottomNav.test.tsx
+++ b/app/test/bottomNav.test.tsx
@@ -17,12 +17,14 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate }),
 }));
 
-jest.mock('lucide-react-native', () => {
+
+jest.mock('react-native-svg', () => {
   const React = require('react');
   return {
-    Hand: (props: any) => React.createElement('Hand', props, props.children),
-    BookOpen: (props: any) => React.createElement('BookOpen', props, props.children),
-    Settings: (props: any) => React.createElement('Settings', props, props.children),
+    __esModule: true,
+    default: (props: any) => React.createElement('Svg', props, props.children),
+    Path: (props: any) => React.createElement('Path', props, props.children),
+    Circle: (props: any) => React.createElement('Circle', props, props.children),
   };
 });
 

--- a/docs/DeterministicBuilds.md
+++ b/docs/DeterministicBuilds.md
@@ -7,8 +7,8 @@ Goals
 - Fail CI if critical deps are unpinned
 
 Critical packages
-- App: react, react-native, expo, react-native-webview, react-native-reanimated, react-native-worklets-core, @nozbe/watermelondb
-- Server: express, express-rate-limit
+ - App: react, react-native, expo, react-native-webview, react-native-reanimated, @nozbe/watermelondb
+ - Server: express, express-rate-limit
 
 Workflow
 1) Pin versions in `app/package.json` and `server/package.json` (no `^`, `~`, or `latest`).

--- a/docs/deps/app-deps.json
+++ b/docs/deps/app-deps.json
@@ -2,8 +2,9 @@
   "version": "1.0.0",
   "name": "amys-echo-app",
   "problems": [
-    "invalid: @types/react@19.0.10 /workspace/AmysEcho/app/node_modules/@types/react",
-    "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
+    "missing: react-native-screens@>= 3.0.0, required by @react-navigation/stack@6.4.1",
+    "missing: react-dom@^19.0.0, required by react-server-dom-webpack@19.0.0",
+    "missing: webpack@^5.59.0, required by react-server-dom-webpack@19.0.0"
   ],
   "dependencies": {
     "@babel/core": {
@@ -64,7 +65,9 @@
               "overridden": false
             },
             "picocolors": {
-              "version": "1.1.1"
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+              "overridden": false
             }
           }
         },
@@ -98,13 +101,52 @@
           "overridden": false,
           "dependencies": {
             "@babel/compat-data": {
-              "version": "7.28.0"
+              "version": "7.28.0",
+              "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+              "overridden": false
             },
             "@babel/helper-validator-option": {
-              "version": "7.27.1"
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+              "overridden": false
             },
             "browserslist": {
-              "version": "4.25.2"
+              "version": "4.25.2",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
+              "overridden": false,
+              "dependencies": {
+                "caniuse-lite": {
+                  "version": "1.0.30001735",
+                  "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
+                  "overridden": false
+                },
+                "electron-to-chromium": {
+                  "version": "1.5.203",
+                  "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.203.tgz",
+                  "overridden": false
+                },
+                "node-releases": {
+                  "version": "2.0.19",
+                  "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+                  "overridden": false
+                },
+                "update-browserslist-db": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "browserslist": {
+                      "version": "4.25.2"
+                    },
+                    "escalade": {
+                      "version": "3.2.0"
+                    },
+                    "picocolors": {
+                      "version": "1.1.1"
+                    }
+                  }
+                }
+              }
             },
             "lru-cache": {
               "version": "5.1.1",
@@ -132,7 +174,17 @@
               "version": "7.28.0"
             },
             "@babel/helper-module-imports": {
-              "version": "7.27.1"
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/traverse": {
+                  "version": "7.28.3"
+                },
+                "@babel/types": {
+                  "version": "7.28.2"
+                }
+              }
             },
             "@babel/helper-validator-identifier": {
               "version": "7.27.1"
@@ -260,1385 +312,6 @@
         }
       }
     },
-    "@babel/plugin-transform-runtime": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.28.0"
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/traverse": {
-              "version": "7.28.3"
-            },
-            "@babel/types": {
-              "version": "7.28.2"
-            }
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-          "overridden": false
-        },
-        "babel-plugin-polyfill-corejs2": {
-          "version": "0.4.14",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/compat-data": {
-              "version": "7.28.0"
-            },
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-define-polyfill-provider": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@babel/helper-compilation-targets": {
-                  "version": "7.27.2"
-                },
-                "@babel/helper-plugin-utils": {
-                  "version": "7.27.1"
-                },
-                "debug": {
-                  "version": "4.4.1"
-                },
-                "lodash.debounce": {
-                  "version": "4.0.8",
-                  "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-                  "overridden": false
-                },
-                "resolve": {
-                  "version": "1.22.10"
-                }
-              }
-            },
-            "semver": {
-              "version": "6.3.1"
-            }
-          }
-        },
-        "babel-plugin-polyfill-corejs3": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-define-polyfill-provider": {
-              "version": "0.6.5"
-            },
-            "core-js-compat": {
-              "version": "3.45.0"
-            }
-          }
-        },
-        "babel-plugin-polyfill-regenerator": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-define-polyfill-provider": {
-              "version": "0.6.5"
-            }
-          }
-        },
-        "semver": {
-          "version": "6.3.1"
-        }
-      }
-    },
-    "@babel/preset-env": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@babel/compat-data": {
-          "version": "7.28.0",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-          "overridden": false
-        },
-        "@babel/core": {
-          "version": "7.28.0"
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.27.2"
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.27.1"
-        },
-        "@babel/helper-validator-option": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-          "overridden": false
-        },
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/traverse": {
-              "version": "7.28.3"
-            }
-          }
-        },
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-skip-transparent-expression-wrappers": {
-              "version": "7.27.1",
-              "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/traverse": {
-                  "version": "7.28.3"
-                },
-                "@babel/types": {
-                  "version": "7.28.2"
-                }
-              }
-            },
-            "@babel/plugin-transform-optional-chaining": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-          "version": "7.28.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/traverse": {
-              "version": "7.28.3"
-            }
-          }
-        },
-        "@babel/plugin-proposal-private-property-in-object": {
-          "version": "7.21.0-placeholder-for-preset-env.2",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            }
-          }
-        },
-        "@babel/plugin-syntax-import-assertions": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-syntax-import-attributes": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-syntax-unicode-sets-regex": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-regexp-features-plugin": {
-              "version": "7.27.1",
-              "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@babel/helper-annotate-as-pure": {
-                  "version": "7.27.3"
-                },
-                "regexpu-core": {
-                  "version": "6.2.0",
-                  "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "regenerate-unicode-properties": {
-                      "version": "10.2.0",
-                      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "regenerate": {
-                          "version": "1.4.2"
-                        }
-                      }
-                    },
-                    "regenerate": {
-                      "version": "1.4.2",
-                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-                      "overridden": false
-                    },
-                    "regjsgen": {
-                      "version": "0.8.0",
-                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
-                      "overridden": false
-                    },
-                    "regjsparser": {
-                      "version": "0.12.0",
-                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "jsesc": {
-                          "version": "3.0.2",
-                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "unicode-match-property-ecmascript": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "unicode-canonical-property-names-ecmascript": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
-                          "overridden": false
-                        },
-                        "unicode-property-aliases-ecmascript": {
-                          "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "unicode-match-property-value-ecmascript": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "6.3.1"
-                }
-              }
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-arrow-functions": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-async-generator-functions": {
-          "version": "7.28.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-remap-async-to-generator": {
-              "version": "7.27.1",
-              "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@babel/helper-annotate-as-pure": {
-                  "version": "7.27.3"
-                },
-                "@babel/helper-wrap-function": {
-                  "version": "7.28.3",
-                  "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/template": {
-                      "version": "7.27.2"
-                    },
-                    "@babel/traverse": {
-                      "version": "7.28.3"
-                    },
-                    "@babel/types": {
-                      "version": "7.28.2"
-                    }
-                  }
-                },
-                "@babel/traverse": {
-                  "version": "7.28.3"
-                }
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.28.3"
-            }
-          }
-        },
-        "@babel/plugin-transform-async-to-generator": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-module-imports": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-remap-async-to-generator": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-block-scoped-functions": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-block-scoping": {
-          "version": "7.28.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-class-properties": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-class-features-plugin": {
-              "version": "7.28.3",
-              "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@babel/helper-annotate-as-pure": {
-                  "version": "7.27.3"
-                },
-                "@babel/helper-member-expression-to-functions": {
-                  "version": "7.27.1",
-                  "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/traverse": {
-                      "version": "7.28.3"
-                    },
-                    "@babel/types": {
-                      "version": "7.28.2"
-                    }
-                  }
-                },
-                "@babel/helper-optimise-call-expression": {
-                  "version": "7.27.1",
-                  "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/types": {
-                      "version": "7.28.2"
-                    }
-                  }
-                },
-                "@babel/helper-replace-supers": {
-                  "version": "7.27.1"
-                },
-                "@babel/helper-skip-transparent-expression-wrappers": {
-                  "version": "7.27.1"
-                },
-                "@babel/traverse": {
-                  "version": "7.28.3"
-                },
-                "semver": {
-                  "version": "6.3.1"
-                }
-              }
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-class-static-block": {
-          "version": "7.28.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-class-features-plugin": {
-              "version": "7.28.3"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-classes": {
-          "version": "7.28.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-annotate-as-pure": {
-              "version": "7.27.3",
-              "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/types": {
-                  "version": "7.28.2"
-                }
-              }
-            },
-            "@babel/helper-compilation-targets": {
-              "version": "7.27.2"
-            },
-            "@babel/helper-globals": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-replace-supers": {
-              "version": "7.27.1",
-              "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@babel/helper-member-expression-to-functions": {
-                  "version": "7.27.1"
-                },
-                "@babel/helper-optimise-call-expression": {
-                  "version": "7.27.1"
-                },
-                "@babel/traverse": {
-                  "version": "7.28.3"
-                }
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.28.3"
-            }
-          }
-        },
-        "@babel/plugin-transform-computed-properties": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/template": {
-              "version": "7.27.2"
-            }
-          }
-        },
-        "@babel/plugin-transform-destructuring": {
-          "version": "7.28.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/traverse": {
-              "version": "7.28.3"
-            }
-          }
-        },
-        "@babel/plugin-transform-dotall-regex": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-regexp-features-plugin": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-duplicate-keys": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-regexp-features-plugin": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-dynamic-import": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-explicit-resource-management": {
-          "version": "7.28.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/plugin-transform-destructuring": {
-              "version": "7.28.0"
-            }
-          }
-        },
-        "@babel/plugin-transform-exponentiation-operator": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-export-namespace-from": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-for-of": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-skip-transparent-expression-wrappers": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-function-name": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-compilation-targets": {
-              "version": "7.27.2"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/traverse": {
-              "version": "7.28.3"
-            }
-          }
-        },
-        "@babel/plugin-transform-json-strings": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-literals": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-logical-assignment-operators": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-member-expression-literals": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-modules-amd": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-module-transforms": {
-              "version": "7.28.3"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-modules-commonjs": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-module-transforms": {
-              "version": "7.28.3"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-modules-systemjs": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-module-transforms": {
-              "version": "7.28.3"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.27.1"
-            },
-            "@babel/traverse": {
-              "version": "7.28.3"
-            }
-          }
-        },
-        "@babel/plugin-transform-modules-umd": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-module-transforms": {
-              "version": "7.28.3"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-named-capturing-groups-regex": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-regexp-features-plugin": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-new-target": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-nullish-coalescing-operator": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-numeric-separator": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-object-rest-spread": {
-          "version": "7.28.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-compilation-targets": {
-              "version": "7.27.2"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/plugin-transform-destructuring": {
-              "version": "7.28.0"
-            },
-            "@babel/plugin-transform-parameters": {
-              "version": "7.27.7"
-            },
-            "@babel/traverse": {
-              "version": "7.28.3"
-            }
-          }
-        },
-        "@babel/plugin-transform-object-super": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-replace-supers": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-optional-catch-binding": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-optional-chaining": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-skip-transparent-expression-wrappers": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-parameters": {
-          "version": "7.27.7",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-private-methods": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-class-features-plugin": {
-              "version": "7.28.3"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-private-property-in-object": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-annotate-as-pure": {
-              "version": "7.27.3"
-            },
-            "@babel/helper-create-class-features-plugin": {
-              "version": "7.28.3"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-property-literals": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-regenerator": {
-          "version": "7.28.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-regexp-modifiers": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-regexp-features-plugin": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-reserved-words": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-shorthand-properties": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-spread": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-skip-transparent-expression-wrappers": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-sticky-regex": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-template-literals": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-typeof-symbol": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-unicode-escapes": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-unicode-property-regex": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-regexp-features-plugin": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-unicode-regex": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-regexp-features-plugin": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-unicode-sets-regex": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-create-regexp-features-plugin": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/preset-modules": {
-          "version": "0.1.6-no-external-plugins",
-          "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/types": {
-              "version": "7.28.2"
-            },
-            "esutils": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "babel-plugin-polyfill-corejs2": {
-          "version": "0.4.14"
-        },
-        "babel-plugin-polyfill-corejs3": {
-          "version": "0.13.0"
-        },
-        "babel-plugin-polyfill-regenerator": {
-          "version": "0.6.5"
-        },
-        "core-js-compat": {
-          "version": "3.45.0",
-          "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "browserslist": {
-              "version": "4.25.2"
-            }
-          }
-        },
-        "semver": {
-          "version": "6.3.1"
-        }
-      }
-    },
-    "@babel/preset-flow": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.27.1.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.28.0"
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.27.1"
-        },
-        "@babel/helper-validator-option": {
-          "version": "7.27.1"
-        },
-        "@babel/plugin-transform-flow-strip-types": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/plugin-syntax-flow": {
-              "version": "7.27.1",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@babel/helper-plugin-utils": {
-                  "version": "7.27.1"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "@babel/preset-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.28.0"
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.27.1"
-        },
-        "@babel/helper-validator-option": {
-          "version": "7.27.1"
-        },
-        "@babel/plugin-syntax-jsx": {
-          "version": "7.27.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            }
-          }
-        },
-        "@babel/plugin-transform-modules-commonjs": {
-          "version": "7.27.1"
-        },
-        "@babel/plugin-transform-typescript": {
-          "version": "7.28.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/helper-annotate-as-pure": {
-              "version": "7.27.3"
-            },
-            "@babel/helper-create-class-features-plugin": {
-              "version": "7.28.3"
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
-            },
-            "@babel/helper-skip-transparent-expression-wrappers": {
-              "version": "7.27.1"
-            },
-            "@babel/plugin-syntax-typescript": {
-              "version": "7.27.1",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@babel/helper-plugin-utils": {
-                  "version": "7.27.1"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "@babel/runtime": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
-      "overridden": false
-    },
     "@nozbe/watermelondb": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@nozbe/watermelondb/-/watermelondb-0.28.0.tgz",
@@ -1702,31 +375,6 @@
         }
       }
     },
-    "@nozbe/with-observables": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@nozbe/with-observables/-/with-observables-1.6.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@types/hoist-non-react-statics": {},
-        "@types/react": {
-          "version": "19.0.10",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: @types/react@19.0.10 /workspace/AmysEcho/app/node_modules/@types/react"
-          ]
-        },
-        "hoist-non-react-statics": {
-          "version": "3.3.2"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
     "@react-native-async-storage/async-storage": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.1.2.tgz",
@@ -1749,1400 +397,6 @@
         }
       }
     },
-    "@react-native-community/cli": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-20.0.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@react-native-community/cli-clean": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-20.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@react-native-community/cli-tools": {
-              "version": "20.0.0"
-            },
-            "chalk": {
-              "version": "4.1.2"
-            },
-            "execa": {
-              "version": "5.1.1"
-            },
-            "fast-glob": {
-              "version": "3.3.3",
-              "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@nodelib/fs.stat": {
-                  "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-                  "overridden": false
-                },
-                "@nodelib/fs.walk": {
-                  "version": "1.2.8",
-                  "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@nodelib/fs.scandir": {
-                      "version": "2.1.5",
-                      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@nodelib/fs.stat": {
-                          "version": "2.0.5"
-                        },
-                        "run-parallel": {
-                          "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "queue-microtask": {
-                              "version": "1.2.3",
-                              "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-                              "overridden": false
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "fastq": {
-                      "version": "1.19.1",
-                      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "reusify": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-                          "overridden": false
-                        }
-                      }
-                    }
-                  }
-                },
-                "glob-parent": {
-                  "version": "5.1.2",
-                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "is-glob": {
-                      "version": "4.0.3",
-                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "is-extglob": {
-                          "version": "2.1.1",
-                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                          "overridden": false
-                        }
-                      }
-                    }
-                  }
-                },
-                "merge2": {
-                  "version": "1.4.1",
-                  "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-                  "overridden": false
-                },
-                "micromatch": {
-                  "version": "4.0.8"
-                }
-              }
-            }
-          }
-        },
-        "@react-native-community/cli-config": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-20.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@react-native-community/cli-tools": {
-              "version": "20.0.0"
-            },
-            "chalk": {
-              "version": "4.1.2"
-            },
-            "cosmiconfig": {
-              "version": "9.0.0",
-              "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "env-paths": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-                  "overridden": false
-                },
-                "import-fresh": {
-                  "version": "3.3.1",
-                  "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "parent-module": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "callsites": {
-                          "version": "3.1.0"
-                        }
-                      }
-                    },
-                    "resolve-from": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "js-yaml": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "argparse": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "parse-json": {
-                  "version": "5.2.0",
-                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/code-frame": {
-                      "version": "7.27.1"
-                    },
-                    "error-ex": {
-                      "version": "1.3.2"
-                    },
-                    "json-parse-even-better-errors": {
-                      "version": "2.3.1"
-                    },
-                    "lines-and-columns": {
-                      "version": "1.2.4"
-                    }
-                  }
-                },
-                "typescript": {
-                  "version": "5.8.3"
-                }
-              }
-            },
-            "deepmerge": {
-              "version": "4.3.1"
-            },
-            "fast-glob": {
-              "version": "3.3.3"
-            },
-            "joi": {
-              "version": "17.13.3",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@hapi/hoek": {
-                  "version": "9.3.0",
-                  "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-                  "overridden": false
-                },
-                "@hapi/topo": {
-                  "version": "5.1.0",
-                  "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@hapi/hoek": {
-                      "version": "9.3.0"
-                    }
-                  }
-                },
-                "@sideway/address": {
-                  "version": "4.1.5",
-                  "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@hapi/hoek": {
-                      "version": "9.3.0"
-                    }
-                  }
-                },
-                "@sideway/formula": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-                  "overridden": false
-                },
-                "@sideway/pinpoint": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-                  "overridden": false
-                }
-              }
-            }
-          }
-        },
-        "@react-native-community/cli-doctor": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-20.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@react-native-community/cli-config": {
-              "version": "20.0.0"
-            },
-            "@react-native-community/cli-platform-android": {
-              "version": "20.0.0",
-              "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-20.0.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@react-native-community/cli-config-android": {
-                  "version": "20.0.0",
-                  "resolved": "https://registry.npmjs.org/@react-native-community/cli-config-android/-/cli-config-android-20.0.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@react-native-community/cli-tools": {
-                      "version": "20.0.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "fast-glob": {
-                      "version": "3.3.3"
-                    },
-                    "fast-xml-parser": {
-                      "version": "4.5.3"
-                    }
-                  }
-                },
-                "@react-native-community/cli-tools": {
-                  "version": "20.0.0"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "execa": {
-                  "version": "5.1.1"
-                },
-                "logkitty": {
-                  "version": "0.7.1",
-                  "resolved": "https://registry.npmjs.org/logkitty/-/logkitty-0.7.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "ansi-fragments": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-fragments/-/ansi-fragments-0.2.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "colorette": {
-                          "version": "1.4.0",
-                          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-                          "overridden": false
-                        },
-                        "slice-ansi": {
-                          "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "3.2.1",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                              "overridden": false,
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.9.3",
-                                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                                  "overridden": false,
-                                  "dependencies": {
-                                    "color-name": {
-                                      "version": "1.1.3",
-                                      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                                      "overridden": false
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "astral-regex": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-                              "overridden": false
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                              "overridden": false
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "5.2.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "4.1.1",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-                              "overridden": false
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "dayjs": {
-                      "version": "1.11.13",
-                      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-                      "overridden": false
-                    },
-                    "yargs": {
-                      "version": "15.4.1",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "cliui": {
-                          "version": "6.0.0",
-                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "string-width": {
-                              "version": "4.2.3"
-                            },
-                            "strip-ansi": {
-                              "version": "6.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-                              "overridden": false,
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "5.0.1"
-                                }
-                              }
-                            },
-                            "wrap-ansi": {
-                              "version": "6.2.0",
-                              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-                              "overridden": false,
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "4.3.0"
-                                },
-                                "string-width": {
-                                  "version": "4.2.3"
-                                },
-                                "strip-ansi": {
-                                  "version": "6.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                          "overridden": false
-                        },
-                        "find-up": {
-                          "version": "4.1.0",
-                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "locate-path": {
-                              "version": "5.0.0",
-                              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-                              "overridden": false,
-                              "dependencies": {
-                                "p-locate": {
-                                  "version": "4.1.0",
-                                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-                                  "overridden": false,
-                                  "dependencies": {
-                                    "p-limit": {
-                                      "version": "2.3.0",
-                                      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-                                      "overridden": false,
-                                      "dependencies": {
-                                        "p-try": {
-                                          "version": "2.2.0"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "path-exists": {
-                              "version": "4.0.0"
-                            }
-                          }
-                        },
-                        "get-caller-file": {
-                          "version": "2.0.5"
-                        },
-                        "require-directory": {
-                          "version": "2.1.1"
-                        },
-                        "require-main-filename": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-                          "overridden": false
-                        },
-                        "set-blocking": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                          "overridden": false
-                        },
-                        "string-width": {
-                          "version": "4.2.3",
-                          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "emoji-regex": {
-                              "version": "8.0.0",
-                              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                              "overridden": false
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "3.0.0",
-                              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                              "overridden": false
-                            },
-                            "strip-ansi": {
-                              "version": "6.0.1"
-                            }
-                          }
-                        },
-                        "which-module": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-                          "overridden": false
-                        },
-                        "y18n": {
-                          "version": "4.0.3",
-                          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-                          "overridden": false
-                        },
-                        "yargs-parser": {
-                          "version": "18.1.3",
-                          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "camelcase": {
-                              "version": "5.3.1"
-                            },
-                            "decamelize": {
-                              "version": "1.2.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "@react-native-community/cli-platform-apple": {
-              "version": "20.0.0",
-              "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-20.0.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@react-native-community/cli-config-apple": {
-                  "version": "20.0.0",
-                  "resolved": "https://registry.npmjs.org/@react-native-community/cli-config-apple/-/cli-config-apple-20.0.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@react-native-community/cli-tools": {
-                      "version": "20.0.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "execa": {
-                      "version": "5.1.1"
-                    },
-                    "fast-glob": {
-                      "version": "3.3.3"
-                    }
-                  }
-                },
-                "@react-native-community/cli-tools": {
-                  "version": "20.0.0"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "execa": {
-                  "version": "5.1.1"
-                },
-                "fast-xml-parser": {
-                  "version": "4.5.3",
-                  "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "strnum": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-                      "overridden": false
-                    }
-                  }
-                }
-              }
-            },
-            "@react-native-community/cli-platform-ios": {
-              "version": "20.0.0",
-              "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-20.0.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@react-native-community/cli-platform-apple": {
-                  "version": "20.0.0"
-                }
-              }
-            },
-            "@react-native-community/cli-tools": {
-              "version": "20.0.0"
-            },
-            "chalk": {
-              "version": "4.1.2"
-            },
-            "command-exists": {
-              "version": "1.2.9",
-              "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-              "overridden": false
-            },
-            "deepmerge": {
-              "version": "4.3.1"
-            },
-            "envinfo": {
-              "version": "7.14.0",
-              "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
-              "overridden": false
-            },
-            "execa": {
-              "version": "5.1.1"
-            },
-            "node-stream-zip": {
-              "version": "1.15.0",
-              "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
-              "overridden": false
-            },
-            "ora": {
-              "version": "5.4.1",
-              "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "bl": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "buffer": {
-                      "version": "5.7.1"
-                    },
-                    "inherits": {
-                      "version": "2.0.4"
-                    },
-                    "readable-stream": {
-                      "version": "3.6.2",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.4"
-                        },
-                        "string_decoder": {
-                          "version": "1.3.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "safe-buffer": {
-                              "version": "5.2.1"
-                            }
-                          }
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "overridden": false
-                        }
-                      }
-                    }
-                  }
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "cli-cursor": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "restore-cursor": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "onetime": {
-                          "version": "5.1.2"
-                        },
-                        "signal-exit": {
-                          "version": "3.0.7"
-                        }
-                      }
-                    }
-                  }
-                },
-                "cli-spinners": {
-                  "version": "2.9.2",
-                  "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-                  "overridden": false
-                },
-                "is-interactive": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-                  "overridden": false
-                },
-                "is-unicode-supported": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-                  "overridden": false
-                },
-                "log-symbols": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "is-unicode-supported": {
-                      "version": "0.1.0"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "6.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "5.0.1"
-                    }
-                  }
-                },
-                "wcwidth": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "semver": {
-              "version": "7.7.2",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-              "overridden": false
-            },
-            "wcwidth": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "defaults": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                      "overridden": false
-                    }
-                  }
-                }
-              }
-            },
-            "yaml": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "@react-native-community/cli-server-api": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-20.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@react-native-community/cli-tools": {
-              "version": "20.0.0"
-            },
-            "body-parser": {
-              "version": "1.20.3",
-              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "bytes": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-                  "overridden": false
-                },
-                "content-type": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-                  "overridden": false
-                },
-                "debug": {
-                  "version": "2.6.9",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "depd": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-                  "overridden": false
-                },
-                "destroy": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-                  "overridden": false
-                },
-                "http-errors": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "depd": {
-                      "version": "2.0.0"
-                    },
-                    "inherits": {
-                      "version": "2.0.4"
-                    },
-                    "setprototypeof": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-                      "overridden": false
-                    },
-                    "statuses": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-                      "overridden": false
-                    },
-                    "toidentifier": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "iconv-lite": {
-                  "version": "0.4.24",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "safer-buffer": {
-                      "version": "2.1.2",
-                      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "on-finished": {
-                  "version": "2.4.1",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "6.13.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "side-channel": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "es-errors": {
-                          "version": "1.3.0",
-                          "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-                          "overridden": false
-                        },
-                        "object-inspect": {
-                          "version": "1.13.4",
-                          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-                          "overridden": false
-                        },
-                        "side-channel-list": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "es-errors": {
-                              "version": "1.3.0"
-                            },
-                            "object-inspect": {
-                              "version": "1.13.4"
-                            }
-                          }
-                        },
-                        "side-channel-map": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "call-bound": {
-                              "version": "1.0.4",
-                              "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-                              "overridden": false,
-                              "dependencies": {
-                                "call-bind-apply-helpers": {
-                                  "version": "1.0.2"
-                                },
-                                "get-intrinsic": {
-                                  "version": "1.3.0"
-                                }
-                              }
-                            },
-                            "es-errors": {
-                              "version": "1.3.0"
-                            },
-                            "get-intrinsic": {
-                              "version": "1.3.0"
-                            },
-                            "object-inspect": {
-                              "version": "1.13.4"
-                            }
-                          }
-                        },
-                        "side-channel-weakmap": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "call-bound": {
-                              "version": "1.0.4"
-                            },
-                            "es-errors": {
-                              "version": "1.3.0"
-                            },
-                            "get-intrinsic": {
-                              "version": "1.3.0"
-                            },
-                            "object-inspect": {
-                              "version": "1.13.4"
-                            },
-                            "side-channel-map": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "raw-body": {
-                  "version": "2.5.2",
-                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "bytes": {
-                      "version": "3.1.2"
-                    },
-                    "http-errors": {
-                      "version": "2.0.0"
-                    },
-                    "iconv-lite": {
-                      "version": "0.4.24"
-                    },
-                    "unpipe": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "type-is": {
-                  "version": "1.6.18",
-                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "media-typer": {
-                      "version": "0.3.0",
-                      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-                      "overridden": false
-                    },
-                    "mime-types": {
-                      "version": "2.1.35"
-                    }
-                  }
-                },
-                "unpipe": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "compression": {
-              "version": "1.8.1",
-              "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "bytes": {
-                  "version": "3.1.2"
-                },
-                "compressible": {
-                  "version": "2.0.18",
-                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.54.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "debug": {
-                  "version": "2.6.9",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "negotiator": {
-                  "version": "0.6.4",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-                  "overridden": false
-                },
-                "on-headers": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
-                  "overridden": false
-                },
-                "safe-buffer": {
-                  "version": "5.2.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                  "overridden": false
-                },
-                "vary": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "connect": {
-              "version": "3.7.0"
-            },
-            "errorhandler": {
-              "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "accepts": {
-                  "version": "1.3.8"
-                },
-                "escape-html": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "nocache": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/nocache/-/nocache-3.0.4.tgz",
-              "overridden": false
-            },
-            "open": {
-              "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "is-wsl": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "pretty-format": {
-              "version": "29.7.0"
-            },
-            "serve-static": {
-              "version": "1.16.2",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "encodeurl": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-                  "overridden": false
-                },
-                "escape-html": {
-                  "version": "1.0.3"
-                },
-                "parseurl": {
-                  "version": "1.3.3"
-                },
-                "send": {
-                  "version": "0.19.0",
-                  "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "debug": {
-                      "version": "2.6.9",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "depd": {
-                      "version": "2.0.0"
-                    },
-                    "destroy": {
-                      "version": "1.2.0"
-                    },
-                    "encodeurl": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-                      "overridden": false
-                    },
-                    "escape-html": {
-                      "version": "1.0.3"
-                    },
-                    "etag": {
-                      "version": "1.8.1"
-                    },
-                    "fresh": {
-                      "version": "0.5.2"
-                    },
-                    "http-errors": {
-                      "version": "2.0.0"
-                    },
-                    "mime": {
-                      "version": "1.6.0",
-                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-                      "overridden": false
-                    },
-                    "ms": {
-                      "version": "2.1.3"
-                    },
-                    "on-finished": {
-                      "version": "2.4.1"
-                    },
-                    "range-parser": {
-                      "version": "1.2.1"
-                    },
-                    "statuses": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                }
-              }
-            },
-            "ws": {
-              "version": "6.2.3"
-            }
-          }
-        },
-        "@react-native-community/cli-tools": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-20.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@vscode/sudo-prompt": {
-              "version": "9.3.1",
-              "resolved": "https://registry.npmjs.org/@vscode/sudo-prompt/-/sudo-prompt-9.3.1.tgz",
-              "overridden": false
-            },
-            "appdirsjs": {
-              "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.7.tgz",
-              "overridden": false
-            },
-            "chalk": {
-              "version": "4.1.2"
-            },
-            "execa": {
-              "version": "5.1.1"
-            },
-            "find-up": {
-              "version": "5.0.0"
-            },
-            "launch-editor": {
-              "version": "2.11.1",
-              "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "picocolors": {
-                  "version": "1.1.1"
-                },
-                "shell-quote": {
-                  "version": "1.8.3"
-                }
-              }
-            },
-            "mime": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-              "overridden": false
-            },
-            "ora": {
-              "version": "5.4.1"
-            },
-            "prompts": {
-              "version": "2.4.2"
-            },
-            "semver": {
-              "version": "7.7.2",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "@react-native-community/cli-types": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-20.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "joi": {
-              "version": "17.13.3"
-            }
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "overridden": false,
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "color-convert": {
-                  "version": "2.0.1"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "has-flag": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                  "overridden": false
-                }
-              }
-            }
-          }
-        },
-        "commander": {
-          "version": "9.5.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-          "overridden": false
-        },
-        "deepmerge": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-          "overridden": false
-        },
-        "execa": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "cross-spawn": {
-              "version": "7.0.6",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-              "overridden": false,
-              "dependencies": {
-                "path-key": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-                  "overridden": false
-                },
-                "shebang-command": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "shebang-regex": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "which": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "isexe": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                }
-              }
-            },
-            "get-stream": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-              "overridden": false
-            },
-            "human-signals": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-              "overridden": false
-            },
-            "is-stream": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-              "overridden": false
-            },
-            "merge-stream": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-              "overridden": false
-            },
-            "npm-run-path": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "path-key": {
-                  "version": "3.1.1"
-                }
-              }
-            },
-            "onetime": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "mimic-fn": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "signal-exit": {
-              "version": "3.0.7",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-              "overridden": false
-            },
-            "strip-final-newline": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "locate-path": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "p-locate": {
-                  "version": "5.0.0",
-                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "p-limit": {
-                      "version": "3.1.0"
-                    }
-                  }
-                }
-              }
-            },
-            "path-exists": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.2.11"
-            },
-            "jsonfile": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.2.11"
-                }
-              }
-            },
-            "universalify": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-          "overridden": false
-        },
-        "prompts": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-          "overridden": false,
-          "dependencies": {
-            "kleur": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-              "overridden": false
-            },
-            "sisteransi": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "semver": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-          "overridden": false
-        }
-      }
-    },
     "@react-native-community/netinfo": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
@@ -3150,60 +404,6 @@
       "dependencies": {
         "react-native": {
           "version": "0.79.5"
-        }
-      }
-    },
-    "@react-navigation/native-stack": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.11.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@react-navigation/elements": {
-          "version": "1.3.31",
-          "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.31.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@react-navigation/native": {
-              "version": "6.1.18"
-            },
-            "react-native-safe-area-context": {
-              "version": "5.4.0"
-            },
-            "react-native": {
-              "version": "0.79.5"
-            },
-            "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
-            }
-          }
-        },
-        "@react-navigation/native": {
-          "version": "6.1.18"
-        },
-        "react-native-safe-area-context": {
-          "version": "5.4.0"
-        },
-        "react-native-screens": {
-          "version": "4.11.1"
-        },
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        },
-        "warn-once": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
-          "overridden": false
         }
       }
     },
@@ -3264,11 +464,7 @@
               "version": "16.13.1"
             },
             "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
+              "version": "19.0.0"
             },
             "use-latest-callback": {
               "version": "0.2.4",
@@ -3276,11 +472,7 @@
               "overridden": false,
               "dependencies": {
                 "react": {
-                  "version": "19.0.0",
-                  "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-                  "problems": [
-                    "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-                  ]
+                  "version": "19.0.0"
                 }
               }
             }
@@ -3305,11 +497,7 @@
           "version": "0.79.5"
         },
         "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
+          "version": "19.0.0"
         }
       }
     },
@@ -3319,7 +507,23 @@
       "overridden": false,
       "dependencies": {
         "@react-navigation/elements": {
-          "version": "1.3.31"
+          "version": "1.3.31",
+          "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.31.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@react-navigation/native": {
+              "version": "6.1.18"
+            },
+            "react-native-safe-area-context": {
+              "version": "5.4.0"
+            },
+            "react-native": {
+              "version": "0.79.5"
+            },
+            "react": {
+              "version": "19.0.0"
+            }
+          }
         },
         "@react-navigation/native": {
           "version": "6.1.18"
@@ -3372,242 +576,22 @@
           "version": "5.4.0"
         },
         "react-native-screens": {
-          "version": "4.11.1"
+          "required": ">= 3.0.0",
+          "missing": true,
+          "problems": [
+            "missing: react-native-screens@>= 3.0.0, required by @react-navigation/stack@6.4.1"
+          ]
         },
         "react-native": {
           "version": "0.79.5"
         },
         "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
+          "version": "19.0.0"
         },
         "warn-once": {
-          "version": "0.1.1"
-        }
-      }
-    },
-    "@shopify/react-native-skia": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.2.3.tgz",
-      "overridden": false,
-      "dependencies": {
-        "canvaskit-wasm": {
-          "version": "0.40.0",
-          "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.40.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@webgpu/types": {
-              "version": "0.1.21",
-              "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "react-native-reanimated": {
-          "version": "3.17.4"
-        },
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react-reconciler": {
-          "version": "0.31.0",
-          "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
-            },
-            "scheduler": {
-              "version": "0.25.0"
-            }
-          }
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
-    "@testing-library/react-native": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.1.tgz",
-      "overridden": false,
-      "dependencies": {
-        "jest-matcher-utils": {
-          "version": "30.0.5",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.5.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@jest/get-type": {
-              "version": "30.0.1",
-              "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
-              "overridden": false
-            },
-            "chalk": {
-              "version": "4.1.2"
-            },
-            "jest-diff": {
-              "version": "30.0.5",
-              "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.5.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/diff-sequences": {
-                  "version": "30.0.1",
-                  "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-                  "overridden": false
-                },
-                "@jest/get-type": {
-                  "version": "30.0.1"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "pretty-format": {
-                  "version": "30.0.5",
-                  "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "30.0.5"
-                    },
-                    "ansi-styles": {
-                      "version": "5.2.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                      "overridden": false
-                    },
-                    "react-is": {
-                      "version": "18.3.1",
-                      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                }
-              }
-            },
-            "pretty-format": {
-              "version": "30.0.5",
-              "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/schemas": {
-                  "version": "30.0.5"
-                },
-                "ansi-styles": {
-                  "version": "5.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                  "overridden": false
-                },
-                "react-is": {
-                  "version": "18.3.1",
-                  "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-                  "overridden": false
-                }
-              }
-            }
-          }
-        },
-        "jest": {
-          "version": "29.7.0"
-        },
-        "picocolors": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
           "overridden": false
-        },
-        "pretty-format": {
-          "version": "30.0.5",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@jest/schemas": {
-              "version": "30.0.5",
-              "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@sinclair/typebox": {
-                  "version": "0.34.40",
-                  "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.40.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "overridden": false
-            },
-            "react-is": {
-              "version": "18.3.1",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react-test-renderer": {
-          "version": "19.0.0",
-          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "react-is": {
-              "version": "19.1.1",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
-              "overridden": false
-            },
-            "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
-            },
-            "scheduler": {
-              "version": "0.25.0"
-            }
-          }
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        },
-        "redent": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "indent-string": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-              "overridden": false
-            },
-            "strip-indent": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "min-indent": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-                  "overridden": false
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -3617,41 +601,59 @@
       "overridden": false
     },
     "@types/jest": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
       "overridden": false,
       "dependencies": {
         "expect": {
-          "version": "30.0.5",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.5.tgz",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
           "overridden": false,
           "dependencies": {
             "@jest/expect-utils": {
-              "version": "30.0.5",
-              "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.5.tgz",
+              "version": "29.7.0",
+              "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
               "overridden": false,
               "dependencies": {
-                "@jest/get-type": {
-                  "version": "30.0.1"
+                "jest-get-type": {
+                  "version": "29.6.3"
                 }
               }
             },
-            "@jest/get-type": {
-              "version": "30.0.1"
+            "jest-get-type": {
+              "version": "29.6.3",
+              "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+              "overridden": false
             },
             "jest-matcher-utils": {
-              "version": "30.0.5"
+              "version": "29.7.0",
+              "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "chalk": {
+                  "version": "4.1.2"
+                },
+                "jest-diff": {
+                  "version": "29.7.0"
+                },
+                "jest-get-type": {
+                  "version": "29.6.3"
+                },
+                "pretty-format": {
+                  "version": "29.7.0"
+                }
+              }
             },
             "jest-message-util": {
-              "version": "30.0.5",
-              "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.5.tgz",
+              "version": "29.7.0",
+              "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
               "overridden": false,
               "dependencies": {
                 "@babel/code-frame": {
                   "version": "7.27.1"
                 },
                 "@jest/types": {
-                  "version": "30.0.5"
+                  "version": "29.6.3"
                 },
                 "@types/stack-utils": {
                   "version": "2.0.3",
@@ -3668,24 +670,7 @@
                   "version": "4.0.8"
                 },
                 "pretty-format": {
-                  "version": "30.0.5",
-                  "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "30.0.5"
-                    },
-                    "ansi-styles": {
-                      "version": "5.2.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                      "overridden": false
-                    },
-                    "react-is": {
-                      "version": "18.3.1",
-                      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "slash": {
                   "version": "3.0.0"
@@ -3704,34 +689,27 @@
                 }
               }
             },
-            "jest-mock": {
-              "version": "30.0.5",
-              "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/types": {
-                  "version": "30.0.5"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "jest-util": {
-                  "version": "30.0.5"
-                }
-              }
-            },
             "jest-util": {
-              "version": "30.0.5"
+              "version": "29.7.0"
             }
           }
         },
         "pretty-format": {
-          "version": "30.0.5",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
           "overridden": false,
           "dependencies": {
             "@jest/schemas": {
-              "version": "30.0.5"
+              "version": "29.6.3",
+              "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@sinclair/typebox": {
+                  "version": "0.27.8",
+                  "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+                  "overridden": false
+                }
+              }
             },
             "ansi-styles": {
               "version": "5.2.0",
@@ -3751,10 +729,6 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "overridden": false,
-      "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-      "problems": [
-        "invalid: @types/react@19.0.10 /workspace/AmysEcho/app/node_modules/@types/react"
-      ],
       "dependencies": {
         "csstype": {
           "version": "3.1.3",
@@ -3764,29 +738,29 @@
       }
     },
     "babel-jest": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.5.tgz",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "overridden": false,
       "dependencies": {
         "@babel/core": {
           "version": "7.28.0"
         },
         "@jest/transform": {
-          "version": "30.0.5",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.0.5.tgz",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
           "overridden": false,
           "dependencies": {
             "@babel/core": {
               "version": "7.28.0"
             },
             "@jest/types": {
-              "version": "30.0.5"
+              "version": "29.6.3"
             },
             "@jridgewell/trace-mapping": {
               "version": "0.3.30"
             },
             "babel-plugin-istanbul": {
-              "version": "7.0.0"
+              "version": "6.1.1"
             },
             "chalk": {
               "version": "4.1.2"
@@ -3801,12 +775,22 @@
               "version": "4.2.11"
             },
             "jest-haste-map": {
-              "version": "30.0.5",
-              "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.0.5.tgz",
+              "version": "29.7.0",
+              "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
               "overridden": false,
               "dependencies": {
                 "@jest/types": {
-                  "version": "30.0.5"
+                  "version": "29.6.3"
+                },
+                "@types/graceful-fs": {
+                  "version": "4.1.9",
+                  "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@types/node": {
+                      "version": "24.3.0"
+                    }
+                  }
                 },
                 "@types/node": {
                   "version": "24.3.0"
@@ -3829,7 +813,23 @@
                   }
                 },
                 "fb-watchman": {
-                  "version": "2.0.2"
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "bser": {
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "node-int64": {
+                          "version": "0.4.0",
+                          "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+                          "overridden": false
+                        }
+                      }
+                    }
+                  }
                 },
                 "fsevents": {
                   "version": "2.3.3",
@@ -3840,29 +840,26 @@
                   "version": "4.2.11"
                 },
                 "jest-regex-util": {
-                  "version": "30.0.1"
+                  "version": "29.6.3"
                 },
                 "jest-util": {
-                  "version": "30.0.5"
+                  "version": "29.7.0"
                 },
                 "jest-worker": {
-                  "version": "30.0.5",
-                  "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.0.5.tgz",
+                  "version": "29.7.0",
+                  "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
                   "overridden": false,
                   "dependencies": {
                     "@types/node": {
                       "version": "24.3.0"
                     },
-                    "@ungap/structured-clone": {
-                      "version": "1.3.0",
-                      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-                      "overridden": false
-                    },
                     "jest-util": {
-                      "version": "30.0.5"
+                      "version": "29.7.0"
                     },
                     "merge-stream": {
-                      "version": "2.0.0"
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+                      "overridden": false
                     },
                     "supports-color": {
                       "version": "8.1.1",
@@ -3880,17 +877,33 @@
                   "version": "4.0.8"
                 },
                 "walker": {
-                  "version": "1.0.8"
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "makeerror": {
+                      "version": "1.0.12",
+                      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "tmpl": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+                          "overridden": false
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
             "jest-regex-util": {
-              "version": "30.0.1",
-              "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+              "version": "29.6.3",
+              "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
               "overridden": false
             },
             "jest-util": {
-              "version": "30.0.5"
+              "version": "29.7.0"
             },
             "micromatch": {
               "version": "4.0.8",
@@ -3939,8 +952,8 @@
               "version": "3.0.0"
             },
             "write-file-atomic": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
               "overridden": false,
               "dependencies": {
                 "imurmurhash": {
@@ -3949,8 +962,8 @@
                   "overridden": false
                 },
                 "signal-exit": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
                   "overridden": false
                 }
               }
@@ -4004,12 +1017,14 @@
           }
         },
         "babel-plugin-istanbul": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.0.tgz",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
           "overridden": false,
           "dependencies": {
             "@babel/helper-plugin-utils": {
-              "version": "7.27.1"
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+              "overridden": false
             },
             "@istanbuljs/load-nyc-config": {
               "version": "1.1.0",
@@ -4063,7 +1078,28 @@
                   "overridden": false
                 },
                 "js-yaml": {
-                  "version": "3.14.1"
+                  "version": "3.14.1",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.10",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "sprintf-js": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                          "overridden": false
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                      "overridden": false
+                    }
+                  }
                 },
                 "resolve-from": {
                   "version": "5.0.0"
@@ -4076,8 +1112,8 @@
               "overridden": false
             },
             "istanbul-lib-instrument": {
-              "version": "6.0.3",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
               "overridden": false,
               "dependencies": {
                 "@babel/core": {
@@ -4095,9 +1131,7 @@
                   "overridden": false
                 },
                 "semver": {
-                  "version": "7.7.2",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-                  "overridden": false
+                  "version": "6.3.1"
                 }
               }
             },
@@ -4159,16 +1193,16 @@
           }
         },
         "babel-preset-jest": {
-          "version": "30.0.1",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.0.1.tgz",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
           "overridden": false,
           "dependencies": {
             "@babel/core": {
               "version": "7.28.0"
             },
             "babel-plugin-jest-hoist": {
-              "version": "30.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.0.1.tgz",
+              "version": "29.6.3",
+              "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
               "overridden": false,
               "dependencies": {
                 "@babel/template": {
@@ -4179,6 +1213,9 @@
                 },
                 "@types/babel__core": {
                   "version": "7.20.5"
+                },
+                "@types/babel__traverse": {
+                  "version": "7.28.0"
                 }
               }
             },
@@ -4243,7 +1280,17 @@
                   }
                 },
                 "@babel/plugin-syntax-import-attributes": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-syntax-import-meta": {
                   "version": "7.10.4",
@@ -4380,10 +1427,38 @@
           }
         },
         "chalk": {
-          "version": "4.1.2"
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "overridden": false,
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "color-convert": {
+                  "version": "2.0.1"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "has-flag": {
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                  "overridden": false
+                }
+              }
+            }
+          }
         },
         "graceful-fs": {
-          "version": "4.2.11"
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+          "overridden": false
         },
         "slash": {
           "version": "3.0.0",
@@ -4392,347 +1467,146 @@
         }
       }
     },
-    "better-sqlite3": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "bindings": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "file-uri-to-path": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "prebuild-install": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "detect-libc": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-              "overridden": false
-            },
-            "expand-template": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-              "overridden": false
-            },
-            "github-from-package": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-              "overridden": false
-            },
-            "minimist": {
-              "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-              "overridden": false
-            },
-            "mkdirp-classic": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-              "overridden": false
-            },
-            "napi-build-utils": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-              "overridden": false
-            },
-            "node-abi": {
-              "version": "3.75.0",
-              "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "semver": {
-                  "version": "7.7.2",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "pump": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.4.5",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "once": {
-                      "version": "1.4.0"
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0"
-                }
-              }
-            },
-            "rc": {
-              "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-              "overridden": false,
-              "dependencies": {
-                "deep-extend": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-                  "overridden": false
-                },
-                "ini": {
-                  "version": "1.3.8",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-                  "overridden": false
-                },
-                "minimist": {
-                  "version": "1.2.8"
-                },
-                "strip-json-comments": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "simple-get": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "decompress-response": {
-                  "version": "6.0.0",
-                  "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "mimic-response": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0"
-                },
-                "simple-concat": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "tar-fs": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "chownr": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                  "overridden": false
-                },
-                "mkdirp-classic": {
-                  "version": "0.5.3"
-                },
-                "pump": {
-                  "version": "3.0.3"
-                },
-                "tar-stream": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "bl": {
-                      "version": "4.1.0"
-                    },
-                    "end-of-stream": {
-                      "version": "1.4.5"
-                    },
-                    "fs-constants": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-                      "overridden": false
-                    },
-                    "inherits": {
-                      "version": "2.0.4"
-                    },
-                    "readable-stream": {
-                      "version": "3.6.2"
-                    }
-                  }
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "safe-buffer": {
-                  "version": "5.2.1"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "crypto-js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "overridden": false
     },
+    "esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "overridden": false,
+      "dependencies": {
+        "@esbuild/aix-ppc64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/android-arm": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/android-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/android-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/darwin-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/darwin-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/freebsd-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/freebsd-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/linux-arm": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/linux-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/linux-ia32": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/linux-loong64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/linux-mips64el": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/linux-ppc64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/linux-riscv64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/linux-s390x": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/linux-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/netbsd-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/openbsd-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/sunos-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/win32-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/win32-ia32": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+          "overridden": false
+        },
+        "@esbuild/win32-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+          "overridden": false
+        }
+      }
+    },
     "expo-audio": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-0.4.8.tgz",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-0.4.9.tgz",
       "overridden": false,
       "dependencies": {
         "expo": {
-          "version": "53.0.20"
+          "version": "53.0.22"
         },
         "react-native": {
           "version": "0.79.5"
         },
         "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
-    "expo-battery": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/expo-battery/-/expo-battery-9.1.4.tgz",
-      "overridden": false,
-      "dependencies": {
-        "expo": {
-          "version": "53.0.20"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
-    "expo-dev-client": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-5.2.4.tgz",
-      "overridden": false,
-      "dependencies": {
-        "expo-dev-launcher": {
-          "version": "5.1.16",
-          "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-5.1.16.tgz",
-          "overridden": false,
-          "dependencies": {
-            "ajv": {
-              "version": "8.11.0",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "fast-deep-equal": {
-                  "version": "3.1.3"
-                },
-                "json-schema-traverse": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                  "overridden": false
-                },
-                "require-from-string": {
-                  "version": "2.0.2"
-                },
-                "uri-js": {
-                  "version": "4.4.1",
-                  "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "punycode": {
-                      "version": "2.3.1"
-                    }
-                  }
-                }
-              }
-            },
-            "expo-dev-menu": {
-              "version": "6.1.14"
-            },
-            "expo-manifests": {
-              "version": "0.16.6"
-            },
-            "expo": {
-              "version": "53.0.20"
-            },
-            "resolve-from": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "expo-dev-menu-interface": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.10.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "expo": {
-              "version": "53.0.20"
-            }
-          }
-        },
-        "expo-dev-menu": {
-          "version": "6.1.14",
-          "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-6.1.14.tgz",
-          "overridden": false,
-          "dependencies": {
-            "expo-dev-menu-interface": {
-              "version": "1.10.0"
-            },
-            "expo": {
-              "version": "53.0.20"
-            }
-          }
-        },
-        "expo-manifests": {
-          "version": "0.16.6",
-          "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.16.6.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@expo/config": {
-              "version": "11.0.13"
-            },
-            "expo-json-utils": {
-              "version": "0.15.0",
-              "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
-              "overridden": false
-            },
-            "expo": {
-              "version": "53.0.20"
-            }
-          }
-        },
-        "expo-updates-interface": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.1.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "expo": {
-              "version": "53.0.20"
-            }
-          }
-        },
-        "expo": {
-          "version": "53.0.20"
+          "version": "19.0.0"
         }
       }
     },
@@ -4742,7 +1616,7 @@
       "overridden": false,
       "dependencies": {
         "expo": {
-          "version": "53.0.20"
+          "version": "53.0.22"
         },
         "ua-parser-js": {
           "version": "0.7.40",
@@ -4751,18 +1625,13 @@
         }
       }
     },
-    "expo-doctor": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/expo-doctor/-/expo-doctor-1.13.5.tgz",
-      "overridden": false
-    },
     "expo-file-system": {
       "version": "18.1.11",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
       "overridden": false,
       "dependencies": {
         "expo": {
-          "version": "53.0.20"
+          "version": "53.0.22"
         },
         "react-native": {
           "version": "0.79.5"
@@ -4775,7 +1644,7 @@
       "overridden": false,
       "dependencies": {
         "expo": {
-          "version": "53.0.20"
+          "version": "53.0.22"
         }
       }
     },
@@ -4785,27 +1654,23 @@
       "overridden": false,
       "dependencies": {
         "expo": {
-          "version": "53.0.20"
+          "version": "53.0.22"
         },
         "react-native": {
           "version": "0.79.5"
         },
         "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
+          "version": "19.0.0"
         }
       }
     },
     "expo-secure-store": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.2.3.tgz",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.2.4.tgz",
       "overridden": false,
       "dependencies": {
         "expo": {
-          "version": "53.0.20"
+          "version": "53.0.22"
         }
       }
     },
@@ -4815,7 +1680,7 @@
       "overridden": false,
       "dependencies": {
         "expo": {
-          "version": "53.0.20"
+          "version": "53.0.22"
         }
       }
     },
@@ -4825,31 +1690,29 @@
       "overridden": false,
       "dependencies": {
         "expo": {
-          "version": "53.0.20"
+          "version": "53.0.22"
         },
         "react-native": {
           "version": "0.79.5"
         },
         "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
+          "version": "19.0.0"
         }
       }
     },
     "expo": {
-      "version": "53.0.20",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.20.tgz",
+      "version": "53.0.22",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.22.tgz",
       "overridden": false,
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.28.2"
+          "version": "7.28.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+          "overridden": false
         },
         "@expo/cli": {
-          "version": "0.24.20",
-          "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.20.tgz",
+          "version": "0.24.21",
+          "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.21.tgz",
           "overridden": false,
           "dependencies": {
             "@0no-co/graphql.web": {
@@ -5209,13 +2072,51 @@
                 }
               }
             },
+            "@expo/schema-utils": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.0.tgz",
+              "overridden": false
+            },
             "@expo/spawn-async": {
               "version": "1.7.2",
               "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
               "overridden": false,
               "dependencies": {
                 "cross-spawn": {
-                  "version": "7.0.6"
+                  "version": "7.0.6",
+                  "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "path-key": {
+                      "version": "3.1.1",
+                      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                      "overridden": false
+                    },
+                    "shebang-command": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "shebang-regex": {
+                          "version": "3.0.0",
+                          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                          "overridden": false
+                        }
+                      }
+                    },
+                    "which": {
+                      "version": "2.0.2",
+                      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "isexe": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                          "overridden": false
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -5260,8 +2161,8 @@
               }
             },
             "@react-native/dev-middleware": {
-              "version": "0.79.5",
-              "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.5.tgz",
+              "version": "0.79.6",
+              "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.6.tgz",
               "overridden": false,
               "dependencies": {
                 "@isaacs/ttlcache": {
@@ -5270,8 +2171,8 @@
                   "overridden": false
                 },
                 "@react-native/debugger-frontend": {
-                  "version": "0.79.5",
-                  "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.5.tgz",
+                  "version": "0.79.6",
+                  "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.6.tgz",
                   "overridden": false
                 },
                 "chrome-launcher": {
@@ -5431,10 +2332,93 @@
                   }
                 },
                 "serve-static": {
-                  "version": "1.16.2"
+                  "version": "1.16.2",
+                  "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "encodeurl": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+                      "overridden": false
+                    },
+                    "escape-html": {
+                      "version": "1.0.3"
+                    },
+                    "parseurl": {
+                      "version": "1.3.3"
+                    },
+                    "send": {
+                      "version": "0.19.0",
+                      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "debug": {
+                          "version": "2.6.9",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                          "overridden": false,
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                              "overridden": false
+                            }
+                          }
+                        },
+                        "depd": {
+                          "version": "2.0.0"
+                        },
+                        "destroy": {
+                          "version": "1.2.0"
+                        },
+                        "encodeurl": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+                          "overridden": false
+                        },
+                        "escape-html": {
+                          "version": "1.0.3"
+                        },
+                        "etag": {
+                          "version": "1.8.1"
+                        },
+                        "fresh": {
+                          "version": "0.5.2"
+                        },
+                        "http-errors": {
+                          "version": "2.0.0"
+                        },
+                        "mime": {
+                          "version": "1.6.0",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+                          "overridden": false
+                        },
+                        "ms": {
+                          "version": "2.1.3"
+                        },
+                        "on-finished": {
+                          "version": "2.4.1"
+                        },
+                        "range-parser": {
+                          "version": "1.2.1"
+                        },
+                        "statuses": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+                          "overridden": false
+                        }
+                      }
+                    }
+                  }
                 },
                 "ws": {
-                  "version": "6.2.3"
+                  "version": "6.2.3",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "async-limiter": {
+                      "version": "1.0.1"
+                    }
+                  }
                 }
               }
             },
@@ -5467,7 +2451,28 @@
               }
             },
             "accepts": {
-              "version": "1.3.8"
+              "version": "1.3.8",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+              "overridden": false,
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.1.35",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.52.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+                      "overridden": false
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.6.3",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+                  "overridden": false
+                }
+              }
             },
             "arg": {
               "version": "5.0.2",
@@ -5532,10 +2537,139 @@
               "overridden": false
             },
             "compression": {
-              "version": "1.8.1"
+              "version": "1.8.1",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "bytes": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+                  "overridden": false
+                },
+                "compressible": {
+                  "version": "2.0.18",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.54.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+                      "overridden": false
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                      "overridden": false
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.6.4",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+                  "overridden": false
+                },
+                "on-headers": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+                  "overridden": false
+                },
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                  "overridden": false
+                },
+                "vary": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+                  "overridden": false
+                }
+              }
             },
             "connect": {
-              "version": "3.7.0"
+              "version": "3.7.0",
+              "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                      "overridden": false
+                    }
+                  }
+                },
+                "finalhandler": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.6.9",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "overridden": false
+                        }
+                      }
+                    },
+                    "encodeurl": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+                      "overridden": false
+                    },
+                    "escape-html": {
+                      "version": "1.0.3"
+                    },
+                    "on-finished": {
+                      "version": "2.3.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.1.1"
+                        }
+                      }
+                    },
+                    "parseurl": {
+                      "version": "1.3.3"
+                    },
+                    "statuses": {
+                      "version": "1.5.0",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                      "overridden": false
+                    },
+                    "unpipe": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                      "overridden": false
+                    }
+                  }
+                },
+                "parseurl": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+                  "overridden": false
+                },
+                "utils-merge": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+                  "overridden": false
+                }
+              }
             },
             "debug": {
               "version": "4.4.1"
@@ -5883,7 +3017,9 @@
                   }
                 },
                 "cli-spinners": {
-                  "version": "2.9.2"
+                  "version": "2.9.2",
+                  "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+                  "overridden": false
                 },
                 "log-symbols": {
                   "version": "2.2.0",
@@ -5921,7 +3057,23 @@
                   }
                 },
                 "wcwidth": {
-                  "version": "1.0.1"
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "defaults": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "clone": {
+                          "version": "1.0.4",
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                          "overridden": false
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -5944,7 +3096,21 @@
               "overridden": false
             },
             "prompts": {
-              "version": "2.4.2"
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+              "overridden": false,
+              "dependencies": {
+                "kleur": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+                  "overridden": false
+                },
+                "sisteransi": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+                  "overridden": false
+                }
+              }
             },
             "qrcode-terminal": {
               "version": "0.11.0",
@@ -5967,7 +3133,31 @@
                   "overridden": false
                 },
                 "rc": {
-                  "version": "1.2.8"
+                  "version": "1.2.8",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "deep-extend": {
+                      "version": "0.6.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+                      "overridden": false
+                    },
+                    "ini": {
+                      "version": "1.3.8",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+                      "overridden": false
+                    },
+                    "minimist": {
+                      "version": "1.2.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+                      "overridden": false
+                    },
+                    "strip-json-comments": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                      "overridden": false
+                    }
+                  }
                 },
                 "resolve": {
                   "version": "1.7.1",
@@ -5982,7 +3172,9 @@
               }
             },
             "resolve-from": {
-              "version": "5.0.0"
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+              "overridden": false
             },
             "resolve.exports": {
               "version": "2.0.3",
@@ -6048,10 +3240,14 @@
                   }
                 },
                 "depd": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+                  "overridden": false
                 },
                 "destroy": {
-                  "version": "1.2.0"
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+                  "overridden": false
                 },
                 "encodeurl": {
                   "version": "2.0.0",
@@ -6059,7 +3255,9 @@
                   "overridden": false
                 },
                 "escape-html": {
-                  "version": "1.0.3"
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                  "overridden": false
                 },
                 "etag": {
                   "version": "1.8.1",
@@ -6072,7 +3270,32 @@
                   "overridden": false
                 },
                 "http-errors": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "depd": {
+                      "version": "2.0.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.4"
+                    },
+                    "setprototypeof": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+                      "overridden": false
+                    },
+                    "statuses": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+                      "overridden": false
+                    },
+                    "toidentifier": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+                      "overridden": false
+                    }
+                  }
                 },
                 "mime": {
                   "version": "1.6.0",
@@ -6083,7 +3306,16 @@
                   "version": "2.1.3"
                 },
                 "on-finished": {
-                  "version": "2.4.1"
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                      "overridden": false
+                    }
+                  }
                 },
                 "range-parser": {
                   "version": "1.2.1",
@@ -6444,7 +3676,9 @@
               "version": "9.1.5"
             },
             "deepmerge": {
-              "version": "4.3.1"
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+              "overridden": false
             },
             "getenv": {
               "version": "2.0.0"
@@ -6652,7 +3886,9 @@
               "version": "10.4.5"
             },
             "jsc-safe-url": {
-              "version": "0.2.4"
+              "version": "0.2.4",
+              "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
+              "overridden": false
             },
             "lightningcss": {
               "version": "1.27.0",
@@ -6755,17 +3991,13 @@
               "version": "0.79.5"
             },
             "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
+              "version": "19.0.0"
             }
           }
         },
         "babel-preset-expo": {
-          "version": "13.2.3",
-          "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.2.3.tgz",
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.2.4.tgz",
           "overridden": false,
           "dependencies": {
             "@babel/helper-module-imports": {
@@ -6827,28 +4059,243 @@
               }
             },
             "@babel/plugin-transform-export-namespace-from": {
-              "version": "7.27.1"
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
+                }
+              }
             },
             "@babel/plugin-transform-flow-strip-types": {
-              "version": "7.27.1"
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
+                },
+                "@babel/plugin-syntax-flow": {
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
+                }
+              }
             },
             "@babel/plugin-transform-modules-commonjs": {
-              "version": "7.27.1"
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-module-transforms": {
+                  "version": "7.28.3"
+                },
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
+                }
+              }
             },
             "@babel/plugin-transform-object-rest-spread": {
-              "version": "7.28.0"
+              "version": "7.28.0",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-compilation-targets": {
+                  "version": "7.27.2"
+                },
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
+                },
+                "@babel/plugin-transform-destructuring": {
+                  "version": "7.28.0",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    },
+                    "@babel/traverse": {
+                      "version": "7.28.3"
+                    }
+                  }
+                },
+                "@babel/plugin-transform-parameters": {
+                  "version": "7.27.7"
+                },
+                "@babel/traverse": {
+                  "version": "7.28.3"
+                }
+              }
             },
             "@babel/plugin-transform-parameters": {
-              "version": "7.27.7"
+              "version": "7.27.7",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
+                }
+              }
             },
             "@babel/plugin-transform-private-methods": {
-              "version": "7.27.1"
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-create-class-features-plugin": {
+                  "version": "7.28.3"
+                },
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
+                }
+              }
             },
             "@babel/plugin-transform-private-property-in-object": {
-              "version": "7.27.1"
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-annotate-as-pure": {
+                  "version": "7.27.3"
+                },
+                "@babel/helper-create-class-features-plugin": {
+                  "version": "7.28.3"
+                },
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
+                }
+              }
             },
             "@babel/plugin-transform-runtime": {
-              "version": "7.28.0"
+              "version": "7.28.0",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-module-imports": {
+                  "version": "7.27.1"
+                },
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
+                },
+                "babel-plugin-polyfill-corejs2": {
+                  "version": "0.4.14",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/compat-data": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-define-polyfill-provider": {
+                      "version": "0.6.5",
+                      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "@babel/core": {
+                          "version": "7.28.0"
+                        },
+                        "@babel/helper-compilation-targets": {
+                          "version": "7.27.2"
+                        },
+                        "@babel/helper-plugin-utils": {
+                          "version": "7.27.1"
+                        },
+                        "debug": {
+                          "version": "4.4.1"
+                        },
+                        "lodash.debounce": {
+                          "version": "4.0.8",
+                          "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+                          "overridden": false
+                        },
+                        "resolve": {
+                          "version": "1.22.10"
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "6.3.1"
+                    }
+                  }
+                },
+                "babel-plugin-polyfill-corejs3": {
+                  "version": "0.13.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-define-polyfill-provider": {
+                      "version": "0.6.5"
+                    },
+                    "core-js-compat": {
+                      "version": "3.45.0",
+                      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "browserslist": {
+                          "version": "4.25.2"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-polyfill-regenerator": {
+                  "version": "0.6.5",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-define-polyfill-provider": {
+                      "version": "0.6.5"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "6.3.1"
+                }
+              }
             },
             "@babel/preset-react": {
               "version": "7.27.1",
@@ -6937,8 +4384,8 @@
               "version": "7.27.1"
             },
             "@react-native/babel-preset": {
-              "version": "0.79.5",
-              "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.5.tgz",
+              "version": "0.79.6",
+              "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.6.tgz",
               "overridden": false,
               "dependencies": {
                 "@babel/core": {
@@ -6973,13 +4420,84 @@
                   "version": "7.27.1"
                 },
                 "@babel/plugin-transform-async-generator-functions": {
-                  "version": "7.28.0"
+                  "version": "7.28.0",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    },
+                    "@babel/helper-remap-async-to-generator": {
+                      "version": "7.27.1",
+                      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "@babel/core": {
+                          "version": "7.28.0"
+                        },
+                        "@babel/helper-annotate-as-pure": {
+                          "version": "7.27.3"
+                        },
+                        "@babel/helper-wrap-function": {
+                          "version": "7.28.3",
+                          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
+                          "overridden": false,
+                          "dependencies": {
+                            "@babel/template": {
+                              "version": "7.27.2"
+                            },
+                            "@babel/traverse": {
+                              "version": "7.28.3"
+                            },
+                            "@babel/types": {
+                              "version": "7.28.2"
+                            }
+                          }
+                        },
+                        "@babel/traverse": {
+                          "version": "7.28.3"
+                        }
+                      }
+                    },
+                    "@babel/traverse": {
+                      "version": "7.28.3"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-async-to-generator": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-module-imports": {
+                      "version": "7.27.1"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    },
+                    "@babel/helper-remap-async-to-generator": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-block-scoping": {
-                  "version": "7.28.0"
+                  "version": "7.28.0",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-class-properties": {
                   "version": "7.27.1"
@@ -6988,7 +4506,20 @@
                   "version": "7.28.3"
                 },
                 "@babel/plugin-transform-computed-properties": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    },
+                    "@babel/template": {
+                      "version": "7.27.2"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-destructuring": {
                   "version": "7.28.0"
@@ -6997,34 +4528,116 @@
                   "version": "7.27.1"
                 },
                 "@babel/plugin-transform-for-of": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    },
+                    "@babel/helper-skip-transparent-expression-wrappers": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-function-name": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-compilation-targets": {
+                      "version": "7.27.2"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    },
+                    "@babel/traverse": {
+                      "version": "7.28.3"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-literals": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-logical-assignment-operators": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-modules-commonjs": {
                   "version": "7.27.1"
                 },
                 "@babel/plugin-transform-named-capturing-groups-regex": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-create-regexp-features-plugin": {
+                      "version": "7.27.1"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-nullish-coalescing-operator": {
                   "version": "7.27.1"
                 },
                 "@babel/plugin-transform-numeric-separator": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-object-rest-spread": {
                   "version": "7.28.0"
                 },
                 "@babel/plugin-transform-optional-catch-binding": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-optional-chaining": {
                   "version": "7.27.1"
@@ -7071,7 +4684,17 @@
                   "version": "7.27.1"
                 },
                 "@babel/plugin-transform-regenerator": {
-                  "version": "7.28.3"
+                  "version": "7.28.3",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-runtime": {
                   "version": "7.28.0"
@@ -7080,10 +4703,33 @@
                   "version": "7.27.1"
                 },
                 "@babel/plugin-transform-spread": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    },
+                    "@babel/helper-skip-transparent-expression-wrappers": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-sticky-regex": {
-                  "version": "7.27.1"
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/helper-plugin-utils": {
+                      "version": "7.27.1"
+                    }
+                  }
                 },
                 "@babel/plugin-transform-typescript": {
                   "version": "7.28.0"
@@ -7095,15 +4741,79 @@
                   "version": "7.27.2"
                 },
                 "@react-native/babel-plugin-codegen": {
-                  "version": "0.79.5",
-                  "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.5.tgz",
+                  "version": "0.79.6",
+                  "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.6.tgz",
                   "overridden": false,
                   "dependencies": {
                     "@babel/traverse": {
                       "version": "7.28.3"
                     },
                     "@react-native/codegen": {
-                      "version": "0.79.5"
+                      "version": "0.79.6",
+                      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.6.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "@babel/core": {
+                          "version": "7.28.0"
+                        },
+                        "@babel/parser": {
+                          "version": "7.28.3"
+                        },
+                        "glob": {
+                          "version": "7.2.3",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+                          "overridden": false,
+                          "dependencies": {
+                            "fs.realpath": {
+                              "version": "1.0.0"
+                            },
+                            "inflight": {
+                              "version": "1.0.6"
+                            },
+                            "inherits": {
+                              "version": "2.0.4"
+                            },
+                            "minimatch": {
+                              "version": "3.1.2",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                              "overridden": false,
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.12",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+                                  "overridden": false,
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "1.0.2"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.4.0"
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        },
+                        "hermes-parser": {
+                          "version": "0.25.1"
+                        },
+                        "invariant": {
+                          "version": "2.2.4"
+                        },
+                        "nullthrows": {
+                          "version": "1.1.1"
+                        },
+                        "yargs": {
+                          "version": "17.7.2"
+                        }
+                      }
                     }
                   }
                 },
@@ -7160,17 +4870,13 @@
               "version": "17.1.7"
             },
             "expo": {
-              "version": "53.0.20"
+              "version": "53.0.22"
             },
             "react-native": {
               "version": "0.79.5"
             },
             "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
+              "version": "19.0.0"
             }
           }
         },
@@ -7186,7 +4892,7 @@
               "version": "1.0.7"
             },
             "expo": {
-              "version": "53.0.20"
+              "version": "53.0.22"
             },
             "react-native": {
               "version": "0.79.5"
@@ -7202,7 +4908,7 @@
           "overridden": false,
           "dependencies": {
             "expo": {
-              "version": "53.0.20"
+              "version": "53.0.22"
             },
             "fontfaceobserver": {
               "version": "2.3.0",
@@ -7210,11 +4916,7 @@
               "overridden": false
             },
             "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
+              "version": "19.0.0"
             }
           }
         },
@@ -7224,14 +4926,10 @@
           "overridden": false,
           "dependencies": {
             "expo": {
-              "version": "53.0.20"
+              "version": "53.0.22"
             },
             "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
+              "version": "19.0.0"
             }
           }
         },
@@ -7284,26 +4982,18 @@
               "version": "0.79.5"
             },
             "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
+              "version": "19.0.0"
             }
           }
         },
         "react-native-webview": {
-          "version": "13.15.0"
+          "version": "13.13.5"
         },
         "react-native": {
           "version": "0.79.5"
         },
         "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
+          "version": "19.0.0"
         },
         "whatwg-url-without-unicode": {
           "version": "8.0.0-3",
@@ -7339,21 +5029,14 @@
         }
       }
     },
-    "identity-obj-proxy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "harmony-reflect": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
-          "overridden": false
-        }
-      }
+    "fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "overridden": false
     },
     "jest-expo": {
-      "version": "53.0.9",
-      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-53.0.9.tgz",
+      "version": "53.0.10",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-53.0.10.tgz",
       "overridden": false,
       "dependencies": {
         "@expo/config": {
@@ -7385,38 +5068,7 @@
           "overridden": false,
           "dependencies": {
             "@jest/types": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/schemas": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@sinclair/typebox": {
-                      "version": "0.27.8",
-                      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "@types/istanbul-lib-coverage": {
-                  "version": "2.0.6"
-                },
-                "@types/istanbul-reports": {
-                  "version": "3.0.4"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "@types/yargs": {
-                  "version": "17.0.33"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                }
-              }
+              "version": "29.6.3"
             }
           }
         },
@@ -7434,38 +5086,7 @@
                   "version": "29.7.0"
                 },
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@types/node": {
                   "version": "24.3.0"
@@ -7482,31 +5103,7 @@
                       "version": "24.3.0"
                     },
                     "jest-util": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@jest/types": {
-                          "version": "29.6.3"
-                        },
-                        "@types/node": {
-                          "version": "24.3.0"
-                        },
-                        "chalk": {
-                          "version": "4.1.2"
-                        },
-                        "ci-info": {
-                          "version": "3.9.0"
-                        },
-                        "graceful-fs": {
-                          "version": "4.2.11"
-                        },
-                        "picomatch": {
-                          "version": "2.3.1",
-                          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                          "overridden": false
-                        }
-                      }
+                      "version": "29.7.0"
                     }
                   }
                 }
@@ -7518,151 +5115,7 @@
               "overridden": false,
               "dependencies": {
                 "expect": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/expect-utils": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "jest-get-type": {
-                          "version": "29.6.3"
-                        }
-                      }
-                    },
-                    "jest-get-type": {
-                      "version": "29.6.3"
-                    },
-                    "jest-matcher-utils": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "chalk": {
-                          "version": "4.1.2"
-                        },
-                        "jest-diff": {
-                          "version": "29.7.0",
-                          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "chalk": {
-                              "version": "4.1.2"
-                            },
-                            "diff-sequences": {
-                              "version": "29.6.3"
-                            },
-                            "jest-get-type": {
-                              "version": "29.6.3"
-                            },
-                            "pretty-format": {
-                              "version": "29.7.0"
-                            }
-                          }
-                        },
-                        "jest-get-type": {
-                          "version": "29.6.3"
-                        },
-                        "pretty-format": {
-                          "version": "29.7.0"
-                        }
-                      }
-                    },
-                    "jest-message-util": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/code-frame": {
-                          "version": "7.27.1"
-                        },
-                        "@jest/types": {
-                          "version": "29.6.3",
-                          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@jest/schemas": {
-                              "version": "29.6.3",
-                              "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                              "overridden": false,
-                              "dependencies": {
-                                "@sinclair/typebox": {
-                                  "version": "0.27.8",
-                                  "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                                  "overridden": false
-                                }
-                              }
-                            },
-                            "@types/istanbul-lib-coverage": {
-                              "version": "2.0.6"
-                            },
-                            "@types/istanbul-reports": {
-                              "version": "3.0.4"
-                            },
-                            "@types/node": {
-                              "version": "24.3.0"
-                            },
-                            "@types/yargs": {
-                              "version": "17.0.33"
-                            },
-                            "chalk": {
-                              "version": "4.1.2"
-                            }
-                          }
-                        },
-                        "@types/stack-utils": {
-                          "version": "2.0.3"
-                        },
-                        "chalk": {
-                          "version": "4.1.2"
-                        },
-                        "graceful-fs": {
-                          "version": "4.2.11"
-                        },
-                        "micromatch": {
-                          "version": "4.0.8"
-                        },
-                        "pretty-format": {
-                          "version": "29.7.0"
-                        },
-                        "slash": {
-                          "version": "3.0.0"
-                        },
-                        "stack-utils": {
-                          "version": "2.0.6"
-                        }
-                      }
-                    },
-                    "jest-util": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@jest/types": {
-                          "version": "29.6.3"
-                        },
-                        "@types/node": {
-                          "version": "24.3.0"
-                        },
-                        "chalk": {
-                          "version": "4.1.2"
-                        },
-                        "ci-info": {
-                          "version": "3.9.0"
-                        },
-                        "graceful-fs": {
-                          "version": "4.2.11"
-                        },
-                        "picomatch": {
-                          "version": "2.3.1",
-                          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                          "overridden": false
-                        }
-                      }
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-snapshot": {
                   "version": "29.7.0"
@@ -7670,38 +5123,7 @@
               }
             },
             "@jest/types": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/schemas": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@sinclair/typebox": {
-                      "version": "0.27.8",
-                      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "@types/istanbul-lib-coverage": {
-                  "version": "2.0.6"
-                },
-                "@types/istanbul-reports": {
-                  "version": "3.0.4"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "@types/yargs": {
-                  "version": "17.0.33"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                }
-              }
+              "version": "29.6.3"
             },
             "jest-mock": {
               "version": "29.7.0",
@@ -7715,295 +5137,46 @@
                   "version": "24.3.0"
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 }
               }
             }
           }
         },
         "babel-jest": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@jest/transform": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
-                },
-                "@jridgewell/trace-mapping": {
-                  "version": "0.3.30"
-                },
-                "babel-plugin-istanbul": {
-                  "version": "6.1.1"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "convert-source-map": {
-                  "version": "2.0.0"
-                },
-                "fast-json-stable-stringify": {
-                  "version": "2.1.0"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "jest-haste-map": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/graceful-fs": {
-                      "version": "4.1.9"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "anymatch": {
-                      "version": "3.1.3"
-                    },
-                    "fb-watchman": {
-                      "version": "2.0.2"
-                    },
-                    "fsevents": {
-                      "version": "2.3.3"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "jest-regex-util": {
-                      "version": "29.6.3"
-                    },
-                    "jest-util": {
-                      "version": "29.7.0"
-                    },
-                    "jest-worker": {
-                      "version": "29.7.0"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "walker": {
-                      "version": "1.0.8"
-                    }
-                  }
-                },
-                "jest-regex-util": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                  "overridden": false
-                },
-                "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "micromatch": {
-                  "version": "4.0.8"
-                },
-                "pirates": {
-                  "version": "4.0.7"
-                },
-                "slash": {
-                  "version": "3.0.0"
-                },
-                "write-file-atomic": {
-                  "version": "4.0.2",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4"
-                    },
-                    "signal-exit": {
-                      "version": "3.0.7"
-                    }
-                  }
-                }
-              }
-            },
-            "@types/babel__core": {
-              "version": "7.20.5"
-            },
-            "babel-plugin-istanbul": {
-              "version": "6.1.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/helper-plugin-utils": {
-                  "version": "7.27.1"
-                },
-                "@istanbuljs/load-nyc-config": {
-                  "version": "1.1.0"
-                },
-                "@istanbuljs/schema": {
-                  "version": "0.1.3"
-                },
-                "istanbul-lib-instrument": {
-                  "version": "5.2.1",
-                  "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/core": {
-                      "version": "7.28.0"
-                    },
-                    "@babel/parser": {
-                      "version": "7.28.3"
-                    },
-                    "@istanbuljs/schema": {
-                      "version": "0.1.3"
-                    },
-                    "istanbul-lib-coverage": {
-                      "version": "3.2.2"
-                    },
-                    "semver": {
-                      "version": "6.3.1"
-                    }
-                  }
-                },
-                "test-exclude": {
-                  "version": "6.0.0"
-                }
-              }
-            },
-            "babel-preset-jest": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "babel-plugin-jest-hoist": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/template": {
-                      "version": "7.27.2"
-                    },
-                    "@babel/types": {
-                      "version": "7.28.2"
-                    },
-                    "@types/babel__core": {
-                      "version": "7.20.5"
-                    },
-                    "@types/babel__traverse": {
-                      "version": "7.28.0"
-                    }
-                  }
-                },
-                "babel-preset-current-node-syntax": {
-                  "version": "1.2.0"
-                }
-              }
-            },
-            "chalk": {
-              "version": "4.1.2"
-            },
-            "graceful-fs": {
-              "version": "4.2.11"
-            },
-            "slash": {
-              "version": "3.0.0"
-            }
-          }
+          "version": "29.7.0"
         },
         "expo": {
-          "version": "53.0.20"
+          "version": "53.0.22"
         },
         "find-up": {
-          "version": "5.0.0"
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "overridden": false,
+          "dependencies": {
+            "locate-path": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "p-locate": {
+                  "version": "5.0.0",
+                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "p-limit": {
+                      "version": "3.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "path-exists": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+              "overridden": false
+            }
+          }
         },
         "jest-environment-jsdom": {
           "version": "29.7.0",
@@ -8019,38 +5192,7 @@
               "overridden": false,
               "dependencies": {
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@sinonjs/fake-timers": {
                   "version": "10.3.0",
@@ -8075,38 +5217,7 @@
                   "version": "24.3.0"
                 },
                 "jest-message-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/code-frame": {
-                      "version": "7.27.1"
-                    },
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/stack-utils": {
-                      "version": "2.0.3"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "pretty-format": {
-                      "version": "29.7.0"
-                    },
-                    "slash": {
-                      "version": "3.0.0"
-                    },
-                    "stack-utils": {
-                      "version": "2.0.6"
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-mock": {
                   "version": "29.7.0",
@@ -8125,67 +5236,12 @@
                   }
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 }
               }
             },
             "@jest/types": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/schemas": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@sinclair/typebox": {
-                      "version": "0.27.8",
-                      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "@types/istanbul-lib-coverage": {
-                  "version": "2.0.6"
-                },
-                "@types/istanbul-reports": {
-                  "version": "3.0.4"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "@types/yargs": {
-                  "version": "17.0.33"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                }
-              }
+              "version": "29.6.3"
             },
             "@types/jsdom": {
               "version": "20.0.1",
@@ -8215,7 +5271,16 @@
               }
             },
             "@types/node": {
-              "version": "24.3.0"
+              "version": "24.3.0",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "undici-types": {
+                  "version": "7.10.0",
+                  "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+                  "overridden": false
+                }
+              }
             },
             "canvas": {},
             "jest-mock": {
@@ -8235,31 +5300,7 @@
               }
             },
             "jest-util": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "ci-info": {
-                  "version": "3.9.0"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "picomatch": {
-                  "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                  "overridden": false
-                }
-              }
+              "version": "29.7.0"
             },
             "jsdom": {
               "version": "20.0.3",
@@ -8277,7 +5318,14 @@
                   "overridden": false,
                   "dependencies": {
                     "acorn-walk": {
-                      "version": "8.3.4"
+                      "version": "8.3.4",
+                      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "acorn": {
+                          "version": "8.15.0"
+                        }
+                      }
                     },
                     "acorn": {
                       "version": "8.15.0"
@@ -8285,7 +5333,9 @@
                   }
                 },
                 "acorn": {
-                  "version": "8.15.0"
+                  "version": "8.15.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+                  "overridden": false
                 },
                 "canvas": {},
                 "cssom": {
@@ -8345,10 +5395,14 @@
                       "version": "4.0.1"
                     },
                     "estraverse": {
-                      "version": "5.3.0"
+                      "version": "5.3.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+                      "overridden": false
                     },
                     "esutils": {
-                      "version": "2.0.3"
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+                      "overridden": false
                     },
                     "source-map": {
                       "version": "0.6.1"
@@ -8383,7 +5437,9 @@
                       "overridden": false,
                       "dependencies": {
                         "es-errors": {
-                          "version": "1.3.0"
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+                          "overridden": false
                         },
                         "get-intrinsic": {
                           "version": "1.3.0",
@@ -8639,7 +5695,9 @@
                       "overridden": false,
                       "dependencies": {
                         "safer-buffer": {
-                          "version": "2.1.2"
+                          "version": "2.1.2",
+                          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+                          "overridden": false
                         }
                       }
                     }
@@ -8700,201 +5758,42 @@
               "version": "7.28.3"
             },
             "@babel/plugin-syntax-jsx": {
-              "version": "7.27.1"
-            },
-            "@babel/plugin-syntax-typescript": {
-              "version": "7.27.1"
-            },
-            "@babel/types": {
-              "version": "7.28.2"
-            },
-            "@jest/expect-utils": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "jest-get-type": {
-                  "version": "29.6.3"
-                }
-              }
-            },
-            "@jest/transform": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
               "overridden": false,
               "dependencies": {
                 "@babel/core": {
                   "version": "7.28.0"
                 },
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@jridgewell/trace-mapping": {
-                  "version": "0.3.30"
-                },
-                "babel-plugin-istanbul": {
-                  "version": "6.1.1",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/helper-plugin-utils": {
-                      "version": "7.27.1"
-                    },
-                    "@istanbuljs/load-nyc-config": {
-                      "version": "1.1.0"
-                    },
-                    "@istanbuljs/schema": {
-                      "version": "0.1.3"
-                    },
-                    "istanbul-lib-instrument": {
-                      "version": "5.2.1",
-                      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/core": {
-                          "version": "7.28.0"
-                        },
-                        "@babel/parser": {
-                          "version": "7.28.3"
-                        },
-                        "@istanbuljs/schema": {
-                          "version": "0.1.3"
-                        },
-                        "istanbul-lib-coverage": {
-                          "version": "3.2.2"
-                        },
-                        "semver": {
-                          "version": "6.3.1",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "test-exclude": {
-                      "version": "6.0.0"
-                    }
-                  }
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "convert-source-map": {
-                  "version": "2.0.0"
-                },
-                "fast-json-stable-stringify": {
-                  "version": "2.1.0"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "jest-haste-map": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/graceful-fs": {
-                      "version": "4.1.9"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "anymatch": {
-                      "version": "3.1.3"
-                    },
-                    "fb-watchman": {
-                      "version": "2.0.2"
-                    },
-                    "fsevents": {
-                      "version": "2.3.3"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "jest-regex-util": {
-                      "version": "29.6.3"
-                    },
-                    "jest-util": {
-                      "version": "29.7.0"
-                    },
-                    "jest-worker": {
-                      "version": "29.7.0"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "walker": {
-                      "version": "1.0.8"
-                    }
-                  }
-                },
-                "jest-regex-util": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                  "overridden": false
-                },
-                "jest-util": {
-                  "version": "29.7.0"
-                },
-                "micromatch": {
-                  "version": "4.0.8"
-                },
-                "pirates": {
-                  "version": "4.0.7"
-                },
-                "slash": {
-                  "version": "3.0.0"
-                },
-                "write-file-atomic": {
-                  "version": "4.0.2",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4"
-                    },
-                    "signal-exit": {
-                      "version": "3.0.7"
-                    }
-                  }
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
                 }
               }
             },
-            "@jest/types": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+            "@babel/plugin-syntax-typescript": {
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
               "overridden": false,
               "dependencies": {
-                "@jest/schemas": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@sinclair/typebox": {
-                      "version": "0.27.8",
-                      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                      "overridden": false
-                    }
-                  }
+                "@babel/core": {
+                  "version": "7.28.0"
                 },
-                "@types/istanbul-lib-coverage": {
-                  "version": "2.0.6"
-                },
-                "@types/istanbul-reports": {
-                  "version": "3.0.4"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "@types/yargs": {
-                  "version": "17.0.33"
-                },
-                "chalk": {
-                  "version": "4.1.2"
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
                 }
               }
+            },
+            "@babel/types": {
+              "version": "7.28.2"
+            },
+            "@jest/expect-utils": {
+              "version": "29.7.0"
+            },
+            "@jest/transform": {
+              "version": "29.7.0"
+            },
+            "@jest/types": {
+              "version": "29.6.3"
             },
             "babel-preset-current-node-syntax": {
               "version": "1.2.0"
@@ -8903,26 +5802,7 @@
               "version": "4.1.2"
             },
             "expect": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/expect-utils": {
-                  "version": "29.7.0"
-                },
-                "jest-get-type": {
-                  "version": "29.6.3"
-                },
-                "jest-matcher-utils": {
-                  "version": "29.7.0"
-                },
-                "jest-message-util": {
-                  "version": "29.7.0"
-                },
-                "jest-util": {
-                  "version": "29.7.0"
-                }
-              }
+              "version": "29.7.0"
             },
             "graceful-fs": {
               "version": "4.2.11"
@@ -8949,89 +5829,16 @@
               }
             },
             "jest-get-type": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-              "overridden": false
+              "version": "29.6.3"
             },
             "jest-matcher-utils": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "jest-diff": {
-                  "version": "29.7.0"
-                },
-                "jest-get-type": {
-                  "version": "29.6.3"
-                },
-                "pretty-format": {
-                  "version": "29.7.0"
-                }
-              }
+              "version": "29.7.0"
             },
             "jest-message-util": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/code-frame": {
-                  "version": "7.27.1"
-                },
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@types/stack-utils": {
-                  "version": "2.0.3"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "micromatch": {
-                  "version": "4.0.8"
-                },
-                "pretty-format": {
-                  "version": "29.7.0"
-                },
-                "slash": {
-                  "version": "3.0.0"
-                },
-                "stack-utils": {
-                  "version": "2.0.6"
-                }
-              }
+              "version": "29.7.0"
             },
             "jest-util": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "ci-info": {
-                  "version": "3.9.0"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "picomatch": {
-                  "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                  "overridden": false
-                }
-              }
+              "version": "29.7.0"
             },
             "natural-compare": {
               "version": "1.4.0",
@@ -9097,9 +5904,7 @@
               "version": "4.1.2"
             },
             "jest-regex-util": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-              "overridden": false
+              "version": "29.6.3"
             },
             "jest-watcher": {
               "version": "29.7.0",
@@ -9110,38 +5915,7 @@
                   "version": "29.7.0"
                 },
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@types/node": {
                   "version": "24.3.0"
@@ -9158,31 +5932,7 @@
                   "overridden": false
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "string-length": {
                   "version": "4.0.2",
@@ -9272,28 +6022,49 @@
               }
             },
             "neo-async": {
-              "version": "2.6.2"
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+              "overridden": false
             },
             "react-dom": {
-              "version": "19.0.0"
-            },
-            "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
+              "missing": true,
               "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
+                "missing: react-dom@^19.0.0, required by react-server-dom-webpack@19.0.0"
               ]
             },
+            "react": {
+              "version": "19.0.0"
+            },
             "webpack-sources": {
-              "version": "3.3.3"
+              "version": "3.3.3",
+              "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+              "overridden": false
             },
             "webpack": {
-              "version": "5.101.3"
+              "missing": true,
+              "problems": [
+                "missing: webpack@^5.59.0, required by react-server-dom-webpack@19.0.0"
+              ]
             }
           }
         },
         "react-test-renderer": {
-          "version": "19.0.0"
+          "version": "19.0.0",
+          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
+          "overridden": false,
+          "dependencies": {
+            "react-is": {
+              "version": "19.1.1",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+              "overridden": false
+            },
+            "react": {
+              "version": "19.0.0"
+            },
+            "scheduler": {
+              "version": "0.25.0"
+            }
+          }
         },
         "server-only": {
           "version": "0.0.1",
@@ -9306,7 +6077,16 @@
           "overridden": false,
           "dependencies": {
             "error-stack-parser": {
-              "version": "2.1.4"
+              "version": "2.1.4",
+              "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+              "overridden": false,
+              "dependencies": {
+                "stackframe": {
+                  "version": "1.3.4",
+                  "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+                  "overridden": false
+                }
+              }
             },
             "stack-generator": {
               "version": "2.0.10",
@@ -9337,11 +6117,6 @@
         }
       }
     },
-    "jest-transform-stub": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz",
-      "overridden": false
-    },
     "jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
@@ -9358,38 +6133,7 @@
               "overridden": false,
               "dependencies": {
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@types/node": {
                   "version": "24.3.0"
@@ -9398,65 +6142,10 @@
                   "version": "4.1.2"
                 },
                 "jest-message-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/code-frame": {
-                      "version": "7.27.1"
-                    },
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/stack-utils": {
-                      "version": "2.0.3"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "pretty-format": {
-                      "version": "29.7.0"
-                    },
-                    "slash": {
-                      "version": "3.0.0"
-                    },
-                    "stack-utils": {
-                      "version": "2.0.6"
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "slash": {
                   "version": "3.0.0"
@@ -9480,180 +6169,10 @@
                   "version": "29.7.0"
                 },
                 "@jest/transform": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/core": {
-                      "version": "7.28.0"
-                    },
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@jridgewell/trace-mapping": {
-                      "version": "0.3.30"
-                    },
-                    "babel-plugin-istanbul": {
-                      "version": "6.1.1",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/helper-plugin-utils": {
-                          "version": "7.27.1"
-                        },
-                        "@istanbuljs/load-nyc-config": {
-                          "version": "1.1.0"
-                        },
-                        "@istanbuljs/schema": {
-                          "version": "0.1.3"
-                        },
-                        "istanbul-lib-instrument": {
-                          "version": "5.2.1",
-                          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@babel/core": {
-                              "version": "7.28.0"
-                            },
-                            "@babel/parser": {
-                              "version": "7.28.3"
-                            },
-                            "@istanbuljs/schema": {
-                              "version": "0.1.3"
-                            },
-                            "istanbul-lib-coverage": {
-                              "version": "3.2.2"
-                            },
-                            "semver": {
-                              "version": "6.3.1"
-                            }
-                          }
-                        },
-                        "test-exclude": {
-                          "version": "6.0.0"
-                        }
-                      }
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "convert-source-map": {
-                      "version": "2.0.0"
-                    },
-                    "fast-json-stable-stringify": {
-                      "version": "2.1.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "jest-haste-map": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@jest/types": {
-                          "version": "29.6.3"
-                        },
-                        "@types/graceful-fs": {
-                          "version": "4.1.9"
-                        },
-                        "@types/node": {
-                          "version": "24.3.0"
-                        },
-                        "anymatch": {
-                          "version": "3.1.3"
-                        },
-                        "fb-watchman": {
-                          "version": "2.0.2"
-                        },
-                        "fsevents": {
-                          "version": "2.3.3"
-                        },
-                        "graceful-fs": {
-                          "version": "4.2.11"
-                        },
-                        "jest-regex-util": {
-                          "version": "29.6.3"
-                        },
-                        "jest-util": {
-                          "version": "29.7.0"
-                        },
-                        "jest-worker": {
-                          "version": "29.7.0"
-                        },
-                        "micromatch": {
-                          "version": "4.0.8"
-                        },
-                        "walker": {
-                          "version": "1.0.8"
-                        }
-                      }
-                    },
-                    "jest-regex-util": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                      "overridden": false
-                    },
-                    "jest-util": {
-                      "version": "29.7.0"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "pirates": {
-                      "version": "4.0.7"
-                    },
-                    "slash": {
-                      "version": "3.0.0"
-                    },
-                    "write-file-atomic": {
-                      "version": "4.0.2",
-                      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "imurmurhash": {
-                          "version": "0.1.4"
-                        },
-                        "signal-exit": {
-                          "version": "3.0.7"
-                        }
-                      }
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@jridgewell/trace-mapping": {
                   "version": "0.3.30"
@@ -9721,7 +6240,28 @@
                   "version": "3.2.2"
                 },
                 "istanbul-lib-instrument": {
-                  "version": "6.0.3"
+                  "version": "6.0.3",
+                  "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/parser": {
+                      "version": "7.28.3"
+                    },
+                    "@istanbuljs/schema": {
+                      "version": "0.1.3"
+                    },
+                    "istanbul-lib-coverage": {
+                      "version": "3.2.2"
+                    },
+                    "semver": {
+                      "version": "7.7.2",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+                      "overridden": false
+                    }
+                  }
                 },
                 "istanbul-lib-report": {
                   "version": "3.0.1",
@@ -9780,65 +6320,10 @@
                   }
                 },
                 "jest-message-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/code-frame": {
-                      "version": "7.27.1"
-                    },
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/stack-utils": {
-                      "version": "2.0.3"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "pretty-format": {
-                      "version": "29.7.0"
-                    },
-                    "slash": {
-                      "version": "3.0.0"
-                    },
-                    "stack-utils": {
-                      "version": "2.0.6"
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-worker": {
                   "version": "29.7.0"
@@ -9887,38 +6372,7 @@
                   "version": "29.7.0"
                 },
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@types/istanbul-lib-coverage": {
                   "version": "2.0.6"
@@ -9929,138 +6383,10 @@
               }
             },
             "@jest/transform": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@jridgewell/trace-mapping": {
-                  "version": "0.3.30"
-                },
-                "babel-plugin-istanbul": {
-                  "version": "6.1.1",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/helper-plugin-utils": {
-                      "version": "7.27.1"
-                    },
-                    "@istanbuljs/load-nyc-config": {
-                      "version": "1.1.0"
-                    },
-                    "@istanbuljs/schema": {
-                      "version": "0.1.3"
-                    },
-                    "istanbul-lib-instrument": {
-                      "version": "5.2.1",
-                      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/core": {
-                          "version": "7.28.0"
-                        },
-                        "@babel/parser": {
-                          "version": "7.28.3"
-                        },
-                        "@istanbuljs/schema": {
-                          "version": "0.1.3"
-                        },
-                        "istanbul-lib-coverage": {
-                          "version": "3.2.2"
-                        },
-                        "semver": {
-                          "version": "6.3.1"
-                        }
-                      }
-                    },
-                    "test-exclude": {
-                      "version": "6.0.0"
-                    }
-                  }
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "convert-source-map": {
-                  "version": "2.0.0"
-                },
-                "fast-json-stable-stringify": {
-                  "version": "2.1.0"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "jest-haste-map": {
-                  "version": "29.7.0"
-                },
-                "jest-regex-util": {
-                  "version": "29.6.3"
-                },
-                "jest-util": {
-                  "version": "29.7.0"
-                },
-                "micromatch": {
-                  "version": "4.0.8"
-                },
-                "pirates": {
-                  "version": "4.0.7"
-                },
-                "slash": {
-                  "version": "3.0.0"
-                },
-                "write-file-atomic": {
-                  "version": "4.0.2",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4"
-                    },
-                    "signal-exit": {
-                      "version": "3.0.7"
-                    }
-                  }
-                }
-              }
+              "version": "29.7.0"
             },
             "@jest/types": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/schemas": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@sinclair/typebox": {
-                      "version": "0.27.8",
-                      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "@types/istanbul-lib-coverage": {
-                  "version": "2.0.6"
-                },
-                "@types/istanbul-reports": {
-                  "version": "3.0.4"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "@types/yargs": {
-                  "version": "17.0.33"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                }
-              }
+              "version": "29.6.3"
             },
             "@types/node": {
               "version": "24.3.0"
@@ -10088,65 +6414,65 @@
               "overridden": false,
               "dependencies": {
                 "execa": {
-                  "version": "5.1.1"
-                },
-                "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+                  "version": "5.1.1",
+                  "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
                   "overridden": false,
                   "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+                    "cross-spawn": {
+                      "version": "7.0.6"
+                    },
+                    "get-stream": {
+                      "version": "6.0.1",
+                      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+                      "overridden": false
+                    },
+                    "human-signals": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+                      "overridden": false
+                    },
+                    "is-stream": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+                      "overridden": false
+                    },
+                    "merge-stream": {
+                      "version": "2.0.0"
+                    },
+                    "npm-run-path": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
                       "overridden": false,
                       "dependencies": {
-                        "@jest/schemas": {
-                          "version": "29.6.3",
-                          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@sinclair/typebox": {
-                              "version": "0.27.8",
-                              "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                              "overridden": false
-                            }
-                          }
-                        },
-                        "@types/istanbul-lib-coverage": {
-                          "version": "2.0.6"
-                        },
-                        "@types/istanbul-reports": {
-                          "version": "3.0.4"
-                        },
-                        "@types/node": {
-                          "version": "24.3.0"
-                        },
-                        "@types/yargs": {
-                          "version": "17.0.33"
-                        },
-                        "chalk": {
-                          "version": "4.1.2"
+                        "path-key": {
+                          "version": "3.1.1"
                         }
                       }
                     },
-                    "@types/node": {
-                      "version": "24.3.0"
+                    "onetime": {
+                      "version": "5.1.2",
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "mimic-fn": {
+                          "version": "2.1.0",
+                          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                          "overridden": false
+                        }
+                      }
                     },
-                    "chalk": {
-                      "version": "4.1.2"
+                    "signal-exit": {
+                      "version": "3.0.7"
                     },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+                    "strip-final-newline": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
                       "overridden": false
                     }
                   }
+                },
+                "jest-util": {
+                  "version": "29.7.0"
                 },
                 "p-limit": {
                   "version": "3.1.0"
@@ -10173,104 +6499,7 @@
                       "version": "4.2.11"
                     },
                     "jest-haste-map": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@jest/types": {
-                          "version": "29.6.3",
-                          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@jest/schemas": {
-                              "version": "29.6.3",
-                              "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                              "overridden": false,
-                              "dependencies": {
-                                "@sinclair/typebox": {
-                                  "version": "0.27.8",
-                                  "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                                  "overridden": false
-                                }
-                              }
-                            },
-                            "@types/istanbul-lib-coverage": {
-                              "version": "2.0.6"
-                            },
-                            "@types/istanbul-reports": {
-                              "version": "3.0.4"
-                            },
-                            "@types/node": {
-                              "version": "24.3.0"
-                            },
-                            "@types/yargs": {
-                              "version": "17.0.33"
-                            },
-                            "chalk": {
-                              "version": "4.1.2"
-                            }
-                          }
-                        },
-                        "@types/graceful-fs": {
-                          "version": "4.1.9"
-                        },
-                        "@types/node": {
-                          "version": "24.3.0"
-                        },
-                        "anymatch": {
-                          "version": "3.1.3"
-                        },
-                        "fb-watchman": {
-                          "version": "2.0.2"
-                        },
-                        "fsevents": {
-                          "version": "2.3.3"
-                        },
-                        "graceful-fs": {
-                          "version": "4.2.11"
-                        },
-                        "jest-regex-util": {
-                          "version": "29.6.3",
-                          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                          "overridden": false
-                        },
-                        "jest-util": {
-                          "version": "29.7.0",
-                          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@jest/types": {
-                              "version": "29.6.3"
-                            },
-                            "@types/node": {
-                              "version": "24.3.0"
-                            },
-                            "chalk": {
-                              "version": "4.1.2"
-                            },
-                            "ci-info": {
-                              "version": "3.9.0"
-                            },
-                            "graceful-fs": {
-                              "version": "4.2.11"
-                            },
-                            "picomatch": {
-                              "version": "2.3.1",
-                              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                              "overridden": false
-                            }
-                          }
-                        },
-                        "jest-worker": {
-                          "version": "29.7.0"
-                        },
-                        "micromatch": {
-                          "version": "4.0.8"
-                        },
-                        "walker": {
-                          "version": "1.0.8"
-                        }
-                      }
+                      "version": "29.7.0"
                     },
                     "slash": {
                       "version": "3.0.0"
@@ -10278,238 +6507,13 @@
                   }
                 },
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@types/node": {
                   "version": "24.3.0"
                 },
                 "babel-jest": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/core": {
-                      "version": "7.28.0"
-                    },
-                    "@jest/transform": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/core": {
-                          "version": "7.28.0"
-                        },
-                        "@jest/types": {
-                          "version": "29.6.3"
-                        },
-                        "@jridgewell/trace-mapping": {
-                          "version": "0.3.30"
-                        },
-                        "babel-plugin-istanbul": {
-                          "version": "6.1.1"
-                        },
-                        "chalk": {
-                          "version": "4.1.2"
-                        },
-                        "convert-source-map": {
-                          "version": "2.0.0"
-                        },
-                        "fast-json-stable-stringify": {
-                          "version": "2.1.0"
-                        },
-                        "graceful-fs": {
-                          "version": "4.2.11"
-                        },
-                        "jest-haste-map": {
-                          "version": "29.7.0",
-                          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@jest/types": {
-                              "version": "29.6.3"
-                            },
-                            "@types/graceful-fs": {
-                              "version": "4.1.9"
-                            },
-                            "@types/node": {
-                              "version": "24.3.0"
-                            },
-                            "anymatch": {
-                              "version": "3.1.3"
-                            },
-                            "fb-watchman": {
-                              "version": "2.0.2"
-                            },
-                            "fsevents": {
-                              "version": "2.3.3"
-                            },
-                            "graceful-fs": {
-                              "version": "4.2.11"
-                            },
-                            "jest-regex-util": {
-                              "version": "29.6.3"
-                            },
-                            "jest-util": {
-                              "version": "29.7.0"
-                            },
-                            "jest-worker": {
-                              "version": "29.7.0"
-                            },
-                            "micromatch": {
-                              "version": "4.0.8"
-                            },
-                            "walker": {
-                              "version": "1.0.8"
-                            }
-                          }
-                        },
-                        "jest-regex-util": {
-                          "version": "29.6.3"
-                        },
-                        "jest-util": {
-                          "version": "29.7.0"
-                        },
-                        "micromatch": {
-                          "version": "4.0.8"
-                        },
-                        "pirates": {
-                          "version": "4.0.7"
-                        },
-                        "slash": {
-                          "version": "3.0.0"
-                        },
-                        "write-file-atomic": {
-                          "version": "4.0.2",
-                          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "imurmurhash": {
-                              "version": "0.1.4"
-                            },
-                            "signal-exit": {
-                              "version": "3.0.7"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "@types/babel__core": {
-                      "version": "7.20.5"
-                    },
-                    "babel-plugin-istanbul": {
-                      "version": "6.1.1",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/helper-plugin-utils": {
-                          "version": "7.27.1"
-                        },
-                        "@istanbuljs/load-nyc-config": {
-                          "version": "1.1.0"
-                        },
-                        "@istanbuljs/schema": {
-                          "version": "0.1.3"
-                        },
-                        "istanbul-lib-instrument": {
-                          "version": "5.2.1",
-                          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@babel/core": {
-                              "version": "7.28.0"
-                            },
-                            "@babel/parser": {
-                              "version": "7.28.3"
-                            },
-                            "@istanbuljs/schema": {
-                              "version": "0.1.3"
-                            },
-                            "istanbul-lib-coverage": {
-                              "version": "3.2.2"
-                            },
-                            "semver": {
-                              "version": "6.3.1"
-                            }
-                          }
-                        },
-                        "test-exclude": {
-                          "version": "6.0.0"
-                        }
-                      }
-                    },
-                    "babel-preset-jest": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/core": {
-                          "version": "7.28.0"
-                        },
-                        "babel-plugin-jest-hoist": {
-                          "version": "29.6.3",
-                          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@babel/template": {
-                              "version": "7.27.2"
-                            },
-                            "@babel/types": {
-                              "version": "7.28.2"
-                            },
-                            "@types/babel__core": {
-                              "version": "7.20.5"
-                            },
-                            "@types/babel__traverse": {
-                              "version": "7.28.0"
-                            }
-                          }
-                        },
-                        "babel-preset-current-node-syntax": {
-                          "version": "1.2.0"
-                        }
-                      }
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "slash": {
-                      "version": "3.0.0"
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "chalk": {
                   "version": "4.1.2"
@@ -10580,38 +6584,7 @@
                       "version": "29.7.0"
                     },
                     "@jest/types": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@jest/schemas": {
-                          "version": "29.6.3",
-                          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@sinclair/typebox": {
-                              "version": "0.27.8",
-                              "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                              "overridden": false
-                            }
-                          }
-                        },
-                        "@types/istanbul-lib-coverage": {
-                          "version": "2.0.6"
-                        },
-                        "@types/istanbul-reports": {
-                          "version": "3.0.4"
-                        },
-                        "@types/node": {
-                          "version": "24.3.0"
-                        },
-                        "@types/yargs": {
-                          "version": "17.0.33"
-                        },
-                        "chalk": {
-                          "version": "4.1.2"
-                        }
-                      }
+                      "version": "29.6.3"
                     },
                     "@types/node": {
                       "version": "24.3.0"
@@ -10643,38 +6616,7 @@
                       "overridden": false,
                       "dependencies": {
                         "@jest/types": {
-                          "version": "29.6.3",
-                          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@jest/schemas": {
-                              "version": "29.6.3",
-                              "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                              "overridden": false,
-                              "dependencies": {
-                                "@sinclair/typebox": {
-                                  "version": "0.27.8",
-                                  "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                                  "overridden": false
-                                }
-                              }
-                            },
-                            "@types/istanbul-lib-coverage": {
-                              "version": "2.0.6"
-                            },
-                            "@types/istanbul-reports": {
-                              "version": "3.0.4"
-                            },
-                            "@types/node": {
-                              "version": "24.3.0"
-                            },
-                            "@types/yargs": {
-                              "version": "17.0.33"
-                            },
-                            "chalk": {
-                              "version": "4.1.2"
-                            }
-                          }
+                          "version": "29.6.3"
                         },
                         "chalk": {
                           "version": "4.1.2"
@@ -10683,31 +6625,7 @@
                           "version": "29.6.3"
                         },
                         "jest-util": {
-                          "version": "29.7.0",
-                          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@jest/types": {
-                              "version": "29.6.3"
-                            },
-                            "@types/node": {
-                              "version": "24.3.0"
-                            },
-                            "chalk": {
-                              "version": "4.1.2"
-                            },
-                            "ci-info": {
-                              "version": "3.9.0"
-                            },
-                            "graceful-fs": {
-                              "version": "4.2.11"
-                            },
-                            "picomatch": {
-                              "version": "2.3.1",
-                              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                              "overridden": false
-                            }
-                          }
+                          "version": "29.7.0"
                         },
                         "pretty-format": {
                           "version": "29.7.0"
@@ -10715,73 +6633,10 @@
                       }
                     },
                     "jest-matcher-utils": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "chalk": {
-                          "version": "4.1.2"
-                        },
-                        "jest-diff": {
-                          "version": "29.7.0",
-                          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "chalk": {
-                              "version": "4.1.2"
-                            },
-                            "diff-sequences": {
-                              "version": "29.6.3"
-                            },
-                            "jest-get-type": {
-                              "version": "29.6.3"
-                            },
-                            "pretty-format": {
-                              "version": "29.7.0"
-                            }
-                          }
-                        },
-                        "jest-get-type": {
-                          "version": "29.6.3"
-                        },
-                        "pretty-format": {
-                          "version": "29.7.0"
-                        }
-                      }
+                      "version": "29.7.0"
                     },
                     "jest-message-util": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/code-frame": {
-                          "version": "7.27.1"
-                        },
-                        "@jest/types": {
-                          "version": "29.6.3"
-                        },
-                        "@types/stack-utils": {
-                          "version": "2.0.3"
-                        },
-                        "chalk": {
-                          "version": "4.1.2"
-                        },
-                        "graceful-fs": {
-                          "version": "4.2.11"
-                        },
-                        "micromatch": {
-                          "version": "4.0.8"
-                        },
-                        "pretty-format": {
-                          "version": "29.7.0"
-                        },
-                        "slash": {
-                          "version": "3.0.0"
-                        },
-                        "stack-utils": {
-                          "version": "2.0.6"
-                        }
-                      }
+                      "version": "29.7.0"
                     },
                     "jest-runtime": {
                       "version": "29.7.0"
@@ -10790,31 +6645,7 @@
                       "version": "29.7.0"
                     },
                     "jest-util": {
-                      "version": "29.7.0",
-                      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@jest/types": {
-                          "version": "29.6.3"
-                        },
-                        "@types/node": {
-                          "version": "24.3.0"
-                        },
-                        "chalk": {
-                          "version": "4.1.2"
-                        },
-                        "ci-info": {
-                          "version": "3.9.0"
-                        },
-                        "graceful-fs": {
-                          "version": "4.2.11"
-                        },
-                        "picomatch": {
-                          "version": "2.3.1",
-                          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                          "overridden": false
-                        }
-                      }
+                      "version": "29.7.0"
                     },
                     "p-limit": {
                       "version": "3.1.0"
@@ -10842,9 +6673,7 @@
                   "version": "29.6.3"
                 },
                 "jest-regex-util": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                  "overridden": false
+                  "version": "29.6.3"
                 },
                 "jest-resolve": {
                   "version": "29.7.0"
@@ -10853,31 +6682,7 @@
                   "version": "29.7.0"
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-validate": {
                   "version": "29.7.0"
@@ -10886,7 +6691,34 @@
                   "version": "4.0.8"
                 },
                 "parse-json": {
-                  "version": "5.2.0"
+                  "version": "5.2.0",
+                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/code-frame": {
+                      "version": "7.27.1"
+                    },
+                    "error-ex": {
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "is-arrayish": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                          "overridden": false
+                        }
+                      }
+                    },
+                    "json-parse-even-better-errors": {
+                      "version": "2.3.1",
+                      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+                      "overridden": false
+                    },
+                    "lines-and-columns": {
+                      "version": "1.2.4"
+                    }
+                  }
                 },
                 "pretty-format": {
                   "version": "29.7.0"
@@ -10899,99 +6731,17 @@
                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
                   "overridden": false
                 },
-                "ts-node": {
-                  "version": "10.9.2"
-                }
+                "ts-node": {}
               }
             },
             "jest-haste-map": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@types/graceful-fs": {
-                  "version": "4.1.9",
-                  "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@types/node": {
-                      "version": "24.3.0"
-                    }
-                  }
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "anymatch": {
-                  "version": "3.1.3"
-                },
-                "fb-watchman": {
-                  "version": "2.0.2"
-                },
-                "fsevents": {
-                  "version": "2.3.3"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "jest-regex-util": {
-                  "version": "29.6.3"
-                },
-                "jest-util": {
-                  "version": "29.7.0"
-                },
-                "jest-worker": {
-                  "version": "29.7.0"
-                },
-                "micromatch": {
-                  "version": "4.0.8"
-                },
-                "walker": {
-                  "version": "1.0.8"
-                }
-              }
+              "version": "29.7.0"
             },
             "jest-message-util": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/code-frame": {
-                  "version": "7.27.1"
-                },
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@types/stack-utils": {
-                  "version": "2.0.3"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "micromatch": {
-                  "version": "4.0.8"
-                },
-                "pretty-format": {
-                  "version": "29.7.0"
-                },
-                "slash": {
-                  "version": "3.0.0"
-                },
-                "stack-utils": {
-                  "version": "2.0.6"
-                }
-              }
+              "version": "29.7.0"
             },
             "jest-regex-util": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-              "overridden": false
+              "version": "29.6.3"
             },
             "jest-resolve-dependencies": {
               "version": "29.7.0",
@@ -10999,9 +6749,7 @@
               "overridden": false,
               "dependencies": {
                 "jest-regex-util": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                  "overridden": false
+                  "version": "29.6.3"
                 },
                 "jest-snapshot": {
                   "version": "29.7.0"
@@ -11020,80 +6768,7 @@
                   "version": "4.2.11"
                 },
                 "jest-haste-map": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@jest/schemas": {
-                          "version": "29.6.3",
-                          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@sinclair/typebox": {
-                              "version": "0.27.8",
-                              "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                              "overridden": false
-                            }
-                          }
-                        },
-                        "@types/istanbul-lib-coverage": {
-                          "version": "2.0.6"
-                        },
-                        "@types/istanbul-reports": {
-                          "version": "3.0.4"
-                        },
-                        "@types/node": {
-                          "version": "24.3.0"
-                        },
-                        "@types/yargs": {
-                          "version": "17.0.33"
-                        },
-                        "chalk": {
-                          "version": "4.1.2"
-                        }
-                      }
-                    },
-                    "@types/graceful-fs": {
-                      "version": "4.1.9"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "anymatch": {
-                      "version": "3.1.3"
-                    },
-                    "fb-watchman": {
-                      "version": "2.0.2"
-                    },
-                    "fsevents": {
-                      "version": "2.3.3"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "jest-regex-util": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                      "overridden": false
-                    },
-                    "jest-util": {
-                      "version": "29.7.0"
-                    },
-                    "jest-worker": {
-                      "version": "29.7.0"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "walker": {
-                      "version": "1.0.8"
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-pnp-resolver": {
                   "version": "1.2.3",
@@ -11106,31 +6781,7 @@
                   }
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-validate": {
                   "version": "29.7.0"
@@ -11161,140 +6812,10 @@
                   "version": "29.7.0"
                 },
                 "@jest/transform": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/core": {
-                      "version": "7.28.0"
-                    },
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@jridgewell/trace-mapping": {
-                      "version": "0.3.30"
-                    },
-                    "babel-plugin-istanbul": {
-                      "version": "6.1.1",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/helper-plugin-utils": {
-                          "version": "7.27.1"
-                        },
-                        "@istanbuljs/load-nyc-config": {
-                          "version": "1.1.0"
-                        },
-                        "@istanbuljs/schema": {
-                          "version": "0.1.3"
-                        },
-                        "istanbul-lib-instrument": {
-                          "version": "5.2.1",
-                          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@babel/core": {
-                              "version": "7.28.0"
-                            },
-                            "@babel/parser": {
-                              "version": "7.28.3"
-                            },
-                            "@istanbuljs/schema": {
-                              "version": "0.1.3"
-                            },
-                            "istanbul-lib-coverage": {
-                              "version": "3.2.2"
-                            },
-                            "semver": {
-                              "version": "6.3.1"
-                            }
-                          }
-                        },
-                        "test-exclude": {
-                          "version": "6.0.0"
-                        }
-                      }
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "convert-source-map": {
-                      "version": "2.0.0"
-                    },
-                    "fast-json-stable-stringify": {
-                      "version": "2.1.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "jest-haste-map": {
-                      "version": "29.7.0"
-                    },
-                    "jest-regex-util": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                      "overridden": false
-                    },
-                    "jest-util": {
-                      "version": "29.7.0"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "pirates": {
-                      "version": "4.0.7"
-                    },
-                    "slash": {
-                      "version": "3.0.0"
-                    },
-                    "write-file-atomic": {
-                      "version": "4.0.2",
-                      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "imurmurhash": {
-                          "version": "0.1.4"
-                        },
-                        "signal-exit": {
-                          "version": "3.0.7"
-                        }
-                      }
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@types/node": {
                   "version": "24.3.0"
@@ -11324,47 +6845,7 @@
                   "version": "29.7.0"
                 },
                 "jest-haste-map": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/graceful-fs": {
-                      "version": "4.1.9"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "anymatch": {
-                      "version": "3.1.3"
-                    },
-                    "fb-watchman": {
-                      "version": "2.0.2"
-                    },
-                    "fsevents": {
-                      "version": "2.3.3"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "jest-regex-util": {
-                      "version": "29.6.3"
-                    },
-                    "jest-util": {
-                      "version": "29.7.0"
-                    },
-                    "jest-worker": {
-                      "version": "29.7.0"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "walker": {
-                      "version": "1.0.8"
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-leak-detector": {
                   "version": "29.7.0",
@@ -11380,38 +6861,7 @@
                   }
                 },
                 "jest-message-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/code-frame": {
-                      "version": "7.27.1"
-                    },
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/stack-utils": {
-                      "version": "2.0.3"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "pretty-format": {
-                      "version": "29.7.0"
-                    },
-                    "slash": {
-                      "version": "3.0.0"
-                    },
-                    "stack-utils": {
-                      "version": "2.0.6"
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-resolve": {
                   "version": "29.7.0"
@@ -11420,31 +6870,7 @@
                   "version": "29.7.0"
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-watcher": {
                   "version": "29.7.0"
@@ -11506,138 +6932,10 @@
                   "version": "29.7.0"
                 },
                 "@jest/transform": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/core": {
-                      "version": "7.28.0"
-                    },
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@jridgewell/trace-mapping": {
-                      "version": "0.3.30"
-                    },
-                    "babel-plugin-istanbul": {
-                      "version": "6.1.1",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@babel/helper-plugin-utils": {
-                          "version": "7.27.1"
-                        },
-                        "@istanbuljs/load-nyc-config": {
-                          "version": "1.1.0"
-                        },
-                        "@istanbuljs/schema": {
-                          "version": "0.1.3"
-                        },
-                        "istanbul-lib-instrument": {
-                          "version": "5.2.1",
-                          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-                          "overridden": false,
-                          "dependencies": {
-                            "@babel/core": {
-                              "version": "7.28.0"
-                            },
-                            "@babel/parser": {
-                              "version": "7.28.3"
-                            },
-                            "@istanbuljs/schema": {
-                              "version": "0.1.3"
-                            },
-                            "istanbul-lib-coverage": {
-                              "version": "3.2.2"
-                            },
-                            "semver": {
-                              "version": "6.3.1"
-                            }
-                          }
-                        },
-                        "test-exclude": {
-                          "version": "6.0.0"
-                        }
-                      }
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "convert-source-map": {
-                      "version": "2.0.0"
-                    },
-                    "fast-json-stable-stringify": {
-                      "version": "2.1.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "jest-haste-map": {
-                      "version": "29.7.0"
-                    },
-                    "jest-regex-util": {
-                      "version": "29.6.3"
-                    },
-                    "jest-util": {
-                      "version": "29.7.0"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "pirates": {
-                      "version": "4.0.7"
-                    },
-                    "slash": {
-                      "version": "3.0.0"
-                    },
-                    "write-file-atomic": {
-                      "version": "4.0.2",
-                      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "imurmurhash": {
-                          "version": "0.1.4"
-                        },
-                        "signal-exit": {
-                          "version": "3.0.7"
-                        }
-                      }
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@types/node": {
                   "version": "24.3.0"
@@ -11699,81 +6997,10 @@
                   "version": "4.2.11"
                 },
                 "jest-haste-map": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/graceful-fs": {
-                      "version": "4.1.9"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "anymatch": {
-                      "version": "3.1.3"
-                    },
-                    "fb-watchman": {
-                      "version": "2.0.2"
-                    },
-                    "fsevents": {
-                      "version": "2.3.3"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "jest-regex-util": {
-                      "version": "29.6.3"
-                    },
-                    "jest-util": {
-                      "version": "29.7.0"
-                    },
-                    "jest-worker": {
-                      "version": "29.7.0"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "walker": {
-                      "version": "1.0.8"
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-message-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/code-frame": {
-                      "version": "7.27.1"
-                    },
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/stack-utils": {
-                      "version": "2.0.3"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "pretty-format": {
-                      "version": "29.7.0"
-                    },
-                    "slash": {
-                      "version": "3.0.0"
-                    },
-                    "stack-utils": {
-                      "version": "2.0.6"
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "jest-mock": {
                   "version": "29.7.0",
@@ -11792,9 +7019,7 @@
                   }
                 },
                 "jest-regex-util": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                  "overridden": false
+                  "version": "29.6.3"
                 },
                 "jest-resolve": {
                   "version": "29.7.0"
@@ -11803,31 +7028,7 @@
                   "version": "29.7.0"
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "slash": {
                   "version": "3.0.0"
@@ -11843,34 +7044,36 @@
               "version": "29.7.0"
             },
             "jest-util": {
+              "version": "29.7.0"
+            },
+            "jest-validate": {
               "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
               "overridden": false,
               "dependencies": {
                 "@jest/types": {
                   "version": "29.6.3"
                 },
-                "@types/node": {
-                  "version": "24.3.0"
+                "camelcase": {
+                  "version": "6.3.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+                  "overridden": false
                 },
                 "chalk": {
                   "version": "4.1.2"
                 },
-                "ci-info": {
-                  "version": "3.9.0"
+                "jest-get-type": {
+                  "version": "29.6.3"
                 },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "picomatch": {
-                  "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+                "leven": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
                   "overridden": false
+                },
+                "pretty-format": {
+                  "version": "29.7.0"
                 }
               }
-            },
-            "jest-validate": {
-              "version": "29.7.0"
             },
             "jest-watcher": {
               "version": "29.7.0"
@@ -11903,16 +7106,7 @@
           "overridden": false,
           "dependencies": {
             "@jest/schemas": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@sinclair/typebox": {
-                  "version": "0.27.8",
-                  "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                  "overridden": false
-                }
-              }
+              "version": "29.6.3"
             },
             "@types/istanbul-lib-coverage": {
               "version": "2.0.6",
@@ -12026,38 +7220,7 @@
               "version": "29.7.0"
             },
             "@jest/types": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/schemas": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@sinclair/typebox": {
-                      "version": "0.27.8",
-                      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "@types/istanbul-lib-coverage": {
-                  "version": "2.0.6"
-                },
-                "@types/istanbul-reports": {
-                  "version": "3.0.4"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "@types/yargs": {
-                  "version": "17.0.33"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                }
-              }
+              "version": "29.6.3"
             },
             "chalk": {
               "version": "4.1.2"
@@ -12068,38 +7231,7 @@
               "overridden": false,
               "dependencies": {
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "chalk": {
                   "version": "4.1.2"
@@ -12114,31 +7246,7 @@
                   "version": "29.7.0"
                 },
                 "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
+                  "version": "29.7.0"
                 },
                 "prompts": {
                   "version": "2.4.2"
@@ -12155,31 +7263,7 @@
               "version": "29.7.0"
             },
             "jest-util": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "ci-info": {
-                  "version": "3.9.0"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "picomatch": {
-                  "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                  "overridden": false
-                }
-              }
+              "version": "29.7.0"
             },
             "jest-validate": {
               "version": "29.7.0"
@@ -12193,375 +7277,25 @@
         "node-notifier": {}
       }
     },
-    "lucide-react-native": {
-      "version": "0.535.0",
-      "resolved": "https://registry.npmjs.org/lucide-react-native/-/lucide-react-native-0.535.0.tgz",
+    "react-native-gesture-handler": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.24.0.tgz",
       "overridden": false,
       "dependencies": {
-        "react-native-svg": {
-          "version": "15.12.1"
-        },
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
-    "metro-config": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.3.tgz",
-      "overridden": false,
-      "dependencies": {
-        "connect": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+        "@egjs/hammerjs": {
+          "version": "2.0.17",
+          "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
           "overridden": false,
           "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "overridden": false,
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "finalhandler": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "debug": {
-                  "version": "2.6.9",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "encodeurl": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-                  "overridden": false
-                },
-                "escape-html": {
-                  "version": "1.0.3"
-                },
-                "on-finished": {
-                  "version": "2.3.0",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.1.1"
-                    }
-                  }
-                },
-                "parseurl": {
-                  "version": "1.3.3"
-                },
-                "statuses": {
-                  "version": "1.5.0",
-                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-                  "overridden": false
-                },
-                "unpipe": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-              "overridden": false
-            },
-            "utils-merge": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "@types/hammerjs": {
+              "version": "2.0.46",
+              "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
               "overridden": false
             }
           }
         },
-        "cosmiconfig": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "import-fresh": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "caller-path": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "caller-callsite": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "callsites": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-                          "overridden": false
-                        }
-                      }
-                    }
-                  }
-                },
-                "resolve-from": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "is-directory": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-              "overridden": false
-            },
-            "js-yaml": {
-              "version": "3.14.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.10",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "parse-json": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "error-ex": {
-                  "version": "1.3.2",
-                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "is-arrayish": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "json-parse-better-errors": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-                  "overridden": false
-                }
-              }
-            }
-          }
-        },
-        "flow-enums-runtime": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
-          "overridden": false
-        },
-        "jest-validate": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@jest/types": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/schemas": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@sinclair/typebox": {
-                      "version": "0.27.8",
-                      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "@types/istanbul-lib-coverage": {
-                  "version": "2.0.6"
-                },
-                "@types/istanbul-reports": {
-                  "version": "3.0.4"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "@types/yargs": {
-                  "version": "17.0.33"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                }
-              }
-            },
-            "camelcase": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-              "overridden": false
-            },
-            "chalk": {
-              "version": "4.1.2"
-            },
-            "jest-get-type": {
-              "version": "29.6.3"
-            },
-            "leven": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-              "overridden": false
-            },
-            "pretty-format": {
-              "version": "29.7.0"
-            }
-          }
-        },
-        "metro-cache": {
-          "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "exponential-backoff": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
-              "overridden": false
-            },
-            "flow-enums-runtime": {
-              "version": "0.0.6"
-            },
-            "https-proxy-agent": {
-              "version": "7.0.6",
-              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-              "overridden": false,
-              "dependencies": {
-                "agent-base": {
-                  "version": "7.1.4",
-                  "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-                  "overridden": false
-                },
-                "debug": {
-                  "version": "4.4.1"
-                }
-              }
-            },
-            "metro-core": {
-              "version": "0.82.3"
-            }
-          }
-        },
-        "metro-core": {
-          "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "flow-enums-runtime": {
-              "version": "0.0.6"
-            },
-            "lodash.throttle": {
-              "version": "4.1.1"
-            },
-            "metro-resolver": {
-              "version": "0.82.3"
-            }
-          }
-        },
-        "metro-runtime": {
-          "version": "0.82.3"
-        },
-        "metro": {
-          "version": "0.82.3"
-        }
-      }
-    },
-    "metro-runtime": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.3.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.28.2"
-        },
-        "flow-enums-runtime": {
-          "version": "0.0.6"
-        }
-      }
-    },
-    "metro-source-map": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.3.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@babel/traverse--for-generate-function-map": {
-          "version": "7.28.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.27.1"
-            },
-            "@babel/generator": {
-              "version": "7.28.3"
-            },
-            "@babel/helper-globals": {
-              "version": "7.28.0"
-            },
-            "@babel/parser": {
-              "version": "7.28.3"
-            },
-            "@babel/template": {
-              "version": "7.27.2"
-            },
-            "@babel/types": {
-              "version": "7.28.2"
-            },
-            "debug": {
-              "version": "4.4.1"
-            }
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.28.3"
-        },
-        "@babel/types": {
-          "version": "7.28.2"
-        },
-        "flow-enums-runtime": {
-          "version": "0.0.6"
+        "hoist-non-react-statics": {
+          "version": "3.3.2"
         },
         "invariant": {
           "version": "2.2.4",
@@ -12580,425 +7314,1421 @@
             }
           }
         },
-        "metro-symbolicate": {
-          "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.3.tgz",
+        "react-native": {
+          "version": "0.79.5"
+        },
+        "react": {
+          "version": "19.0.0"
+        }
+      }
+    },
+    "react-native-reanimated": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.4.tgz",
+      "overridden": false,
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.28.0"
+        },
+        "@babel/plugin-transform-arrow-functions": {
+          "version": "7.27.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
           "overridden": false,
           "dependencies": {
-            "flow-enums-runtime": {
-              "version": "0.0.6"
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.27.1"
+            }
+          }
+        },
+        "@babel/plugin-transform-class-properties": {
+          "version": "7.27.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-create-class-features-plugin": {
+              "version": "7.28.3",
+              "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-annotate-as-pure": {
+                  "version": "7.27.3"
+                },
+                "@babel/helper-member-expression-to-functions": {
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/traverse": {
+                      "version": "7.28.3"
+                    },
+                    "@babel/types": {
+                      "version": "7.28.2"
+                    }
+                  }
+                },
+                "@babel/helper-optimise-call-expression": {
+                  "version": "7.27.1",
+                  "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/types": {
+                      "version": "7.28.2"
+                    }
+                  }
+                },
+                "@babel/helper-replace-supers": {
+                  "version": "7.27.1"
+                },
+                "@babel/helper-skip-transparent-expression-wrappers": {
+                  "version": "7.27.1"
+                },
+                "@babel/traverse": {
+                  "version": "7.28.3"
+                },
+                "semver": {
+                  "version": "6.3.1"
+                }
+              }
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.27.1"
+            }
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.28.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.3.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-annotate-as-pure": {
+              "version": "7.27.3",
+              "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/types": {
+                  "version": "7.28.2"
+                }
+              }
+            },
+            "@babel/helper-compilation-targets": {
+              "version": "7.27.2"
+            },
+            "@babel/helper-globals": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.27.1"
+            },
+            "@babel/helper-replace-supers": {
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-member-expression-to-functions": {
+                  "version": "7.27.1"
+                },
+                "@babel/helper-optimise-call-expression": {
+                  "version": "7.27.1"
+                },
+                "@babel/traverse": {
+                  "version": "7.28.3"
+                }
+              }
+            },
+            "@babel/traverse": {
+              "version": "7.28.3"
+            }
+          }
+        },
+        "@babel/plugin-transform-nullish-coalescing-operator": {
+          "version": "7.27.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.27.1"
+            }
+          }
+        },
+        "@babel/plugin-transform-optional-chaining": {
+          "version": "7.27.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.27.1"
+            },
+            "@babel/helper-skip-transparent-expression-wrappers": {
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/traverse": {
+                  "version": "7.28.3"
+                },
+                "@babel/types": {
+                  "version": "7.28.2"
+                }
+              }
+            }
+          }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+          "version": "7.27.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.27.1"
+            }
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.27.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.27.1"
+            }
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.27.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-create-regexp-features-plugin": {
+              "version": "7.27.1",
+              "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-annotate-as-pure": {
+                  "version": "7.27.3"
+                },
+                "regexpu-core": {
+                  "version": "6.2.0",
+                  "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "regenerate-unicode-properties": {
+                      "version": "10.2.0",
+                      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "regenerate": {
+                          "version": "1.4.2"
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.4.2",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+                      "overridden": false
+                    },
+                    "regjsgen": {
+                      "version": "0.8.0",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+                      "overridden": false
+                    },
+                    "regjsparser": {
+                      "version": "0.12.0",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "3.0.2",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+                          "overridden": false
+                        }
+                      }
+                    },
+                    "unicode-match-property-ecmascript": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "unicode-canonical-property-names-ecmascript": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+                          "overridden": false
+                        },
+                        "unicode-property-aliases-ecmascript": {
+                          "version": "2.1.0",
+                          "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+                          "overridden": false
+                        }
+                      }
+                    },
+                    "unicode-match-property-value-ecmascript": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+                      "overridden": false
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "6.3.1"
+                }
+              }
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.27.1"
+            }
+          }
+        },
+        "@babel/preset-typescript": {
+          "version": "7.27.1",
+          "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.27.1"
+            },
+            "@babel/helper-validator-option": {
+              "version": "7.27.1"
+            },
+            "@babel/plugin-syntax-jsx": {
+              "version": "7.27.1"
+            },
+            "@babel/plugin-transform-modules-commonjs": {
+              "version": "7.27.1"
+            },
+            "@babel/plugin-transform-typescript": {
+              "version": "7.28.0",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/helper-annotate-as-pure": {
+                  "version": "7.27.3"
+                },
+                "@babel/helper-create-class-features-plugin": {
+                  "version": "7.28.3"
+                },
+                "@babel/helper-plugin-utils": {
+                  "version": "7.27.1"
+                },
+                "@babel/helper-skip-transparent-expression-wrappers": {
+                  "version": "7.27.1"
+                },
+                "@babel/plugin-syntax-typescript": {
+                  "version": "7.27.1"
+                }
+              }
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "2.0.0"
+        },
+        "invariant": {
+          "version": "2.2.4"
+        },
+        "react-native-is-edge-to-edge": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
+          "overridden": false,
+          "dependencies": {
+            "react-native": {
+              "version": "0.79.5"
+            },
+            "react": {
+              "version": "19.0.0"
+            }
+          }
+        },
+        "react-native": {
+          "version": "0.79.5"
+        },
+        "react": {
+          "version": "19.0.0"
+        }
+      }
+    },
+    "react-native-safe-area-context": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
+      "overridden": false,
+      "dependencies": {
+        "react-native": {
+          "version": "0.79.5"
+        },
+        "react": {
+          "version": "19.0.0"
+        }
+      }
+    },
+    "react-native-svg": {
+      "version": "15.11.2",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.11.2.tgz",
+      "overridden": false,
+      "dependencies": {
+        "css-select": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+          "overridden": false,
+          "dependencies": {
+            "boolbase": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+              "overridden": false
+            },
+            "css-what": {
+              "version": "6.2.2",
+              "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+              "overridden": false
+            },
+            "domhandler": {
+              "version": "5.0.3",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "domelementtype": {
+                  "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+                  "overridden": false
+                }
+              }
+            },
+            "domutils": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+              "overridden": false,
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "2.3.0"
+                    },
+                    "domhandler": {
+                      "version": "5.0.3"
+                    },
+                    "entities": {
+                      "version": "4.5.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+                      "overridden": false
+                    }
+                  }
+                },
+                "domelementtype": {
+                  "version": "2.3.0"
+                },
+                "domhandler": {
+                  "version": "5.0.3"
+                }
+              }
+            },
+            "nth-check": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "boolbase": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "css-tree": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+          "overridden": false,
+          "dependencies": {
+            "mdn-data": {
+              "version": "2.0.14",
+              "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+              "overridden": false
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "overridden": false
+            }
+          }
+        },
+        "react-native": {
+          "version": "0.79.5"
+        },
+        "react": {
+          "version": "19.0.0"
+        },
+        "warn-once": {
+          "version": "0.1.1"
+        }
+      }
+    },
+    "react-native-webview": {
+      "version": "13.13.5",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.13.5.tgz",
+      "overridden": false,
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0"
+        },
+        "invariant": {
+          "version": "2.2.4"
+        },
+        "react-native": {
+          "version": "0.79.5"
+        },
+        "react": {
+          "version": "19.0.0"
+        }
+      }
+    },
+    "react-native": {
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.5.tgz",
+      "overridden": false,
+      "dependencies": {
+        "@jest/create-cache-key-function": {
+          "version": "29.7.0"
+        },
+        "@react-native/assets-registry": {
+          "version": "0.79.5",
+          "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.5.tgz",
+          "overridden": false
+        },
+        "@react-native/codegen": {
+          "version": "0.79.5",
+          "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.5.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@babel/core": {
+              "version": "7.28.0"
+            },
+            "glob": {
+              "version": "7.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0"
+                },
+                "inflight": {
+                  "version": "1.0.6"
+                },
+                "inherits": {
+                  "version": "2.0.4"
+                },
+                "minimatch": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.12",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.2"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.4.0"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "hermes-parser": {
+              "version": "0.25.1",
+              "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+              "overridden": false,
+              "dependencies": {
+                "hermes-estree": {
+                  "version": "0.25.1",
+                  "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+                  "overridden": false
+                }
+              }
             },
             "invariant": {
               "version": "2.2.4"
             },
-            "metro-source-map": {
-              "version": "0.82.3"
+            "nullthrows": {
+              "version": "1.1.1"
+            },
+            "yargs": {
+              "version": "17.7.2"
+            }
+          }
+        },
+        "@react-native/community-cli-plugin": {
+          "version": "0.79.5",
+          "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.5.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@react-native-community/cli": {},
+            "@react-native/dev-middleware": {
+              "version": "0.79.5",
+              "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.5.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@isaacs/ttlcache": {
+                  "version": "1.4.1"
+                },
+                "@react-native/debugger-frontend": {
+                  "version": "0.79.5",
+                  "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.5.tgz",
+                  "overridden": false
+                },
+                "chrome-launcher": {
+                  "version": "0.15.2"
+                },
+                "chromium-edge-launcher": {
+                  "version": "0.2.0"
+                },
+                "connect": {
+                  "version": "3.7.0"
+                },
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                      "overridden": false
+                    }
+                  }
+                },
+                "invariant": {
+                  "version": "2.2.4"
+                },
+                "nullthrows": {
+                  "version": "1.1.1"
+                },
+                "open": {
+                  "version": "7.4.2",
+                  "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "is-docker": {
+                      "version": "2.2.1"
+                    },
+                    "is-wsl": {
+                      "version": "2.2.0"
+                    }
+                  }
+                },
+                "serve-static": {
+                  "version": "1.16.2"
+                },
+                "ws": {
+                  "version": "6.2.3"
+                }
+              }
+            },
+            "chalk": {
+              "version": "4.1.2"
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "overridden": false,
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "overridden": false
+                }
+              }
+            },
+            "invariant": {
+              "version": "2.2.4"
+            },
+            "metro-config": {
+              "version": "0.82.3",
+              "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "connect": {
+                  "version": "3.7.0"
+                },
+                "cosmiconfig": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "import-fresh": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "caller-path": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+                          "overridden": false,
+                          "dependencies": {
+                            "caller-callsite": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+                              "overridden": false,
+                              "dependencies": {
+                                "callsites": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+                                  "overridden": false
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "resolve-from": {
+                          "version": "3.0.0",
+                          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+                          "overridden": false
+                        }
+                      }
+                    },
+                    "is-directory": {
+                      "version": "0.3.1",
+                      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+                      "overridden": false
+                    },
+                    "js-yaml": {
+                      "version": "3.14.1"
+                    },
+                    "parse-json": {
+                      "version": "4.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "error-ex": {
+                          "version": "1.3.2"
+                        },
+                        "json-parse-better-errors": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+                          "overridden": false
+                        }
+                      }
+                    }
+                  }
+                },
+                "flow-enums-runtime": {
+                  "version": "0.0.6"
+                },
+                "jest-validate": {
+                  "version": "29.7.0"
+                },
+                "metro-cache": {
+                  "version": "0.82.3",
+                  "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "exponential-backoff": {
+                      "version": "3.1.2",
+                      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+                      "overridden": false
+                    },
+                    "flow-enums-runtime": {
+                      "version": "0.0.6"
+                    },
+                    "https-proxy-agent": {
+                      "version": "7.0.6",
+                      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "7.1.4",
+                          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+                          "overridden": false
+                        },
+                        "debug": {
+                          "version": "4.4.1"
+                        }
+                      }
+                    },
+                    "metro-core": {
+                      "version": "0.82.3"
+                    }
+                  }
+                },
+                "metro-core": {
+                  "version": "0.82.3"
+                },
+                "metro-runtime": {
+                  "version": "0.82.3"
+                },
+                "metro": {
+                  "version": "0.82.3"
+                }
+              }
+            },
+            "metro-core": {
+              "version": "0.82.3",
+              "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "flow-enums-runtime": {
+                  "version": "0.0.6"
+                },
+                "lodash.throttle": {
+                  "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+                  "overridden": false
+                },
+                "metro-resolver": {
+                  "version": "0.82.3",
+                  "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "flow-enums-runtime": {
+                      "version": "0.0.6"
+                    }
+                  }
+                }
+              }
+            },
+            "metro": {
+              "version": "0.82.3",
+              "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/code-frame": {
+                  "version": "7.27.1"
+                },
+                "@babel/core": {
+                  "version": "7.28.0"
+                },
+                "@babel/generator": {
+                  "version": "7.28.3"
+                },
+                "@babel/parser": {
+                  "version": "7.28.3"
+                },
+                "@babel/template": {
+                  "version": "7.27.2"
+                },
+                "@babel/traverse": {
+                  "version": "7.28.3"
+                },
+                "@babel/types": {
+                  "version": "7.28.2"
+                },
+                "accepts": {
+                  "version": "1.3.8"
+                },
+                "chalk": {
+                  "version": "4.1.2"
+                },
+                "ci-info": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                  "overridden": false
+                },
+                "connect": {
+                  "version": "3.7.0"
+                },
+                "debug": {
+                  "version": "4.4.1"
+                },
+                "error-stack-parser": {
+                  "version": "2.1.4"
+                },
+                "flow-enums-runtime": {
+                  "version": "0.0.6"
+                },
+                "graceful-fs": {
+                  "version": "4.2.11"
+                },
+                "hermes-parser": {
+                  "version": "0.28.1",
+                  "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "hermes-estree": {
+                      "version": "0.28.1",
+                      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
+                      "overridden": false
+                    }
+                  }
+                },
+                "image-size": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "queue": {
+                      "version": "6.0.2",
+                      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.4"
+                        }
+                      }
+                    }
+                  }
+                },
+                "invariant": {
+                  "version": "2.2.4"
+                },
+                "jest-worker": {
+                  "version": "29.7.0"
+                },
+                "jsc-safe-url": {
+                  "version": "0.2.4"
+                },
+                "lodash.throttle": {
+                  "version": "4.1.1"
+                },
+                "metro-babel-transformer": {
+                  "version": "0.82.3",
+                  "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "flow-enums-runtime": {
+                      "version": "0.0.6"
+                    },
+                    "hermes-parser": {
+                      "version": "0.28.1",
+                      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "hermes-estree": {
+                          "version": "0.28.1",
+                          "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
+                          "overridden": false
+                        }
+                      }
+                    },
+                    "nullthrows": {
+                      "version": "1.1.1"
+                    }
+                  }
+                },
+                "metro-cache-key": {
+                  "version": "0.82.3",
+                  "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "flow-enums-runtime": {
+                      "version": "0.0.6"
+                    }
+                  }
+                },
+                "metro-cache": {
+                  "version": "0.82.3"
+                },
+                "metro-config": {
+                  "version": "0.82.3"
+                },
+                "metro-core": {
+                  "version": "0.82.3"
+                },
+                "metro-file-map": {
+                  "version": "0.82.3",
+                  "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "debug": {
+                      "version": "4.4.1"
+                    },
+                    "fb-watchman": {
+                      "version": "2.0.2"
+                    },
+                    "flow-enums-runtime": {
+                      "version": "0.0.6"
+                    },
+                    "graceful-fs": {
+                      "version": "4.2.11"
+                    },
+                    "invariant": {
+                      "version": "2.2.4"
+                    },
+                    "jest-worker": {
+                      "version": "29.7.0"
+                    },
+                    "micromatch": {
+                      "version": "4.0.8"
+                    },
+                    "nullthrows": {
+                      "version": "1.1.1"
+                    },
+                    "walker": {
+                      "version": "1.0.8"
+                    }
+                  }
+                },
+                "metro-resolver": {
+                  "version": "0.82.3"
+                },
+                "metro-runtime": {
+                  "version": "0.82.3"
+                },
+                "metro-source-map": {
+                  "version": "0.82.3"
+                },
+                "metro-symbolicate": {
+                  "version": "0.82.3"
+                },
+                "metro-transform-plugins": {
+                  "version": "0.82.3",
+                  "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/generator": {
+                      "version": "7.28.3"
+                    },
+                    "@babel/template": {
+                      "version": "7.27.2"
+                    },
+                    "@babel/traverse": {
+                      "version": "7.28.3"
+                    },
+                    "flow-enums-runtime": {
+                      "version": "0.0.6"
+                    },
+                    "nullthrows": {
+                      "version": "1.1.1"
+                    }
+                  }
+                },
+                "metro-transform-worker": {
+                  "version": "0.82.3",
+                  "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.3.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "@babel/core": {
+                      "version": "7.28.0"
+                    },
+                    "@babel/generator": {
+                      "version": "7.28.3"
+                    },
+                    "@babel/parser": {
+                      "version": "7.28.3"
+                    },
+                    "@babel/types": {
+                      "version": "7.28.2"
+                    },
+                    "flow-enums-runtime": {
+                      "version": "0.0.6"
+                    },
+                    "metro-babel-transformer": {
+                      "version": "0.82.3"
+                    },
+                    "metro-cache-key": {
+                      "version": "0.82.3"
+                    },
+                    "metro-cache": {
+                      "version": "0.82.3"
+                    },
+                    "metro-minify-terser": {
+                      "version": "0.82.3",
+                      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.3.tgz",
+                      "overridden": false,
+                      "dependencies": {
+                        "flow-enums-runtime": {
+                          "version": "0.0.6"
+                        },
+                        "terser": {
+                          "version": "5.43.1",
+                          "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+                          "overridden": false,
+                          "dependencies": {
+                            "@jridgewell/source-map": {
+                              "version": "0.3.11",
+                              "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+                              "overridden": false,
+                              "dependencies": {
+                                "@jridgewell/gen-mapping": {
+                                  "version": "0.3.13"
+                                },
+                                "@jridgewell/trace-mapping": {
+                                  "version": "0.3.30"
+                                }
+                              }
+                            },
+                            "acorn": {
+                              "version": "8.15.0"
+                            },
+                            "commander": {
+                              "version": "2.20.3",
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                              "overridden": false
+                            },
+                            "source-map-support": {
+                              "version": "0.5.21"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "metro-source-map": {
+                      "version": "0.82.3"
+                    },
+                    "metro-transform-plugins": {
+                      "version": "0.82.3"
+                    },
+                    "metro": {
+                      "version": "0.82.3"
+                    },
+                    "nullthrows": {
+                      "version": "1.1.1"
+                    }
+                  }
+                },
+                "mime-types": {
+                  "version": "2.1.35"
+                },
+                "nullthrows": {
+                  "version": "1.1.1"
+                },
+                "serialize-error": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+                  "overridden": false
+                },
+                "source-map": {
+                  "version": "0.5.7",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                  "overridden": false
+                },
+                "throat": {
+                  "version": "5.0.0",
+                  "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+                  "overridden": false
+                },
+                "ws": {
+                  "version": "7.5.10",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "bufferutil": {},
+                    "utf-8-validate": {}
+                  }
+                },
+                "yargs": {
+                  "version": "17.7.2"
+                }
+              }
+            },
+            "semver": {
+              "version": "7.7.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+              "overridden": false
+            }
+          }
+        },
+        "@react-native/gradle-plugin": {
+          "version": "0.79.5",
+          "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.5.tgz",
+          "overridden": false
+        },
+        "@react-native/js-polyfills": {
+          "version": "0.79.5",
+          "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.5.tgz",
+          "overridden": false
+        },
+        "@react-native/normalize-colors": {
+          "version": "0.79.5",
+          "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.5.tgz",
+          "overridden": false
+        },
+        "@react-native/virtualized-lists": {
+          "version": "0.79.5",
+          "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.5.tgz",
+          "overridden": false,
+          "dependencies": {
+            "@types/react": {
+              "version": "19.0.10"
+            },
+            "invariant": {
+              "version": "2.2.4"
             },
             "nullthrows": {
               "version": "1.1.1"
             },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "overridden": false
+            "react-native": {
+              "version": "0.79.5"
             },
-            "vlq": {
-              "version": "1.0.1"
+            "react": {
+              "version": "19.0.0"
             }
           }
         },
-        "nullthrows": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
-          "overridden": false
+        "@types/react": {
+          "version": "19.0.10"
         },
-        "ob1": {
-          "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.3.tgz",
+        "abort-controller": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
           "overridden": false,
           "dependencies": {
-            "flow-enums-runtime": {
-              "version": "0.0.6"
+            "event-target-shim": {
+              "version": "5.0.1"
             }
           }
         },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+        "anser": {
+          "version": "1.4.10",
+          "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
           "overridden": false
         },
-        "vlq": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
           "overridden": false
-        }
-      }
-    },
-    "metro": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.3.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.27.1"
         },
-        "@babel/core": {
-          "version": "7.28.0"
+        "babel-jest": {
+          "version": "29.7.0"
         },
-        "@babel/generator": {
-          "version": "7.28.3"
-        },
-        "@babel/parser": {
-          "version": "7.28.3"
-        },
-        "@babel/template": {
-          "version": "7.27.2"
-        },
-        "@babel/traverse": {
-          "version": "7.28.3"
-        },
-        "@babel/types": {
-          "version": "7.28.2"
-        },
-        "accepts": {
-          "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+        "babel-plugin-syntax-hermes-parser": {
+          "version": "0.25.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
           "overridden": false,
           "dependencies": {
-            "mime-types": {
-              "version": "2.1.35"
-            },
-            "negotiator": {
-              "version": "0.6.3",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-              "overridden": false
+            "hermes-parser": {
+              "version": "0.25.1"
             }
           }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "overridden": false
         },
         "chalk": {
           "version": "4.1.2"
         },
-        "ci-info": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+        "commander": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
           "overridden": false
         },
-        "connect": {
-          "version": "3.7.0"
-        },
-        "debug": {
-          "version": "4.4.1"
-        },
-        "error-stack-parser": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
-          "overridden": false,
-          "dependencies": {
-            "stackframe": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-              "overridden": false
-            }
-          }
+        "event-target-shim": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+          "overridden": false
         },
         "flow-enums-runtime": {
-          "version": "0.0.6"
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
+          "overridden": false
         },
-        "graceful-fs": {
-          "version": "4.2.11"
-        },
-        "hermes-parser": {
-          "version": "0.28.1",
-          "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
           "overridden": false,
           "dependencies": {
-            "hermes-estree": {
-              "version": "0.28.1",
-              "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
               "overridden": false
-            }
-          }
-        },
-        "image-size": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "queue": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "overridden": false,
               "dependencies": {
-                "inherits": {
-                  "version": "2.0.4"
+                "once": {
+                  "version": "1.4.0"
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "overridden": false
                 }
               }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "overridden": false
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "overridden": false,
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.12",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+                  "overridden": false,
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.2"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "overridden": false
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "overridden": false,
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "overridden": false
             }
           }
         },
         "invariant": {
           "version": "2.2.4"
         },
-        "jest-worker": {
+        "jest-environment-node": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
           "overridden": false,
           "dependencies": {
+            "@jest/environment": {
+              "version": "29.7.0"
+            },
+            "@jest/fake-timers": {
+              "version": "29.7.0"
+            },
+            "@jest/types": {
+              "version": "29.6.3"
+            },
             "@types/node": {
               "version": "24.3.0"
             },
-            "jest-util": {
+            "jest-mock": {
               "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
               "overridden": false,
               "dependencies": {
                 "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
+                  "version": "29.6.3"
                 },
                 "@types/node": {
                   "version": "24.3.0"
                 },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "ci-info": {
-                  "version": "3.9.0"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "picomatch": {
-                  "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                  "overridden": false
+                "jest-util": {
+                  "version": "29.7.0"
                 }
               }
             },
-            "merge-stream": {
-              "version": "2.0.0"
-            },
-            "supports-color": {
-              "version": "8.1.1",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "has-flag": {
-                  "version": "4.0.0"
-                }
-              }
-            }
-          }
-        },
-        "jsc-safe-url": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
-          "overridden": false
-        },
-        "lodash.throttle": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-          "overridden": false
-        },
-        "metro-babel-transformer": {
-          "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "flow-enums-runtime": {
-              "version": "0.0.6"
-            },
-            "hermes-parser": {
-              "version": "0.28.1",
-              "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "hermes-estree": {
-                  "version": "0.28.1",
-                  "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "nullthrows": {
-              "version": "1.1.1"
-            }
-          }
-        },
-        "metro-cache-key": {
-          "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "flow-enums-runtime": {
-              "version": "0.0.6"
-            }
-          }
-        },
-        "metro-cache": {
-          "version": "0.82.3"
-        },
-        "metro-config": {
-          "version": "0.82.3"
-        },
-        "metro-core": {
-          "version": "0.82.3"
-        },
-        "metro-file-map": {
-          "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "debug": {
-              "version": "4.4.1"
-            },
-            "fb-watchman": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "bser": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "node-int64": {
-                      "version": "0.4.0",
-                      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                }
-              }
-            },
-            "flow-enums-runtime": {
-              "version": "0.0.6"
-            },
-            "graceful-fs": {
-              "version": "4.2.11"
-            },
-            "invariant": {
-              "version": "2.2.4"
-            },
-            "jest-worker": {
+            "jest-util": {
               "version": "29.7.0"
-            },
-            "micromatch": {
-              "version": "4.0.8"
-            },
-            "nullthrows": {
-              "version": "1.1.1"
-            },
-            "walker": {
-              "version": "1.0.8",
-              "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-              "overridden": false,
-              "dependencies": {
-                "makeerror": {
-                  "version": "1.0.12",
-                  "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "tmpl": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-                      "overridden": false
-                    }
-                  }
-                }
-              }
             }
           }
         },
-        "metro-resolver": {
-          "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "flow-enums-runtime": {
-              "version": "0.0.6"
-            }
-          }
+        "memoize-one": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+          "overridden": false
         },
         "metro-runtime": {
-          "version": "0.82.3"
-        },
-        "metro-source-map": {
-          "version": "0.82.3"
-        },
-        "metro-symbolicate": {
-          "version": "0.82.3"
-        },
-        "metro-transform-plugins": {
           "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.3.tgz",
+          "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.3.tgz",
           "overridden": false,
           "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@babel/generator": {
-              "version": "7.28.3"
-            },
-            "@babel/template": {
-              "version": "7.27.2"
-            },
-            "@babel/traverse": {
-              "version": "7.28.3"
+            "@babel/runtime": {
+              "version": "7.28.2"
             },
             "flow-enums-runtime": {
               "version": "0.0.6"
-            },
-            "nullthrows": {
-              "version": "1.1.1"
             }
           }
         },
-        "metro-transform-worker": {
+        "metro-source-map": {
           "version": "0.82.3",
-          "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.3.tgz",
+          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.3.tgz",
           "overridden": false,
           "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
+            "@babel/traverse--for-generate-function-map": {
+              "version": "7.28.3",
+              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "@babel/code-frame": {
+                  "version": "7.27.1"
+                },
+                "@babel/generator": {
+                  "version": "7.28.3"
+                },
+                "@babel/helper-globals": {
+                  "version": "7.28.0"
+                },
+                "@babel/parser": {
+                  "version": "7.28.3"
+                },
+                "@babel/template": {
+                  "version": "7.27.2"
+                },
+                "@babel/types": {
+                  "version": "7.28.2"
+                },
+                "debug": {
+                  "version": "4.4.1"
+                }
+              }
             },
-            "@babel/generator": {
-              "version": "7.28.3"
-            },
-            "@babel/parser": {
+            "@babel/traverse": {
               "version": "7.28.3"
             },
             "@babel/types": {
@@ -13007,79 +8737,152 @@
             "flow-enums-runtime": {
               "version": "0.0.6"
             },
-            "metro-babel-transformer": {
-              "version": "0.82.3"
+            "invariant": {
+              "version": "2.2.4"
             },
-            "metro-cache-key": {
-              "version": "0.82.3"
-            },
-            "metro-cache": {
-              "version": "0.82.3"
-            },
-            "metro-minify-terser": {
+            "metro-symbolicate": {
               "version": "0.82.3",
-              "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.3.tgz",
+              "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.3.tgz",
               "overridden": false,
               "dependencies": {
                 "flow-enums-runtime": {
                   "version": "0.0.6"
                 },
-                "terser": {
-                  "version": "5.43.1"
+                "invariant": {
+                  "version": "2.2.4"
+                },
+                "metro-source-map": {
+                  "version": "0.82.3"
+                },
+                "nullthrows": {
+                  "version": "1.1.1"
+                },
+                "source-map": {
+                  "version": "0.5.7",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                  "overridden": false
+                },
+                "vlq": {
+                  "version": "1.0.1"
                 }
               }
             },
-            "metro-source-map": {
-              "version": "0.82.3"
-            },
-            "metro-transform-plugins": {
-              "version": "0.82.3"
-            },
-            "metro": {
-              "version": "0.82.3"
-            },
             "nullthrows": {
               "version": "1.1.1"
-            }
-          }
-        },
-        "mime-types": {
-          "version": "2.1.35",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-          "overridden": false,
-          "dependencies": {
-            "mime-db": {
-              "version": "1.52.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            },
+            "ob1": {
+              "version": "0.82.3",
+              "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.3.tgz",
+              "overridden": false,
+              "dependencies": {
+                "flow-enums-runtime": {
+                  "version": "0.0.6"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "overridden": false
+            },
+            "vlq": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
               "overridden": false
             }
           }
         },
         "nullthrows": {
-          "version": "1.1.1"
-        },
-        "serialize-error": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
           "overridden": false
         },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+        "pretty-format": {
+          "version": "29.7.0"
+        },
+        "promise": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+          "overridden": false,
+          "dependencies": {
+            "asap": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+              "overridden": false
+            }
+          }
+        },
+        "react-devtools-core": {
+          "version": "6.1.5",
+          "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
+          "overridden": false,
+          "dependencies": {
+            "shell-quote": {
+              "version": "1.8.3",
+              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+              "overridden": false
+            },
+            "ws": {
+              "version": "7.5.10",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+              "overridden": false,
+              "dependencies": {
+                "bufferutil": {},
+                "utf-8-validate": {}
+              }
+            }
+          }
+        },
+        "react-refresh": {
+          "version": "0.14.2",
+          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
           "overridden": false
         },
-        "throat": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+        "react": {
+          "version": "19.0.0"
+        },
+        "regenerator-runtime": {
+          "version": "0.13.11",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+          "overridden": false
+        },
+        "scheduler": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+          "overridden": false
+        },
+        "semver": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+          "overridden": false
+        },
+        "stacktrace-parser": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+          "overridden": false,
+          "dependencies": {
+            "type-fest": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+              "overridden": false
+            }
+          }
+        },
+        "whatwg-fetch": {
+          "version": "3.6.20",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
           "overridden": false
         },
         "ws": {
-          "version": "7.5.10",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
           "overridden": false,
           "dependencies": {
-            "bufferutil": {},
-            "utf-8-validate": {}
+            "async-limiter": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+              "overridden": false
+            }
           }
         },
         "yargs": {
@@ -13181,1152 +8984,10 @@
         }
       }
     },
-    "react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        },
-        "scheduler": {
-          "version": "0.25.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-          "overridden": false
-        }
-      }
-    },
-    "react-native-gesture-handler": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.24.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@egjs/hammerjs": {
-          "version": "2.0.17",
-          "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@types/hammerjs": {
-              "version": "2.0.46",
-              "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "hoist-non-react-statics": {
-          "version": "3.3.2"
-        },
-        "invariant": {
-          "version": "2.2.4"
-        },
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
-    "react-native-permissions": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-5.4.1.tgz",
-      "overridden": false,
-      "dependencies": {
-        "react-native-windows": {},
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
-    "react-native-reanimated": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.4.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.28.0"
-        },
-        "@babel/plugin-transform-arrow-functions": {
-          "version": "7.27.1"
-        },
-        "@babel/plugin-transform-class-properties": {
-          "version": "7.27.1"
-        },
-        "@babel/plugin-transform-classes": {
-          "version": "7.28.3"
-        },
-        "@babel/plugin-transform-nullish-coalescing-operator": {
-          "version": "7.27.1"
-        },
-        "@babel/plugin-transform-optional-chaining": {
-          "version": "7.27.1"
-        },
-        "@babel/plugin-transform-shorthand-properties": {
-          "version": "7.27.1"
-        },
-        "@babel/plugin-transform-template-literals": {
-          "version": "7.27.1"
-        },
-        "@babel/plugin-transform-unicode-regex": {
-          "version": "7.27.1"
-        },
-        "@babel/preset-typescript": {
-          "version": "7.27.1"
-        },
-        "convert-source-map": {
-          "version": "2.0.0"
-        },
-        "invariant": {
-          "version": "2.2.4"
-        },
-        "react-native-is-edge-to-edge": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
-          "overridden": false,
-          "dependencies": {
-            "react-native": {
-              "version": "0.79.5"
-            },
-            "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
-            }
-          }
-        },
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
-    "react-native-safe-area-context": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
-    "react-native-screens": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.11.1.tgz",
-      "overridden": false,
-      "dependencies": {
-        "react-freeze": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
-          "overridden": false,
-          "dependencies": {
-            "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
-            }
-          }
-        },
-        "react-native-is-edge-to-edge": {
-          "version": "1.1.7"
-        },
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        },
-        "warn-once": {
-          "version": "0.1.1"
-        }
-      }
-    },
-    "react-native-svg": {
-      "version": "15.12.1",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
-      "overridden": false,
-      "dependencies": {
-        "css-select": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-          "overridden": false,
-          "dependencies": {
-            "boolbase": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-              "overridden": false
-            },
-            "css-what": {
-              "version": "6.2.2",
-              "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-              "overridden": false
-            },
-            "domhandler": {
-              "version": "5.0.3",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "domelementtype": {
-                  "version": "2.3.0",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "domutils": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "dom-serializer": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "2.3.0"
-                    },
-                    "domhandler": {
-                      "version": "5.0.3"
-                    },
-                    "entities": {
-                      "version": "4.5.0",
-                      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "domelementtype": {
-                  "version": "2.3.0"
-                },
-                "domhandler": {
-                  "version": "5.0.3"
-                }
-              }
-            },
-            "nth-check": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "boolbase": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "css-tree": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "mdn-data": {
-              "version": "2.0.14",
-              "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-              "overridden": false
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        },
-        "warn-once": {
-          "version": "0.1.1"
-        }
-      }
-    },
-    "react-native-webview": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0"
-        },
-        "invariant": {
-          "version": "2.2.4"
-        },
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        }
-      }
-    },
-    "react-native-worklets-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-native-worklets-core/-/react-native-worklets-core-1.6.0.tgz",
-      "overridden": false,
-      "dependencies": {
-        "react-native": {
-          "version": "0.79.5"
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        },
-        "string-hash-64": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
-          "overridden": false
-        }
-      }
-    },
-    "react-native": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.5.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@jest/create-cache-key-function": {
-          "version": "29.7.0"
-        },
-        "@react-native/assets-registry": {
-          "version": "0.79.5",
-          "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.5.tgz",
-          "overridden": false
-        },
-        "@react-native/codegen": {
-          "version": "0.79.5",
-          "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.5.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "glob": {
-              "version": "7.2.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0"
-                },
-                "inflight": {
-                  "version": "1.0.6"
-                },
-                "inherits": {
-                  "version": "2.0.4"
-                },
-                "minimatch": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.12",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.2"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0"
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "hermes-parser": {
-              "version": "0.25.1",
-              "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "hermes-estree": {
-                  "version": "0.25.1",
-                  "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "invariant": {
-              "version": "2.2.4"
-            },
-            "nullthrows": {
-              "version": "1.1.1"
-            },
-            "yargs": {
-              "version": "17.7.2"
-            }
-          }
-        },
-        "@react-native/community-cli-plugin": {
-          "version": "0.79.5",
-          "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.5.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@react-native-community/cli": {
-              "version": "20.0.0"
-            },
-            "@react-native/dev-middleware": {
-              "version": "0.79.5"
-            },
-            "chalk": {
-              "version": "4.1.2"
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "overridden": false,
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "invariant": {
-              "version": "2.2.4"
-            },
-            "metro-config": {
-              "version": "0.82.3"
-            },
-            "metro-core": {
-              "version": "0.82.3"
-            },
-            "metro": {
-              "version": "0.82.3"
-            },
-            "semver": {
-              "version": "7.7.2",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "@react-native/gradle-plugin": {
-          "version": "0.79.5",
-          "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.5.tgz",
-          "overridden": false
-        },
-        "@react-native/js-polyfills": {
-          "version": "0.79.5",
-          "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.5.tgz",
-          "overridden": false
-        },
-        "@react-native/normalize-colors": {
-          "version": "0.79.5",
-          "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.5.tgz",
-          "overridden": false
-        },
-        "@react-native/virtualized-lists": {
-          "version": "0.79.5",
-          "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.5.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@types/react": {
-              "version": "19.0.10",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: @types/react@19.0.10 /workspace/AmysEcho/app/node_modules/@types/react"
-              ]
-            },
-            "invariant": {
-              "version": "2.2.4"
-            },
-            "nullthrows": {
-              "version": "1.1.1"
-            },
-            "react-native": {
-              "version": "0.79.5"
-            },
-            "react": {
-              "version": "19.0.0",
-              "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-              "problems": [
-                "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-              ]
-            }
-          }
-        },
-        "@types/react": {
-          "version": "19.0.10",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: @types/react@19.0.10 /workspace/AmysEcho/app/node_modules/@types/react"
-          ]
-        },
-        "abort-controller": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "event-target-shim": {
-              "version": "5.0.1"
-            }
-          }
-        },
-        "anser": {
-          "version": "1.4.10",
-          "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
-          "overridden": false
-        },
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "overridden": false
-        },
-        "babel-jest": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@babel/core": {
-              "version": "7.28.0"
-            },
-            "@jest/transform": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "@jest/types": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/schemas": {
-                      "version": "29.6.3",
-                      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                      "overridden": false,
-                      "dependencies": {
-                        "@sinclair/typebox": {
-                          "version": "0.27.8",
-                          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                          "overridden": false
-                        }
-                      }
-                    },
-                    "@types/istanbul-lib-coverage": {
-                      "version": "2.0.6"
-                    },
-                    "@types/istanbul-reports": {
-                      "version": "3.0.4"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "@types/yargs": {
-                      "version": "17.0.33"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    }
-                  }
-                },
-                "@jridgewell/trace-mapping": {
-                  "version": "0.3.30"
-                },
-                "babel-plugin-istanbul": {
-                  "version": "6.1.1"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "convert-source-map": {
-                  "version": "2.0.0"
-                },
-                "fast-json-stable-stringify": {
-                  "version": "2.1.0"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "jest-haste-map": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/graceful-fs": {
-                      "version": "4.1.9"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "anymatch": {
-                      "version": "3.1.3"
-                    },
-                    "fb-watchman": {
-                      "version": "2.0.2"
-                    },
-                    "fsevents": {
-                      "version": "2.3.3"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "jest-regex-util": {
-                      "version": "29.6.3"
-                    },
-                    "jest-util": {
-                      "version": "29.7.0"
-                    },
-                    "jest-worker": {
-                      "version": "29.7.0"
-                    },
-                    "micromatch": {
-                      "version": "4.0.8"
-                    },
-                    "walker": {
-                      "version": "1.0.8"
-                    }
-                  }
-                },
-                "jest-regex-util": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-                  "overridden": false
-                },
-                "jest-util": {
-                  "version": "29.7.0",
-                  "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jest/types": {
-                      "version": "29.6.3"
-                    },
-                    "@types/node": {
-                      "version": "24.3.0"
-                    },
-                    "chalk": {
-                      "version": "4.1.2"
-                    },
-                    "ci-info": {
-                      "version": "3.9.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.2.11"
-                    },
-                    "picomatch": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "micromatch": {
-                  "version": "4.0.8"
-                },
-                "pirates": {
-                  "version": "4.0.7"
-                },
-                "slash": {
-                  "version": "3.0.0"
-                },
-                "write-file-atomic": {
-                  "version": "4.0.2",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4"
-                    },
-                    "signal-exit": {
-                      "version": "3.0.7"
-                    }
-                  }
-                }
-              }
-            },
-            "@types/babel__core": {
-              "version": "7.20.5"
-            },
-            "babel-plugin-istanbul": {
-              "version": "6.1.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/helper-plugin-utils": {
-                  "version": "7.27.1"
-                },
-                "@istanbuljs/load-nyc-config": {
-                  "version": "1.1.0"
-                },
-                "@istanbuljs/schema": {
-                  "version": "0.1.3"
-                },
-                "istanbul-lib-instrument": {
-                  "version": "5.2.1",
-                  "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/core": {
-                      "version": "7.28.0"
-                    },
-                    "@babel/parser": {
-                      "version": "7.28.3"
-                    },
-                    "@istanbuljs/schema": {
-                      "version": "0.1.3"
-                    },
-                    "istanbul-lib-coverage": {
-                      "version": "3.2.2"
-                    },
-                    "semver": {
-                      "version": "6.3.1",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "test-exclude": {
-                  "version": "6.0.0"
-                }
-              }
-            },
-            "babel-preset-jest": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@babel/core": {
-                  "version": "7.28.0"
-                },
-                "babel-plugin-jest-hoist": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@babel/template": {
-                      "version": "7.27.2"
-                    },
-                    "@babel/types": {
-                      "version": "7.28.2"
-                    },
-                    "@types/babel__core": {
-                      "version": "7.20.5"
-                    },
-                    "@types/babel__traverse": {
-                      "version": "7.28.0"
-                    }
-                  }
-                },
-                "babel-preset-current-node-syntax": {
-                  "version": "1.2.0"
-                }
-              }
-            },
-            "chalk": {
-              "version": "4.1.2"
-            },
-            "graceful-fs": {
-              "version": "4.2.11"
-            },
-            "slash": {
-              "version": "3.0.0"
-            }
-          }
-        },
-        "babel-plugin-syntax-hermes-parser": {
-          "version": "0.25.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "hermes-parser": {
-              "version": "0.25.1"
-            }
-          }
-        },
-        "base64-js": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-          "overridden": false
-        },
-        "chalk": {
-          "version": "4.1.2"
-        },
-        "commander": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-          "overridden": false
-        },
-        "event-target-shim": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-          "overridden": false
-        },
-        "flow-enums-runtime": {
-          "version": "0.0.6"
-        },
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "overridden": false
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "overridden": false,
-              "dependencies": {
-                "once": {
-                  "version": "1.4.0"
-                },
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-              "overridden": false
-            },
-            "minimatch": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.12",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.2"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "overridden": false
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "invariant": {
-          "version": "2.2.4"
-        },
-        "jest-environment-node": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@jest/environment": {
-              "version": "29.7.0"
-            },
-            "@jest/fake-timers": {
-              "version": "29.7.0"
-            },
-            "@jest/types": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/schemas": {
-                  "version": "29.6.3",
-                  "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@sinclair/typebox": {
-                      "version": "0.27.8",
-                      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                      "overridden": false
-                    }
-                  }
-                },
-                "@types/istanbul-lib-coverage": {
-                  "version": "2.0.6"
-                },
-                "@types/istanbul-reports": {
-                  "version": "3.0.4"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "@types/yargs": {
-                  "version": "17.0.33"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                }
-              }
-            },
-            "@types/node": {
-              "version": "24.3.0"
-            },
-            "jest-mock": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "jest-util": {
-                  "version": "29.7.0"
-                }
-              }
-            },
-            "jest-util": {
-              "version": "29.7.0",
-              "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jest/types": {
-                  "version": "29.6.3"
-                },
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "chalk": {
-                  "version": "4.1.2"
-                },
-                "ci-info": {
-                  "version": "3.9.0"
-                },
-                "graceful-fs": {
-                  "version": "4.2.11"
-                },
-                "picomatch": {
-                  "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-                  "overridden": false
-                }
-              }
-            }
-          }
-        },
-        "memoize-one": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-          "overridden": false
-        },
-        "metro-runtime": {
-          "version": "0.82.3"
-        },
-        "metro-source-map": {
-          "version": "0.82.3"
-        },
-        "nullthrows": {
-          "version": "1.1.1"
-        },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@jest/schemas": {
-              "version": "29.6.3",
-              "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@sinclair/typebox": {
-                  "version": "0.27.8",
-                  "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "overridden": false
-            },
-            "react-is": {
-              "version": "18.3.1",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "promise": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "asap": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "react-devtools-core": {
-          "version": "6.1.5",
-          "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
-          "overridden": false,
-          "dependencies": {
-            "shell-quote": {
-              "version": "1.8.3",
-              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-              "overridden": false
-            },
-            "ws": {
-              "version": "7.5.10",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-              "overridden": false,
-              "dependencies": {
-                "bufferutil": {},
-                "utf-8-validate": {}
-              }
-            }
-          }
-        },
-        "react-refresh": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-          "overridden": false
-        },
-        "react": {
-          "version": "19.0.0",
-          "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-          "problems": [
-            "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-          ]
-        },
-        "regenerator-runtime": {
-          "version": "0.13.11",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-          "overridden": false
-        },
-        "scheduler": {
-          "version": "0.25.0"
-        },
-        "semver": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-          "overridden": false
-        },
-        "stacktrace-parser": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
-          "overridden": false,
-          "dependencies": {
-            "type-fest": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "whatwg-fetch": {
-          "version": "3.6.20",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-          "overridden": false
-        },
-        "ws": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "async-limiter": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "yargs": {
-          "version": "17.7.2"
-        }
-      }
-    },
     "react": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "overridden": false,
-      "invalid": "\"^16||^17||^18\" from node_modules/@nozbe/with-observables",
-      "problems": [
-        "invalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react"
-      ]
+      "overridden": false
     },
     "ts-jest": {
       "version": "29.4.0",
@@ -14337,48 +8998,13 @@
           "version": "7.28.0"
         },
         "@jest/transform": {
-          "version": "30.0.5"
+          "version": "29.7.0"
         },
         "@jest/types": {
-          "version": "30.0.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@jest/pattern": {
-              "version": "30.0.1",
-              "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "jest-regex-util": {
-                  "version": "30.0.1"
-                }
-              }
-            },
-            "@jest/schemas": {
-              "version": "30.0.5"
-            },
-            "@types/istanbul-lib-coverage": {
-              "version": "2.0.6"
-            },
-            "@types/istanbul-reports": {
-              "version": "3.0.4"
-            },
-            "@types/node": {
-              "version": "24.3.0"
-            },
-            "@types/yargs": {
-              "version": "17.0.33"
-            },
-            "chalk": {
-              "version": "4.1.2"
-            }
-          }
+          "version": "29.6.3"
         },
         "babel-jest": {
-          "version": "30.0.5"
+          "version": "29.7.0"
         },
         "bs-logger": {
           "version": "0.2.6",
@@ -14435,12 +9061,12 @@
           "overridden": false
         },
         "jest-util": {
-          "version": "30.0.5",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
           "overridden": false,
           "dependencies": {
             "@jest/types": {
-              "version": "30.0.5"
+              "version": "29.6.3"
             },
             "@types/node": {
               "version": "24.3.0"
@@ -14449,16 +9075,14 @@
               "version": "4.1.2"
             },
             "ci-info": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
-              "overridden": false
+              "version": "3.9.0"
             },
             "graceful-fs": {
               "version": "4.2.11"
             },
             "picomatch": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
               "overridden": false
             }
           }
@@ -14499,608 +9123,15 @@
         }
       }
     },
-    "ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@cspotcode/source-map-support": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@jridgewell/trace-mapping": {
-              "version": "0.3.9",
-              "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jridgewell/resolve-uri": {
-                  "version": "3.1.2"
-                },
-                "@jridgewell/sourcemap-codec": {
-                  "version": "1.5.5"
-                }
-              }
-            }
-          }
-        },
-        "@swc/core": {},
-        "@swc/wasm": {},
-        "@tsconfig/node10": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-          "overridden": false
-        },
-        "@tsconfig/node12": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-          "overridden": false
-        },
-        "@tsconfig/node14": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-          "overridden": false
-        },
-        "@tsconfig/node16": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-          "overridden": false
-        },
-        "@types/node": {
-          "version": "24.3.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-          "overridden": false,
-          "dependencies": {
-            "undici-types": {
-              "version": "7.10.0",
-              "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "acorn-walk": {
-          "version": "8.3.4",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-          "overridden": false,
-          "dependencies": {
-            "acorn": {
-              "version": "8.15.0"
-            }
-          }
-        },
-        "acorn": {
-          "version": "8.15.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-          "overridden": false
-        },
-        "arg": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-          "overridden": false
-        },
-        "create-require": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-          "overridden": false
-        },
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "overridden": false
-        },
-        "make-error": {
-          "version": "1.3.6"
-        },
-        "typescript": {
-          "version": "5.8.3"
-        },
-        "v8-compile-cache-lib": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-          "overridden": false
-        },
-        "yn": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-          "overridden": false
-        }
-      }
-    },
     "typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "overridden": false
-    },
-    "webpack": {
-      "version": "5.101.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
-      "overridden": false,
-      "dependencies": {
-        "@types/eslint-scope": {
-          "version": "3.7.7",
-          "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@types/eslint": {
-              "version": "9.6.1",
-              "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@types/estree": {
-                  "version": "1.0.8"
-                },
-                "@types/json-schema": {
-                  "version": "7.0.15"
-                }
-              }
-            },
-            "@types/estree": {
-              "version": "1.0.8"
-            }
-          }
-        },
-        "@types/estree": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-          "overridden": false
-        },
-        "@types/json-schema": {
-          "version": "7.0.15",
-          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-          "overridden": false
-        },
-        "@webassemblyjs/ast": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@webassemblyjs/helper-numbers": {
-              "version": "1.13.2",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": {
-                  "version": "1.13.2",
-                  "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-                  "overridden": false
-                },
-                "@webassemblyjs/helper-api-error": {
-                  "version": "1.13.2"
-                },
-                "@xtuc/long": {
-                  "version": "4.2.2",
-                  "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "@webassemblyjs/helper-wasm-bytecode": {
-              "version": "1.13.2",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "@webassemblyjs/wasm-edit": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@webassemblyjs/ast": {
-              "version": "1.14.1"
-            },
-            "@webassemblyjs/helper-buffer": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-              "overridden": false
-            },
-            "@webassemblyjs/helper-wasm-bytecode": {
-              "version": "1.13.2"
-            },
-            "@webassemblyjs/helper-wasm-section": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@webassemblyjs/ast": {
-                  "version": "1.14.1"
-                },
-                "@webassemblyjs/helper-buffer": {
-                  "version": "1.14.1"
-                },
-                "@webassemblyjs/helper-wasm-bytecode": {
-                  "version": "1.13.2"
-                },
-                "@webassemblyjs/wasm-gen": {
-                  "version": "1.14.1"
-                }
-              }
-            },
-            "@webassemblyjs/wasm-gen": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@webassemblyjs/ast": {
-                  "version": "1.14.1"
-                },
-                "@webassemblyjs/helper-wasm-bytecode": {
-                  "version": "1.13.2"
-                },
-                "@webassemblyjs/ieee754": {
-                  "version": "1.13.2"
-                },
-                "@webassemblyjs/leb128": {
-                  "version": "1.13.2"
-                },
-                "@webassemblyjs/utf8": {
-                  "version": "1.13.2"
-                }
-              }
-            },
-            "@webassemblyjs/wasm-opt": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@webassemblyjs/ast": {
-                  "version": "1.14.1"
-                },
-                "@webassemblyjs/helper-buffer": {
-                  "version": "1.14.1"
-                },
-                "@webassemblyjs/wasm-gen": {
-                  "version": "1.14.1"
-                },
-                "@webassemblyjs/wasm-parser": {
-                  "version": "1.14.1"
-                }
-              }
-            },
-            "@webassemblyjs/wasm-parser": {
-              "version": "1.14.1"
-            },
-            "@webassemblyjs/wast-printer": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@webassemblyjs/ast": {
-                  "version": "1.14.1"
-                },
-                "@xtuc/long": {
-                  "version": "4.2.2"
-                }
-              }
-            }
-          }
-        },
-        "@webassemblyjs/wasm-parser": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@webassemblyjs/ast": {
-              "version": "1.14.1"
-            },
-            "@webassemblyjs/helper-api-error": {
-              "version": "1.13.2",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-              "overridden": false
-            },
-            "@webassemblyjs/helper-wasm-bytecode": {
-              "version": "1.13.2"
-            },
-            "@webassemblyjs/ieee754": {
-              "version": "1.13.2",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@xtuc/ieee754": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "@webassemblyjs/leb128": {
-              "version": "1.13.2",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@xtuc/long": {
-                  "version": "4.2.2"
-                }
-              }
-            },
-            "@webassemblyjs/utf8": {
-              "version": "1.13.2",
-              "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "acorn-import-phases": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-          "overridden": false,
-          "dependencies": {
-            "acorn": {
-              "version": "8.15.0"
-            }
-          }
-        },
-        "acorn": {
-          "version": "8.15.0"
-        },
-        "browserslist": {
-          "version": "4.25.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
-          "overridden": false,
-          "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30001735",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
-              "overridden": false
-            },
-            "electron-to-chromium": {
-              "version": "1.5.203",
-              "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.203.tgz",
-              "overridden": false
-            },
-            "node-releases": {
-              "version": "2.0.19",
-              "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-              "overridden": false
-            },
-            "update-browserslist-db": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-              "overridden": false,
-              "dependencies": {
-                "browserslist": {
-                  "version": "4.25.2"
-                },
-                "escalade": {
-                  "version": "3.2.0"
-                },
-                "picocolors": {
-                  "version": "1.1.1"
-                }
-              }
-            }
-          }
-        },
-        "chrome-trace-event": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-          "overridden": false
-        },
-        "enhanced-resolve": {
-          "version": "5.18.3",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-          "overridden": false,
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.2.11"
-            },
-            "tapable": {
-              "version": "2.2.2"
-            }
-          }
-        },
-        "es-module-lexer": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-          "overridden": false
-        },
-        "eslint-scope": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-          "overridden": false,
-          "dependencies": {
-            "esrecurse": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "estraverse": {
-                  "version": "5.3.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                  "overridden": false
-                }
-              }
-            },
-            "estraverse": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-              "overridden": false
-            }
-          }
-        },
-        "events": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-          "overridden": false
-        },
-        "glob-to-regexp": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-          "overridden": false
-        },
-        "graceful-fs": {
-          "version": "4.2.11"
-        },
-        "json-parse-even-better-errors": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-          "overridden": false
-        },
-        "loader-runner": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-          "overridden": false
-        },
-        "mime-types": {
-          "version": "2.1.35"
-        },
-        "neo-async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-          "overridden": false
-        },
-        "schema-utils": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@types/json-schema": {
-              "version": "7.0.15"
-            },
-            "ajv-formats": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "ajv": {
-                  "version": "8.11.0"
-                }
-              }
-            },
-            "ajv-keywords": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-              "overridden": false,
-              "dependencies": {
-                "ajv": {
-                  "version": "8.11.0"
-                },
-                "fast-deep-equal": {
-                  "version": "3.1.3"
-                }
-              }
-            },
-            "ajv": {
-              "version": "8.11.0"
-            }
-          }
-        },
-        "tapable": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-          "overridden": false
-        },
-        "terser-webpack-plugin": {
-          "version": "5.3.14",
-          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-          "overridden": false,
-          "dependencies": {
-            "@jridgewell/trace-mapping": {
-              "version": "0.3.30"
-            },
-            "jest-worker": {
-              "version": "27.5.1",
-              "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@types/node": {
-                  "version": "24.3.0"
-                },
-                "merge-stream": {
-                  "version": "2.0.0"
-                },
-                "supports-color": {
-                  "version": "8.1.1",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "4.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "schema-utils": {
-              "version": "4.3.2"
-            },
-            "serialize-javascript": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-              "overridden": false,
-              "dependencies": {
-                "randombytes": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "safe-buffer": {
-                      "version": "5.2.1"
-                    }
-                  }
-                }
-              }
-            },
-            "terser": {
-              "version": "5.43.1",
-              "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-              "overridden": false,
-              "dependencies": {
-                "@jridgewell/source-map": {
-                  "version": "0.3.11",
-                  "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-                  "overridden": false,
-                  "dependencies": {
-                    "@jridgewell/gen-mapping": {
-                      "version": "0.3.13"
-                    },
-                    "@jridgewell/trace-mapping": {
-                      "version": "0.3.30"
-                    }
-                  }
-                },
-                "acorn": {
-                  "version": "8.15.0"
-                },
-                "commander": {
-                  "version": "2.20.3",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                  "overridden": false
-                },
-                "source-map-support": {
-                  "version": "0.5.21"
-                }
-              }
-            },
-            "webpack": {
-              "version": "5.101.3"
-            }
-          }
-        },
-        "watchpack": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-          "overridden": false,
-          "dependencies": {
-            "glob-to-regexp": {
-              "version": "0.4.1"
-            },
-            "graceful-fs": {
-              "version": "4.2.11"
-            }
-          }
-        },
-        "webpack-sources": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-          "overridden": false
-        }
-      }
     }
   },
   "error": {
     "code": "ELSPROBLEMS",
-    "summary": "invalid: @types/react@19.0.10 /workspace/AmysEcho/app/node_modules/@types/react\ninvalid: react@19.0.0 /workspace/AmysEcho/app/node_modules/react",
+    "summary": "missing: react-native-screens@>= 3.0.0, required by @react-navigation/stack@6.4.1\nmissing: react-dom@^19.0.0, required by react-server-dom-webpack@19.0.0\nmissing: webpack@^5.59.0, required by react-server-dom-webpack@19.0.0",
     "detail": ""
   }
 }

--- a/scripts/check-pins.js
+++ b/scripts/check-pins.js
@@ -27,7 +27,6 @@ const criticalAppDeps = [
   'react-native',
   'expo',
   'react-native-webview',
-  'react-native-worklets-core',
   'react-native-reanimated',
   '@nozbe/watermelondb',
 ];

--- a/scripts/update-webview-base64.js
+++ b/scripts/update-webview-base64.js
@@ -66,13 +66,17 @@ async function updateFflate() {
 
 function updateInstallMlp() {
   const appDir = path.join(__dirname, '..', 'app');
-  const tsNodePath = require.resolve('ts-node', { paths: [appDir] });
-  const tsNode = require(tsNodePath);
-  tsNode.register({
-    transpileOnly: true,
-    compilerOptions: { module: 'commonjs', target: 'es2018', lib: ['es2020', 'dom'] },
+  const ts = require('typescript');
+  const srcPath = path.join(appDir, 'src', 'webview', 'installMlp.ts');
+  const tsCode = fs.readFileSync(srcPath, 'utf8');
+  const { outputText } = ts.transpileModule(tsCode, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2018, lib: ['es2020', 'dom'] },
   });
-  const { installMlp } = require(path.join(appDir, 'src', 'webview', 'installMlp.ts'));
+  const Module = module.constructor;
+  const m = new Module();
+  m.paths = Module._nodeModulePaths(appDir);
+  m._compile(outputText, srcPath);
+  const { installMlp } = m.exports;
   const code = `(${installMlp.toString()})();`;
   const base64 = Buffer.from(code, 'utf8').toString('base64');
   const header = `/**\n * Generated from app/src/webview/installMlp.ts\n * Run scripts/update-webview-base64.js after modifying installMlp.ts.\n */`;


### PR DESCRIPTION
## Summary
- drop unused dependencies including lucide-react-native, react-native-worklets-core and native-stack
- inline SVG icons, rework pulsing circle, and switch to JS stack navigator
- clean up scripts and checks after removing ts-node

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b4a2a9f29083228d1a5818da73fda2