### PR TITLE
chore: refresh model after training

### DIFF
--- a/app/src/services/syncService.ts
+++ b/app/src/services/syncService.ts
@@ -7,6 +7,7 @@ import { processFramesForUpload } from './handUtils';
 import { Q } from '@nozbe/watermelondb';
 import { uploadTelemetry } from './analytics';
 import { telemetry } from '../telemetry/recorder';
+import { refreshDgsModel } from './modelUpdate';
 
 export const syncService = {
   async syncTelemetry(): Promise<void> {
@@ -74,6 +75,7 @@ export const syncService = {
             }
           });
           logger.info(`Uploaded ${pendingSamples.length} samples successfully.`);
+          await refreshDgsModel(activeProfileId).catch(() => {});
         } else {
           logger.error(`Failed to upload training data: ${response.status} ${response.statusText}`);
         }

--- a/app/src/services/syncService.ts
+++ b/app/src/services/syncService.ts
@@ -75,7 +75,7 @@ export const syncService = {
             }
           });
           logger.info(`Uploaded ${pendingSamples.length} samples successfully.`);
-          await refreshDgsModel(activeProfileId).catch(() => {});
+          await refreshDgsModel(activeProfileId);
         } else {
           logger.error(`Failed to upload training data: ${response.status} ${response.statusText}`);
         }

--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -3,7 +3,7 @@ import NetInfo from '@react-native-community/netinfo';
 import { loadProfile, TrainingSample, loadBackendApiToken } from '../storage';
 import { API_URL } from '../constants';
 import { logger } from '../utils/logger';
-import { fetchCentroids } from './dgsModelClient';
+import { refreshDgsModel } from './modelUpdate';
 import { processFramesForUpload } from './handUtils';
 
 const TRAINING_KEY = 'gestureTrainingData';
@@ -102,7 +102,7 @@ export async function syncTrainingData(opts?: SyncProgressOptions): Promise<void
     if (!completed) {
       throw new Error('training status polling timed out');
     }
-    await fetchCentroids(profile?.id || undefined).catch(() => {});
+    await refreshDgsModel(profile?.id || undefined).catch(() => {});
     for (const p of pending) p.syncStatus = 'synced';
     await AsyncStorage.setItem(TRAINING_KEY, JSON.stringify(data));
   } catch (e) {

--- a/app/src/services/trainingSync.ts
+++ b/app/src/services/trainingSync.ts
@@ -102,7 +102,7 @@ export async function syncTrainingData(opts?: SyncProgressOptions): Promise<void
     if (!completed) {
       throw new Error('training status polling timed out');
     }
-    await refreshDgsModel(profile?.id || undefined).catch(() => {});
+    await refreshDgsModel(profile?.id);
     for (const p of pending) p.syncStatus = 'synced';
     await AsyncStorage.setItem(TRAINING_KEY, JSON.stringify(data));
   } catch (e) {

--- a/app/test/syncService.test.ts
+++ b/app/test/syncService.test.ts
@@ -24,7 +24,12 @@ jest.mock('../src/utils/logger', () => ({
   logger: mockLogger,
 }));
 
+jest.mock('../src/services/modelUpdate', () => ({
+  refreshDgsModel: jest.fn(async () => 'centroid'),
+}));
+
 import { syncService } from '../src/services/syncService';
+import { refreshDgsModel } from '../src/services/modelUpdate';
 
 beforeEach(() => {
   const sample: {
@@ -63,6 +68,7 @@ describe('syncService.uploadPendingTrainingData', () => {
     expect(body.samples[0].landmarkData[0]).toEqual([1, 2, 3]);
     expect(mockSamples[0].customSyncStatus).toBe('synced');
     expect(mockDatabase.write).toHaveBeenCalled();
+    expect(refreshDgsModel).toHaveBeenCalledWith('p1');
   });
 
   it('logs error and leaves samples pending on failure', async () => {
@@ -71,6 +77,7 @@ describe('syncService.uploadPendingTrainingData', () => {
     expect(mockLogger.error).toHaveBeenCalledWith('Failed to upload training data: 500 fail');
     expect(mockSamples[0].customSyncStatus).toBe('pending');
     expect(mockDatabase.write).not.toHaveBeenCalled();
+    expect(refreshDgsModel).not.toHaveBeenCalled();
   });
 });
 

--- a/app/test/trainingSync.test.ts
+++ b/app/test/trainingSync.test.ts
@@ -14,8 +14,8 @@ jest.mock('../src/storage', () => ({
   loadBackendApiToken: async () => 'token',
 }));
 
-jest.mock('../src/services/dgsModelClient', () => ({
-  fetchCentroids: jest.fn(async () => null),
+jest.mock('../src/services/modelUpdate', () => ({
+  refreshDgsModel: jest.fn(async () => 'centroid'),
 }));
 
 jest.mock('../src/utils/logger', () => ({
@@ -23,7 +23,7 @@ jest.mock('../src/utils/logger', () => ({
 }));
 
 import { syncTrainingData } from '../src/services/trainingSync';
-import { fetchCentroids } from '../src/services/dgsModelClient';
+import { refreshDgsModel } from '../src/services/modelUpdate';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { logger } from '../src/utils/logger';
 
@@ -93,7 +93,7 @@ describe('syncTrainingData', () => {
     expect(body.samples[0].landmarkData[0]).toEqual([1, 2, 3]);
     expect(body.samples[0].landmarkData).toHaveLength(42);
     expect(body.samples[0].profileId).toBe('amy');
-    expect(fetchCentroids).toHaveBeenCalledWith('amy');
+    expect(refreshDgsModel).toHaveBeenCalledWith('amy');
     const updated = JSON.parse((await AsyncStorage.getItem(TRAINING_KEY))!);
     expect(updated[0].syncStatus).toBe('synced');
   });


### PR DESCRIPTION
## Summary
- refresh custom model after training samples sync
- test model refresh after training and data upload

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b4b5941a44832299d37132aeae9686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Automatically refreshes the DGS model after successful training data uploads and after training completes, ensuring the latest model is available sooner without manual steps. Refresh errors are safely ignored and do not affect syncing.
- Tests
  - Updated unit tests to validate model refresh is triggered on successful sync and not called on failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->