### PR TITLE
fix(webview): handle context restoration and model transfer edge cases

### DIFF
--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1419,17 +1419,17 @@
     });
     return stopPromise;
   }
-  var onPageHide = () => cleanup();
-  var onBeforeUnload = () => cleanup();
+  var onPageHide = () => void cleanup();
+  var onBeforeUnload = () => void cleanup();
   var onResize = () => resizeOverlay();
   window.addEventListener("pagehide", onPageHide);
   window.addEventListener("beforeunload", onBeforeUnload);
   window.addEventListener("resize", onResize);
-  function cleanup() {
+  async function cleanup() {
     if (cleanedUp) return;
     cleanedUp = true;
     running = false;
-    void stopCamera();
+    await stopCamera();
     try {
       document.getElementById("tapToStart")?.remove();
     } catch (e) {

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1184,6 +1184,7 @@
   var lastSentGesture = null;
   var lastSentScore = 0;
   var running = true;
+  var cleanedUp = false;
   var TARGET_FPS = 30;
   var MIN_FRAME_TIME = 1e3 / TARGET_FPS;
   var lastFrameTs = 0;
@@ -1383,7 +1384,7 @@
   var stopping = false;
   var stopOnce = null;
   async function stopCamera() {
-    if (stopping) return stopOnce ?? Promise.resolve();
+    if (stopping) return stopOnce;
     stopping = true;
     stopOnce = (async () => {
       try {
@@ -1420,20 +1421,15 @@
     });
     return stopOnce;
   }
-  var onPageHide = () => {
-    running = false;
-    void stopCamera();
-  };
-  var onBeforeUnload = () => {
-    running = false;
-    void stopCamera();
-  };
+  var onPageHide = () => cleanup();
+  var onBeforeUnload = () => cleanup();
   var onResize = () => resizeOverlay();
   window.addEventListener("pagehide", onPageHide);
   window.addEventListener("beforeunload", onBeforeUnload);
   window.addEventListener("resize", onResize);
   function cleanup() {
-    if (!running) return;
+    if (cleanedUp) return;
+    cleanedUp = true;
     running = false;
     void stopCamera();
     try {

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1381,12 +1381,10 @@
     });
   }
   createGestureRecognizer();
-  var stopping = false;
-  var stopOnce = null;
+  var stopPromise = null;
   async function stopCamera() {
-    if (stopping) return stopOnce;
-    stopping = true;
-    stopOnce = (async () => {
+    if (stopPromise) return stopPromise;
+    stopPromise = (async () => {
       try {
         video.pause();
       } catch (e) {
@@ -1417,9 +1415,9 @@
       }
       gestureRecognizer = null;
     })().finally(() => {
-      stopping = false;
+      stopPromise = null;
     });
-    return stopOnce;
+    return stopPromise;
   }
   var onPageHide = () => cleanup();
   var onBeforeUnload = () => cleanup();

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1117,6 +1117,7 @@
   });
   overlay.addEventListener("contextrestored", () => {
     overlay.getContext("2d");
+    resizeOverlay();
     if (running) window.requestAnimationFrame(predictWebcam);
   });
   video.setAttribute("autoplay", "");
@@ -1379,36 +1380,45 @@
     });
   }
   createGestureRecognizer();
+  var stopping = false;
+  var stopOnce = null;
   async function stopCamera() {
-    try {
-      video.pause();
-    } catch (e) {
-      console.warn("Video konnte w\xE4hrend des Aufr\xE4umens nicht pausiert werden:", e);
-    }
-    try {
-      video.removeEventListener("loadeddata", predictWebcam);
-    } catch (e) {
-      console.warn(
-        'Entfernen des "loadeddata"-Listeners w\xE4hrend des Aufr\xE4umens fehlgeschlagen:',
-        e
-      );
-    }
-    try {
-      const s = video.srcObject;
-      if (s) {
-        s.getTracks().forEach((t) => t.stop());
-        video.srcObject = null;
+    if (stopping) return stopOnce ?? Promise.resolve();
+    stopping = true;
+    stopOnce = (async () => {
+      try {
+        video.pause();
+      } catch (e) {
+        console.warn("Video konnte w\xE4hrend des Aufr\xE4umens nicht pausiert werden:", e);
       }
-    } catch (e) {
-      console.warn("Fehler beim Stoppen des Kamerastreams:", e);
-    }
-    try {
-      const res = gestureRecognizer?.close?.();
-      if (res && typeof res.then === "function") await res;
-    } catch (e) {
-      console.warn("Fehler beim Schlie\xDFen des Gestenerkenners:", e);
-    }
-    gestureRecognizer = null;
+      try {
+        video.removeEventListener("loadeddata", predictWebcam);
+      } catch (e) {
+        console.warn(
+          'Entfernen des "loadeddata"-Listeners w\xE4hrend des Aufr\xE4umens fehlgeschlagen:',
+          e
+        );
+      }
+      try {
+        const s = video.srcObject;
+        if (s) {
+          s.getTracks().forEach((t) => t.stop());
+          video.srcObject = null;
+        }
+      } catch (e) {
+        console.warn("Fehler beim Stoppen des Kamerastreams:", e);
+      }
+      try {
+        const res = gestureRecognizer?.close?.();
+        if (res && typeof res.then === "function") await res;
+      } catch (e) {
+        console.warn("Fehler beim Schlie\xDFen des Gestenerkenners:", e);
+      }
+      gestureRecognizer = null;
+    })().finally(() => {
+      stopping = false;
+    });
+    return stopOnce;
   }
   var onPageHide = () => {
     running = false;

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1117,6 +1117,7 @@
   });
   overlay.addEventListener("contextrestored", () => {
     overlay.getContext("2d");
+    if (running) window.requestAnimationFrame(predictWebcam);
   });
   video.setAttribute("autoplay", "");
   video.setAttribute("playsinline", "");
@@ -1225,7 +1226,7 @@
                 }
               }
             }
-            multiHand = perHand.length >= 2 || (results?.landmarks?.length ?? 0) >= 2;
+            multiHand = perHand.length >= 2;
             if (multiHand) {
               let left = perHand.find((h) => /left/i.test(h.hand)) || null;
               let right = perHand.find((h) => /right/i.test(h.hand)) || null;
@@ -1378,7 +1379,7 @@
     });
   }
   createGestureRecognizer();
-  function stopCamera() {
+  async function stopCamera() {
     try {
       video.pause();
     } catch (e) {
@@ -1402,7 +1403,8 @@
       console.warn("Fehler beim Stoppen des Kamerastreams:", e);
     }
     try {
-      gestureRecognizer?.close?.();
+      const res = gestureRecognizer?.close?.();
+      if (res && typeof res.then === "function") await res;
     } catch (e) {
       console.warn("Fehler beim Schlie\xDFen des Gestenerkenners:", e);
     }
@@ -1410,11 +1412,11 @@
   }
   var onPageHide = () => {
     running = false;
-    stopCamera();
+    void stopCamera();
   };
   var onBeforeUnload = () => {
     running = false;
-    stopCamera();
+    void stopCamera();
   };
   var onResize = () => resizeOverlay();
   window.addEventListener("pagehide", onPageHide);
@@ -1423,7 +1425,7 @@
   function cleanup() {
     if (!running) return;
     running = false;
-    stopCamera();
+    void stopCamera();
     try {
       document.getElementById("tapToStart")?.remove();
     } catch (e) {

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1213,7 +1213,7 @@
           let outGesture = null;
           let outScore = 0;
           const perHand = [];
-          let multiHand = false;
+          let multiHand = (results?.landmarks?.length ?? 0) >= 2;
           const handedArr = (results?.handednesses || []).map((h) => h?.[0]?.categoryName || "unknown");
           if (results?.gestures?.length) {
             for (let i = 0; i < results.gestures.length; i++) {
@@ -1228,8 +1228,7 @@
                 }
               }
             }
-            multiHand = perHand.length >= 2;
-            if (multiHand) {
+            if (perHand.length >= 2) {
               let left = perHand.find((h) => /left/i.test(h.hand)) || null;
               let right = perHand.find((h) => /right/i.test(h.hand)) || null;
               if (!left || !right) {

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -69,16 +69,16 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
     modelTransferLock.current = true;
     queuedModelRef.current = false;
     const CHUNK = 64 * 1024;
+    const sanitized = b64
+      .replace(/\\/g, '\\\\')
+      .replace(/'/g, "\\'")
+      .replace(/\r?\n/g, '')
+      .replace(/\u2028|\u2029/g, '');
     webviewRef.current.injectJavaScript(
       'window.__beginMlpTransfer&&window.__beginMlpTransfer();',
     );
-    for (let i = 0; i < b64.length; i += CHUNK) {
-      const part = b64
-        .slice(i, i + CHUNK)
-        .replace(/\\/g, '\\\\')
-        .replace(/'/g, "\\'")
-        .replace(/\r?\n/g, '\\n')
-        .replace(/\u2028|\u2029/g, '');
+    for (let i = 0; i < sanitized.length; i += CHUNK) {
+      const part = sanitized.slice(i, i + CHUNK);
       webviewRef.current.injectJavaScript(
         `window.__pushMlpChunk&&window.__pushMlpChunk('${part}');`,
       );
@@ -140,6 +140,10 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
 
   useEffect(() => {
     return () => {
+      if (transferWatchdogRef.current) {
+        clearTimeout(transferWatchdogRef.current);
+        transferWatchdogRef.current = null;
+      }
       try {
         webviewRef.current?.injectJavaScript(
           'window.__cleanupGestureDetector&&window.__cleanupGestureDetector();',

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -69,18 +69,14 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
     modelTransferLock.current = true;
     queuedModelRef.current = false;
     const CHUNK = 64 * 1024;
-    const sanitized = b64
-      .replace(/\\/g, '\\\\')
-      .replace(/'/g, "\\'")
-      .replace(/\r?\n/g, '')
-      .replace(/\u2028|\u2029/g, '');
+    const normalized = b64.replace(/\r?\n/g, '');
     webviewRef.current.injectJavaScript(
       'window.__beginMlpTransfer&&window.__beginMlpTransfer();',
     );
-    for (let i = 0; i < sanitized.length; i += CHUNK) {
-      const part = sanitized.slice(i, i + CHUNK);
+    for (let i = 0; i < normalized.length; i += CHUNK) {
+      const part = normalized.slice(i, i + CHUNK);
       webviewRef.current.injectJavaScript(
-        `window.__pushMlpChunk&&window.__pushMlpChunk('${part}');`,
+        'window.__pushMlpChunk&&window.__pushMlpChunk(' + JSON.stringify(part) + ');',
       );
     }
     webviewRef.current.injectJavaScript(

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -69,7 +69,8 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
     modelTransferLock.current = true;
     queuedModelRef.current = false;
     const CHUNK = 64 * 1024;
-    const normalized = b64.replace(/\r?\n/g, '');
+    // Remove any non-base64 characters to keep the payload safe for injection
+    const normalized = b64.replace(/[^A-Za-z0-9+/=]/g, '');
     webviewRef.current.injectJavaScript(
       'window.__beginMlpTransfer&&window.__beginMlpTransfer();',
     );

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -246,7 +246,7 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
             let outGesture = null;
             let outScore = 0;
             const perHand: { hand: string; label: string; score: number }[] = [];
-            let multiHand = false;
+            let multiHand = ((results?.landmarks?.length ?? 0) >= 2);
             const handedArr = (results?.handednesses || []).map(h => (h?.[0]?.categoryName) || 'unknown');
             if (results?.gestures?.length) {
               for (let i = 0; i < results.gestures.length; i++) {
@@ -261,8 +261,7 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
                   }
                 }
               }
-              multiHand = perHand.length >= 2;
-              if (multiHand) {
+              if (perHand.length >= 2) {
                 let left = perHand.find(h => /left/i.test(h.hand)) || null;
                 let right = perHand.find(h => /right/i.test(h.hand)) || null;
                 if (!left || !right) {

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -417,12 +417,10 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
         });
     }
     createGestureRecognizer();
-    let stopping = false;
-    let stopOnce: Promise<void> | null = null;
+    let stopPromise: Promise<void> | null = null;
     async function stopCamera() {
-      if (stopping) return stopOnce!;
-      stopping = true;
-      stopOnce = (async () => {
+      if (stopPromise) return stopPromise;
+      stopPromise = (async () => {
         try {
           video.pause();
         } catch (e) {
@@ -453,9 +451,9 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
         }
         gestureRecognizer = null;
       })().finally(() => {
-        stopping = false;
+        stopPromise = null;
       });
-      return stopOnce;
+      return stopPromise;
     }
 
     const onPageHide = () => cleanup();

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -148,6 +148,8 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
     overlay.addEventListener('contextrestored', () => {
       // Ensure a fresh context can be obtained after restoration
       overlay.getContext('2d');
+      // Trigger a redraw immediately so the overlay doesn't stay blank
+      if (running) window.requestAnimationFrame(predictWebcam);
     });
     video.setAttribute('autoplay', '');
     video.setAttribute('playsinline', '');
@@ -257,8 +259,7 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
                   }
                 }
               }
-              multiHand =
-                perHand.length >= 2 || (results?.landmarks?.length ?? 0) >= 2;
+              multiHand = perHand.length >= 2;
               if (multiHand) {
                 let left = perHand.find(h => /left/i.test(h.hand)) || null;
                 let right = perHand.find(h => /right/i.test(h.hand)) || null;
@@ -414,7 +415,7 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
         });
     }
     createGestureRecognizer();
-    function stopCamera() {
+    async function stopCamera() {
       try {
         video.pause();
       } catch (e) {
@@ -438,15 +439,16 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
         console.warn('Fehler beim Stoppen des Kamerastreams:', e);
       }
       try {
-        gestureRecognizer?.close?.();
+        const res = gestureRecognizer?.close?.();
+        if (res && typeof (res as any).then === 'function') await res;
       } catch (e) {
         console.warn('Fehler beim Schließen des Gestenerkenners:', e);
       }
       gestureRecognizer = null;
     }
 
-    const onPageHide = () => { running = false; stopCamera(); };
-    const onBeforeUnload = () => { running = false; stopCamera(); };
+    const onPageHide = () => { running = false; void stopCamera(); };
+    const onBeforeUnload = () => { running = false; void stopCamera(); };
     const onResize = () => resizeOverlay();
     window.addEventListener('pagehide', onPageHide);
     window.addEventListener('beforeunload', onBeforeUnload);
@@ -455,7 +457,7 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
     function cleanup() {
       if (!running) return;
       running = false;
-      stopCamera();
+      void stopCamera();
       try {
         document.getElementById('tapToStart')?.remove();
       } catch (e) {

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -148,6 +148,7 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
     overlay.addEventListener('contextrestored', () => {
       // Ensure a fresh context can be obtained after restoration
       overlay.getContext('2d');
+      resizeOverlay();
       // Trigger a redraw immediately so the overlay doesn't stay blank
       if (running) window.requestAnimationFrame(predictWebcam);
     });
@@ -415,36 +416,45 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
         });
     }
     createGestureRecognizer();
+    let stopping = false;
+    let stopOnce: Promise<void> | null = null;
     async function stopCamera() {
-      try {
-        video.pause();
-      } catch (e) {
-        console.warn('Video konnte während des Aufräumens nicht pausiert werden:', e);
-      }
-      try {
-        video.removeEventListener('loadeddata', predictWebcam);
-      } catch (e) {
-        console.warn(
-          'Entfernen des "loadeddata"-Listeners während des Aufräumens fehlgeschlagen:',
-          e,
-        );
-      }
-      try {
-        const s = video.srcObject as MediaStream | null;
-        if (s) {
-          s.getTracks().forEach((t) => t.stop());
-          video.srcObject = null;
+      if (stopping) return stopOnce ?? Promise.resolve();
+      stopping = true;
+      stopOnce = (async () => {
+        try {
+          video.pause();
+        } catch (e) {
+          console.warn('Video konnte während des Aufräumens nicht pausiert werden:', e);
         }
-      } catch (e) {
-        console.warn('Fehler beim Stoppen des Kamerastreams:', e);
-      }
-      try {
-        const res = gestureRecognizer?.close?.();
-        if (res && typeof (res as any).then === 'function') await res;
-      } catch (e) {
-        console.warn('Fehler beim Schließen des Gestenerkenners:', e);
-      }
-      gestureRecognizer = null;
+        try {
+          video.removeEventListener('loadeddata', predictWebcam);
+        } catch (e) {
+          console.warn(
+            'Entfernen des "loadeddata"-Listeners während des Aufräumens fehlgeschlagen:',
+            e,
+          );
+        }
+        try {
+          const s = video.srcObject as MediaStream | null;
+          if (s) {
+            s.getTracks().forEach((t) => t.stop());
+            video.srcObject = null;
+          }
+        } catch (e) {
+          console.warn('Fehler beim Stoppen des Kamerastreams:', e);
+        }
+        try {
+          const res = gestureRecognizer?.close?.();
+          if (res && typeof (res as any).then === 'function') await res;
+        } catch (e) {
+          console.warn('Fehler beim Schließen des Gestenerkenners:', e);
+        }
+        gestureRecognizer = null;
+      })().finally(() => {
+        stopping = false;
+      });
+      return stopOnce;
     }
 
     const onPageHide = () => { running = false; void stopCamera(); };

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -217,6 +217,7 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
     let lastSentGesture = null;
     let lastSentScore = 0;
     let running = true;
+    let cleanedUp = false;
     const TARGET_FPS = 30;
     const MIN_FRAME_TIME = 1000 / TARGET_FPS;
     let lastFrameTs = 0;
@@ -419,7 +420,7 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
     let stopping = false;
     let stopOnce: Promise<void> | null = null;
     async function stopCamera() {
-      if (stopping) return stopOnce ?? Promise.resolve();
+      if (stopping) return stopOnce!;
       stopping = true;
       stopOnce = (async () => {
         try {
@@ -457,15 +458,16 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
       return stopOnce;
     }
 
-    const onPageHide = () => { running = false; void stopCamera(); };
-    const onBeforeUnload = () => { running = false; void stopCamera(); };
+    const onPageHide = () => cleanup();
+    const onBeforeUnload = () => cleanup();
     const onResize = () => resizeOverlay();
     window.addEventListener('pagehide', onPageHide);
     window.addEventListener('beforeunload', onBeforeUnload);
     window.addEventListener('resize', onResize);
 
     function cleanup() {
-      if (!running) return;
+      if (cleanedUp) return;
+      cleanedUp = true;
       running = false;
       void stopCamera();
       try {

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -456,18 +456,18 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
       return stopPromise;
     }
 
-    const onPageHide = () => cleanup();
-    const onBeforeUnload = () => cleanup();
+    const onPageHide = () => void cleanup();
+    const onBeforeUnload = () => void cleanup();
     const onResize = () => resizeOverlay();
     window.addEventListener('pagehide', onPageHide);
     window.addEventListener('beforeunload', onBeforeUnload);
     window.addEventListener('resize', onResize);
 
-    function cleanup() {
+    async function cleanup() {
       if (cleanedUp) return;
       cleanedUp = true;
       running = false;
-      void stopCamera();
+      await stopCamera();
       try {
         document.getElementById('tapToStart')?.remove();
       } catch (e) {


### PR DESCRIPTION
## Summary
- ensure overlay redraws after WebGL context restoration
- guard multi-hand fallback and await recognizer shutdown
- sanitize model chunks and clear transfer watchdog on unmount

## Testing
- `npm ci --prefix app`
- `npm run build:webview --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `npx expo-doctor` *(fails: requires confirmation)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b5df797b3c832292de7788fbe3a9b5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Restores overlay drawing after graphics context resets to prevent frozen visuals.
  - Improves multi-hand detection for more consistent gesture recognition.
  - Makes camera/gesture shutdown idempotent and asynchronous to reduce leaks, hangs, and rare crashes.
  - Sanitizes payloads and sends JSON-encoded chunks to avoid transmission/parse errors.
  - Clears watchdog timers on unmount to prevent lingering background activity.
  - Ensures cleanup emits a completion telemetry event after teardown.

- New Features
  - Adds a public cleanup hook to trigger detector cleanup from the host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->