### PR TITLE
Improve gesture detector error logging

### DIFF
--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -983,7 +983,8 @@
       window.ReactNativeWebView?.postMessage(
         JSON.stringify({ type: "error", message: e.message, file: e.filename, line: e.lineno, col: e.colno })
       );
-    } catch {
+    } catch (err2) {
+      console.warn("Fehler beim Weiterleiten des Fehlerereignisses:", err2);
     }
   });
   window.fflate = { unzip, unzipSync };
@@ -992,7 +993,8 @@
     window.ReactNativeWebView?.postMessage?.(
       JSON.stringify({ type: "telemetry", event: "mlp_ready" })
     );
-  } catch {
+  } catch (err2) {
+    console.warn("Fehler beim Senden des MLP-Bereit-Ereignisses:", err2);
   }
   var tapToStartText = window.__tapToStart || "";
   var recognizerInitFailed = window.__recognizerInitFailed || "Erkennung konnte nicht gestartet werden: ";
@@ -1019,7 +1021,8 @@
               return { base, version: v };
             }
           }
-        } catch {
+        } catch (err2) {
+          console.warn("Fehler beim Abrufen von", base, err2);
         }
       }
       return null;
@@ -1166,7 +1169,8 @@
       const initMs = Math.round(performance.now() - visionStart);
       try {
         window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: "telemetry", event: "recognizer_init", ms: initMs }));
-      } catch {
+      } catch (err2) {
+        console.warn("Fehler beim Senden des recognizer_init-Ereignisses:", err2);
       }
       video.addEventListener("loadeddata", predictWebcam);
     } catch (e) {
@@ -1174,7 +1178,8 @@
         window.ReactNativeWebView?.postMessage?.(
           JSON.stringify({ type: "error", message: recognizerInitFailed + (e instanceof Error ? e.message : String(e)) })
         );
-      } catch {
+      } catch (err2) {
+        console.warn("Fehler beim Senden der Initialisierungsfehlermeldung:", err2);
       }
     }
   }
@@ -1308,7 +1313,8 @@
               }
               ctx.restore();
             }
-          } catch {
+          } catch (err2) {
+            console.warn("Fehler beim Zeichnen der \xDCberlagerung:", err2);
           }
           const now = performance.now();
           const confidence = allLandmarks.length ? outScore : 0;
@@ -1327,7 +1333,8 @@
                   handednesses: handedArr
                 })
               );
-            } catch {
+            } catch (err2) {
+              console.warn("Fehler beim Senden der Gestenerkennung:", err2);
             }
           }
         }
@@ -1337,7 +1344,8 @@
         window.ReactNativeWebView?.postMessage?.(
           JSON.stringify({ type: "warn", message: predictionError + (e instanceof Error ? e.message : String(e)) })
         );
-      } catch {
+      } catch (err2) {
+        console.warn("Fehler beim Senden der Warnung:", err2);
       }
     }
     window.requestAnimationFrame(predictWebcam);
@@ -1350,7 +1358,8 @@
         overlay.width = w;
         overlay.height = h;
       }
-    } catch {
+    } catch (err2) {
+      console.warn("Fehler beim Anpassen der \xDCberlagerung:", err2);
     }
   }
   async function startCamera() {
@@ -1361,7 +1370,8 @@
         video.muted = true;
         await video.play();
         resizeOverlay();
-      } catch {
+      } catch (err2) {
+        console.warn("Fehler beim Starten des Videos:", err2);
       }
       const tracks = stream.getVideoTracks();
       window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: "telemetry", event: "camera_started", tracks: tracks.map((t) => t.label) }));

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -244,8 +244,8 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
               }),
             });
           }
-        } catch {
-          // ignore telemetry failures
+        } catch (e) {
+          console.warn('Fehler beim Senden der Telemetrie:', e);
         }
       }
     } catch (error) {
@@ -277,13 +277,17 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
         onConsoleMessage={(e: any) => {
           try {
             console.log('WV:', e.nativeEvent.message);
-          } catch {}
+          } catch (err) {
+            console.warn('Fehler beim Protokollieren der WebView-Nachricht:', err);
+          }
         }}
         onPermissionRequest={(event: any) => {
           try {
             const videoOnly = (event.nativeEvent.resources || []).filter((r: string) => r === 'VIDEO_CAPTURE');
             event.nativeEvent.grant(videoOnly);
-          } catch {}
+          } catch (err) {
+            console.warn('Fehler bei der Erteilung von Berechtigungen:', err);
+          }
         }}
       />
     </View>

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -12,7 +12,9 @@ window.addEventListener('error', (e) => {
     (window as any).ReactNativeWebView?.postMessage(
       JSON.stringify({ type: 'error', message: e.message, file: (e as any).filename, line: (e as any).lineno, col: (e as any).colno }),
     );
-  } catch {}
+  } catch (err) {
+    console.warn('Fehler beim Weiterleiten des Fehlerereignisses:', err);
+  }
 });
 
 (window as any).fflate = { unzip, unzipSync };
@@ -21,7 +23,9 @@ try {
   (window as any).ReactNativeWebView?.postMessage?.(
     JSON.stringify({ type: 'telemetry', event: 'mlp_ready' })
   );
-} catch {}
+} catch (err) {
+  console.warn('Fehler beim Senden des MLP-Bereit-Ereignisses:', err);
+}
 
 const tapToStartText = (window as any).__tapToStart || '';
 const recognizerInitFailed = (window as any).__recognizerInitFailed || 'Erkennung konnte nicht gestartet werden: ';
@@ -51,7 +55,9 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
                 return { base, version: v };
               }
             }
-          } catch {}
+          } catch (err) {
+            console.warn('Fehler beim Abrufen von', base, err);
+          }
         }
         return null;
       }
@@ -199,7 +205,9 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
         const initMs = Math.round(performance.now() - visionStart);
         try {
           window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: 'telemetry', event: 'recognizer_init', ms: initMs }));
-        } catch {}
+        } catch (err) {
+          console.warn('Fehler beim Senden des recognizer_init-Ereignisses:', err);
+        }
         // Start prediction loop after recognizer is created and video is loaded
         video.addEventListener('loadeddata', predictWebcam);
       } catch (e) {
@@ -207,7 +215,9 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
           window.ReactNativeWebView?.postMessage?.(
             JSON.stringify({ type: 'error', message: recognizerInitFailed + (e instanceof Error ? e.message : String(e)) })
           );
-        } catch {}
+        } catch (err) {
+          console.warn('Fehler beim Senden der Initialisierungsfehlermeldung:', err);
+        }
       }
     }
 
@@ -345,27 +355,31 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
                   }
                 }
                 ctx.restore();
-              }
-            } catch {}
+            }
+            } catch (err) {
+              console.warn('Fehler beim Zeichnen der Überlagerung:', err);
+            }
 
-              const now = performance.now();
-              const confidence = allLandmarks.length ? outScore : 0;
+            const now = performance.now();
+            const confidence = allLandmarks.length ? outScore : 0;
               const changed = outGesture !== lastSentGesture || Math.abs(confidence - lastSentScore) >= 0.05;
               if (changed || now - lastSentAt >= 100) {
                 lastSentGesture = outGesture;
                 lastSentScore = confidence;
                 lastSentAt = now;
                 try {
-                  window.ReactNativeWebView?.postMessage?.(
-                    JSON.stringify({
-                      type: 'gesture',
-                      gesture: outGesture || null,
-                      confidence,
-                      landmarks: allLandmarks,
-                      handednesses: handedArr,
-                    }),
-                  );
-                } catch {}
+                window.ReactNativeWebView?.postMessage?.(
+                  JSON.stringify({
+                    type: 'gesture',
+                    gesture: outGesture || null,
+                    confidence,
+                    landmarks: allLandmarks,
+                    handednesses: handedArr,
+                  }),
+                );
+                } catch (err) {
+                  console.warn('Fehler beim Senden der Gestenerkennung:', err);
+                }
               }
           }
         }
@@ -374,7 +388,9 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
           window.ReactNativeWebView?.postMessage?.(
             JSON.stringify({ type: 'warn', message: predictionError + (e instanceof Error ? e.message : String(e)) })
           );
-        } catch {}
+        } catch (err) {
+          console.warn('Fehler beim Senden der Warnung:', err);
+        }
       }
       window.requestAnimationFrame(predictWebcam);
     }
@@ -386,14 +402,18 @@ const FALLBACK_CONFIDENCE_THRESHOLD = (window as any).__fallbackThreshold ?? 0.5
         const w = video.clientWidth || window.innerWidth;
         const h = video.clientHeight || window.innerHeight;
         if (overlay.width !== w || overlay.height !== h) { overlay.width = w; overlay.height = h; }
-      } catch {}
+      } catch (err) {
+        console.warn('Fehler beim Anpassen der Überlagerung:', err);
+      }
     }
 
     async function startCamera() { // Renamed from start() for clarity
       try {
         const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: facingMode, width: { ideal: 1280 }, height: { ideal: 720 } }, audio: false });
         video.srcObject = stream;
-        try { video.muted = true; await video.play(); resizeOverlay(); } catch {}
+        try { video.muted = true; await video.play(); resizeOverlay(); } catch (err) {
+          console.warn('Fehler beim Starten des Videos:', err);
+        }
         const tracks = stream.getVideoTracks();
         window.ReactNativeWebView?.postMessage?.(JSON.stringify({ type: 'telemetry', event: 'camera_started', tracks: tracks.map(t=>t.label) }));
         // createGestureRecognizer will add the loadeddata listener


### PR DESCRIPTION
## Summary
- log telemetry send failures and WebView callbacks in `MediaPipeGestureDetector`
- replace silent catch blocks in WebView gesture detector with German `console.warn` messages
- rebuild gesture detector asset

## Testing
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `npm run type-check --prefix server`
- `npm test --prefix server`
- `npm test --prefix integration`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`

------
https://chatgpt.com/codex/tasks/task_e_68b5fae596a48322be4adcbcbe7429d4