### PR TITLE
Optimize gesture overlay resizing in webview

### DIFF
--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1476,14 +1476,17 @@
       const w = (rect.width || video.clientWidth || 0) | 0;
       const h = (rect.height || video.clientHeight || 0) | 0;
       const dpr = Math.max(1, window.devicePixelRatio || 1);
-      overlayDpr = dpr;
-      if (overlayWidth !== w || overlayHeight !== h) {
-        overlay.style.width = w + "px";
-        overlay.style.height = h + "px";
+      const dprChanged = dpr !== overlayDpr;
+      if (overlayWidth !== w || overlayHeight !== h || dprChanged) {
+        if (overlayWidth !== w || overlayHeight !== h) {
+          overlay.style.width = w + "px";
+          overlay.style.height = h + "px";
+        }
         overlay.width = Math.round(w * dpr);
         overlay.height = Math.round(h * dpr);
         overlayWidth = w;
         overlayHeight = h;
+        overlayDpr = dpr;
       }
       lastVideoWidth = video.videoWidth;
       lastVideoHeight = video.videoHeight;

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1173,12 +1173,16 @@
   var lastVideoHeight = 0;
   var overlayWidth = 0;
   var overlayHeight = 0;
+  var overlayDpr = 1;
+  var videoResizeObserver = null;
   video.setAttribute("autoplay", "");
   video.setAttribute("playsinline", "");
   video.setAttribute("muted", "");
   function initDom() {
     document.body.appendChild(video);
     document.body.appendChild(overlay);
+    videoResizeObserver = new ResizeObserver(() => resizeOverlay());
+    videoResizeObserver.observe(video);
     const tap = document.createElement("div");
     tap.id = "tapToStart";
     tap.innerText = tapToStartText;
@@ -1396,8 +1400,9 @@
           try {
             const ctx = overlay.getContext("2d");
             if (ctx) {
-              ctx.clearRect(0, 0, overlayWidth, overlayHeight);
+              ctx.clearRect(0, 0, overlay.width, overlay.height);
               ctx.save();
+              ctx.scale(overlayDpr, overlayDpr);
               if (mirrorOverlay) {
                 ctx.scale(-1, 1);
                 ctx.translate(-overlayWidth, 0);
@@ -1468,11 +1473,17 @@
   function resizeOverlay() {
     try {
       const rect = video.getBoundingClientRect();
-      const w = (rect.width || video.clientWidth || window.innerWidth) | 0;
-      const h = (rect.height || video.clientHeight || window.innerHeight) | 0;
+      const w = (rect.width || video.clientWidth || 0) | 0;
+      const h = (rect.height || video.clientHeight || 0) | 0;
+      const dpr = Math.max(1, window.devicePixelRatio || 1);
+      overlayDpr = dpr;
       if (overlayWidth !== w || overlayHeight !== h) {
-        overlay.width = overlayWidth = w;
-        overlay.height = overlayHeight = h;
+        overlay.style.width = w + "px";
+        overlay.style.height = h + "px";
+        overlay.width = Math.round(w * dpr);
+        overlay.height = Math.round(h * dpr);
+        overlayWidth = w;
+        overlayHeight = h;
       }
       lastVideoWidth = video.videoWidth;
       lastVideoHeight = video.videoHeight;
@@ -1593,6 +1604,8 @@
     cleanedUp = true;
     running = false;
     await stopCamera();
+    videoResizeObserver?.disconnect();
+    videoResizeObserver = null;
     try {
       document.getElementById("tapToStart")?.remove();
     } catch (e) {

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1182,6 +1182,10 @@
   function initDom() {
     document.body.appendChild(video);
     document.body.appendChild(overlay);
+    try {
+      resizeOverlay();
+    } catch {
+    }
     if (typeof ResizeObserver === "function") {
       videoResizeObserver = new ResizeObserver(() => resizeOverlay());
       videoResizeObserver.observe(video);
@@ -1406,7 +1410,7 @@
           }
           try {
             const ctx = overlay.getContext("2d");
-            if (ctx) {
+            if (ctx && overlayWidth && overlayHeight) {
               ctx.clearRect(0, 0, overlay.width, overlay.height);
               ctx.save();
               ctx.scale(overlayDpr, overlayDpr);
@@ -1483,9 +1487,10 @@
       const w = (rect.width || video.clientWidth || 0) | 0;
       const h = (rect.height || video.clientHeight || 0) | 0;
       const dpr = Math.max(1, window.devicePixelRatio || 1);
+      const sizeChanged = overlayWidth !== w || overlayHeight !== h;
       const dprChanged = dpr !== overlayDpr;
-      if (overlayWidth !== w || overlayHeight !== h || dprChanged) {
-        if (overlayWidth !== w || overlayHeight !== h) {
+      if (sizeChanged || dprChanged) {
+        if (sizeChanged) {
           overlay.style.width = w + "px";
           overlay.style.height = h + "px";
         }
@@ -1601,6 +1606,10 @@
     } else {
       running = true;
       lastFrameTs = 0;
+      try {
+        resizeOverlay();
+      } catch {
+      }
       window.requestAnimationFrame(predictWebcam);
     }
   };

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -3,7 +3,7 @@
 (() => {
   // node_modules/fflate/esm/browser.js
   var ch2 = {};
-  var wk = function(c, id, msg, transfer, cb) {
+  var wk = (function(c, id, msg, transfer, cb) {
     var w = new Worker(ch2[id] || (ch2[id] = URL.createObjectURL(new Blob([
       c + ';addEventListener("error",function(e){e=e.error;postMessage({$e$:[e.message,e.code,e.stack]})})'
     ], { type: "text/javascript" }))));
@@ -19,7 +19,7 @@
     };
     w.postMessage(msg, transfer);
     return w;
-  };
+  });
   var u8 = Uint8Array;
   var u16 = Uint16Array;
   var i32 = Int32Array;
@@ -124,7 +124,7 @@
   }
   var x;
   var i;
-  var hMap = function(cd, mb, r) {
+  var hMap = (function(cd, mb, r) {
     var s = cd.length;
     var i = 0;
     var l = new u16(mb);
@@ -159,7 +159,7 @@
       }
     }
     return co;
-  };
+  });
   var flt = new u8(288);
   for (i = 0; i < 144; ++i)
     flt[i] = 8;
@@ -1169,6 +1169,10 @@
   var video = document.createElement("video");
   var overlay = document.createElement("canvas");
   overlay.id = "overlay";
+  var lastVideoWidth = 0;
+  var lastVideoHeight = 0;
+  var overlayWidth = 0;
+  var overlayHeight = 0;
   video.setAttribute("autoplay", "");
   video.setAttribute("playsinline", "");
   video.setAttribute("muted", "");
@@ -1303,6 +1307,9 @@
       if (gestureRecognizer && video.currentTime > 0 && !video.paused && !video.ended) {
         if (lastVideoTime !== video.currentTime) {
           lastVideoTime = video.currentTime;
+          if (video.videoWidth !== lastVideoWidth || video.videoHeight !== lastVideoHeight) {
+            resizeOverlay();
+          }
           const start = performance.now();
           const results = gestureRecognizer.recognizeForVideo(video, start);
           const frameLatency = Math.round(performance.now() - start);
@@ -1387,14 +1394,13 @@
             }
           }
           try {
-            resizeOverlay();
             const ctx = overlay.getContext("2d");
             if (ctx) {
-              ctx.clearRect(0, 0, overlay.width, overlay.height);
+              ctx.clearRect(0, 0, overlayWidth, overlayHeight);
               ctx.save();
               if (mirrorOverlay) {
                 ctx.scale(-1, 1);
-                ctx.translate(-overlay.width, 0);
+                ctx.translate(-overlayWidth, 0);
               }
               ctx.lineWidth = 3;
               ctx.strokeStyle = "rgba(0, 255, 180, 0.9)";
@@ -1405,13 +1411,13 @@
                   const pa = hand[a];
                   const pb = hand[b];
                   if (!pa || !pb) continue;
-                  ctx.moveTo(pa.x * overlay.width, pa.y * overlay.height);
-                  ctx.lineTo(pb.x * overlay.width, pb.y * overlay.height);
+                  ctx.moveTo(pa.x * overlayWidth, pa.y * overlayHeight);
+                  ctx.lineTo(pb.x * overlayWidth, pb.y * overlayHeight);
                 }
                 ctx.stroke();
                 for (const lm of hand) {
                   ctx.beginPath();
-                  ctx.arc(lm.x * overlay.width, lm.y * overlay.height, 4, 0, Math.PI * 2);
+                  ctx.arc(lm.x * overlayWidth, lm.y * overlayHeight, 4, 0, Math.PI * 2);
                   ctx.fill();
                 }
               }
@@ -1464,10 +1470,12 @@
       const rect = video.getBoundingClientRect();
       const w = (rect.width || video.clientWidth || window.innerWidth) | 0;
       const h = (rect.height || video.clientHeight || window.innerHeight) | 0;
-      if (overlay.width !== w || overlay.height !== h) {
-        overlay.width = w;
-        overlay.height = h;
+      if (overlayWidth !== w || overlayHeight !== h) {
+        overlay.width = overlayWidth = w;
+        overlay.height = overlayHeight = h;
       }
+      lastVideoWidth = video.videoWidth;
+      lastVideoHeight = video.videoHeight;
     } catch (err2) {
       console.warn("Failed to resize overlay:", err2);
     }
@@ -1482,7 +1490,9 @@
       try {
         video.muted = true;
         await video.play();
-        resizeOverlay();
+        if (video.videoWidth !== lastVideoWidth || video.videoHeight !== lastVideoHeight) {
+          resizeOverlay();
+        }
       } catch (err2) {
         console.warn("Failed to start video:", err2);
         throw err2;

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1175,14 +1175,21 @@
   var overlayHeight = 0;
   var overlayDpr = 1;
   var videoResizeObserver = null;
+  var removeWindowResize = null;
   video.setAttribute("autoplay", "");
   video.setAttribute("playsinline", "");
   video.setAttribute("muted", "");
   function initDom() {
     document.body.appendChild(video);
     document.body.appendChild(overlay);
-    videoResizeObserver = new ResizeObserver(() => resizeOverlay());
-    videoResizeObserver.observe(video);
+    if (typeof ResizeObserver === "function") {
+      videoResizeObserver = new ResizeObserver(() => resizeOverlay());
+      videoResizeObserver.observe(video);
+    } else {
+      const onWinResize = () => resizeOverlay();
+      window.addEventListener("resize", onWinResize);
+      removeWindowResize = () => window.removeEventListener("resize", onWinResize);
+    }
     const tap = document.createElement("div");
     tap.id = "tapToStart";
     tap.innerText = tapToStartText;
@@ -1609,6 +1616,10 @@
       videoResizeObserver.disconnect();
     }
     videoResizeObserver = null;
+    if (removeWindowResize) {
+      removeWindowResize();
+      removeWindowResize = null;
+    }
     try {
       const tapEl = document.getElementById("tapToStart");
       if (tapEl) {

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1585,7 +1585,6 @@
   }
   var onPageHide = () => void cleanup();
   var onBeforeUnload = () => void cleanup();
-  var onResize = () => resizeOverlay();
   var onVisibilityChange = () => {
     if (document.hidden) {
       running = false;
@@ -1597,17 +1596,21 @@
   };
   window.addEventListener("pagehide", onPageHide);
   window.addEventListener("beforeunload", onBeforeUnload);
-  window.addEventListener("resize", onResize);
   document.addEventListener("visibilitychange", onVisibilityChange);
   async function cleanup() {
     if (cleanedUp) return;
     cleanedUp = true;
     running = false;
     await stopCamera();
-    videoResizeObserver?.disconnect();
+    if (videoResizeObserver) {
+      videoResizeObserver.disconnect();
+    }
     videoResizeObserver = null;
     try {
-      document.getElementById("tapToStart")?.remove();
+      const tapEl = document.getElementById("tapToStart");
+      if (tapEl) {
+        tapEl.remove();
+      }
     } catch (e) {
       console.warn("Failed to remove 'tapToStart' element:", e);
     }
@@ -1623,7 +1626,6 @@
     }
     window.removeEventListener("pagehide", onPageHide);
     window.removeEventListener("beforeunload", onBeforeUnload);
-    window.removeEventListener("resize", onResize);
     window.removeEventListener("error", onError);
     window.removeEventListener("unhandledrejection", onUnhandledRejection);
     document.removeEventListener("visibilitychange", onVisibilityChange);

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -702,7 +702,7 @@ const onVisibilityChange = () => {
     running = true;
     lastFrameTs = 0;
     // Ensure overlay matches current layout/DPR after tab visibility changes
-    try { resizeOverlay(); } catch {}
+    try { resizeOverlay(); } catch (e) { console.warn('Resize on visibility change failed:', e); }
     window.requestAnimationFrame(predictWebcam);
   }
 };

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -683,7 +683,6 @@ async function stopCamera() {
 
 const onPageHide = () => void cleanup();
 const onBeforeUnload = () => void cleanup();
-const onResize = () => resizeOverlay();
 const onVisibilityChange = () => {
   if (document.hidden) {
     running = false;
@@ -695,7 +694,6 @@ const onVisibilityChange = () => {
 };
 window.addEventListener('pagehide', onPageHide);
 window.addEventListener('beforeunload', onBeforeUnload);
-window.addEventListener('resize', onResize);
 document.addEventListener('visibilitychange', onVisibilityChange);
 
 async function cleanup() {
@@ -703,10 +701,15 @@ async function cleanup() {
   cleanedUp = true;
   running = false;
   await stopCamera();
-  videoResizeObserver?.disconnect();
+  if (videoResizeObserver) {
+    videoResizeObserver.disconnect();
+  }
   videoResizeObserver = null;
   try {
-    document.getElementById('tapToStart')?.remove();
+    const tapEl = document.getElementById('tapToStart');
+    if (tapEl) {
+      tapEl.remove();
+    }
   } catch (e) {
     console.warn("Failed to remove 'tapToStart' element:", e);
   }
@@ -722,7 +725,6 @@ async function cleanup() {
   }
   window.removeEventListener('pagehide', onPageHide);
   window.removeEventListener('beforeunload', onBeforeUnload);
-  window.removeEventListener('resize', onResize);
   window.removeEventListener('error', onError);
   window.removeEventListener('unhandledrejection', onUnhandledRejection);
   document.removeEventListener('visibilitychange', onVisibilityChange);

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -237,6 +237,7 @@ video.setAttribute('muted', '');
 function initDom() {
   document.body.appendChild(video);
   document.body.appendChild(overlay);
+  try { resizeOverlay(); } catch {}
   if (typeof ResizeObserver === 'function') {
     videoResizeObserver = new ResizeObserver(() => resizeOverlay());
     videoResizeObserver.observe(video);
@@ -478,7 +479,7 @@ function predictWebcam() {
         // Draw overlay landmarks
         try {
           const ctx = overlay.getContext('2d');
-          if (ctx) {
+          if (ctx && overlayWidth && overlayHeight) {
             ctx.clearRect(0, 0, overlay.width, overlay.height);
             ctx.save();
             // Draw in CSS pixels while canvas is scaled for HiDPI
@@ -570,9 +571,10 @@ function resizeOverlay() {
     const w = (rect.width || video.clientWidth || 0) | 0;
     const h = (rect.height || video.clientHeight || 0) | 0;
     const dpr = Math.max(1, window.devicePixelRatio || 1);
+    const sizeChanged = overlayWidth !== w || overlayHeight !== h;
     const dprChanged = dpr !== overlayDpr;
-    if (overlayWidth !== w || overlayHeight !== h || dprChanged) {
-      if (overlayWidth !== w || overlayHeight !== h) {
+    if (sizeChanged || dprChanged) {
+      if (sizeChanged) {
         overlay.style.width = w + 'px';
         overlay.style.height = h + 'px';
       }
@@ -699,6 +701,8 @@ const onVisibilityChange = () => {
   } else {
     running = true;
     lastFrameTs = 0;
+    // Ensure overlay matches current layout/DPR after tab visibility changes
+    try { resizeOverlay(); } catch {}
     window.requestAnimationFrame(predictWebcam);
   }
 };

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -224,6 +224,10 @@ let runningMode = 'VIDEO';
 const video = document.createElement('video');
 const overlay = document.createElement('canvas');
 overlay.id = 'overlay';
+let lastVideoWidth = 0;
+let lastVideoHeight = 0;
+let overlayWidth = 0;
+let overlayHeight = 0;
 video.setAttribute('autoplay', '');
 video.setAttribute('playsinline', '');
 video.setAttribute('muted', '');
@@ -364,6 +368,12 @@ function predictWebcam() {
       if (lastVideoTime !== video.currentTime) {
         // Only process if video frame has changed
         lastVideoTime = video.currentTime;
+        if (
+          video.videoWidth !== lastVideoWidth ||
+          video.videoHeight !== lastVideoHeight
+        ) {
+          resizeOverlay();
+        }
         const start = performance.now();
         const results = gestureRecognizer.recognizeForVideo(video, start);
         const frameLatency = Math.round(performance.now() - start);
@@ -456,15 +466,14 @@ function predictWebcam() {
         }
         // Draw overlay landmarks
         try {
-          resizeOverlay();
           const ctx = overlay.getContext('2d');
           if (ctx) {
-            ctx.clearRect(0, 0, overlay.width, overlay.height);
+            ctx.clearRect(0, 0, overlayWidth, overlayHeight);
             ctx.save();
             // Mirror horizontally to match video when using the front camera
             if (mirrorOverlay) {
               ctx.scale(-1, 1);
-              ctx.translate(-overlay.width, 0);
+              ctx.translate(-overlayWidth, 0);
             }
             ctx.lineWidth = 3;
             ctx.strokeStyle = 'rgba(0, 255, 180, 0.9)';
@@ -476,14 +485,14 @@ function predictWebcam() {
                 const pa = hand[a];
                 const pb = hand[b];
                 if (!pa || !pb) continue;
-                ctx.moveTo(pa.x * overlay.width, pa.y * overlay.height);
-                ctx.lineTo(pb.x * overlay.width, pb.y * overlay.height);
+                ctx.moveTo(pa.x * overlayWidth, pa.y * overlayHeight);
+                ctx.lineTo(pb.x * overlayWidth, pb.y * overlayHeight);
               }
               ctx.stroke();
               // points
               for (const lm of hand) {
                 ctx.beginPath();
-                ctx.arc(lm.x * overlay.width, lm.y * overlay.height, 4, 0, Math.PI * 2);
+                ctx.arc(lm.x * overlayWidth, lm.y * overlayHeight, 4, 0, Math.PI * 2);
                 ctx.fill();
               }
             }
@@ -547,10 +556,12 @@ function resizeOverlay() {
     const rect = video.getBoundingClientRect();
     const w = (rect.width || video.clientWidth || window.innerWidth) | 0;
     const h = (rect.height || video.clientHeight || window.innerHeight) | 0;
-    if (overlay.width !== w || overlay.height !== h) {
-      overlay.width = w;
-      overlay.height = h;
+    if (overlayWidth !== w || overlayHeight !== h) {
+      overlay.width = overlayWidth = w;
+      overlay.height = overlayHeight = h;
     }
+    lastVideoWidth = video.videoWidth;
+    lastVideoHeight = video.videoHeight;
   } catch (err) {
     console.warn('Failed to resize overlay:', err);
   }
@@ -567,7 +578,12 @@ async function startCamera() {
     try {
       video.muted = true;
       await video.play();
-      resizeOverlay();
+      if (
+        video.videoWidth !== lastVideoWidth ||
+        video.videoHeight !== lastVideoHeight
+      ) {
+        resizeOverlay();
+      }
     } catch (err) {
       console.warn('Failed to start video:', err);
       throw err;

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -563,14 +563,17 @@ function resizeOverlay() {
     const w = (rect.width || video.clientWidth || 0) | 0;
     const h = (rect.height || video.clientHeight || 0) | 0;
     const dpr = Math.max(1, window.devicePixelRatio || 1);
-    overlayDpr = dpr;
-    if (overlayWidth !== w || overlayHeight !== h) {
-      overlay.style.width = w + 'px';
-      overlay.style.height = h + 'px';
+    const dprChanged = dpr !== overlayDpr;
+    if (overlayWidth !== w || overlayHeight !== h || dprChanged) {
+      if (overlayWidth !== w || overlayHeight !== h) {
+        overlay.style.width = w + 'px';
+        overlay.style.height = h + 'px';
+      }
       overlay.width = Math.round(w * dpr);
       overlay.height = Math.round(h * dpr);
       overlayWidth = w;
       overlayHeight = h;
+      overlayDpr = dpr;
     }
     lastVideoWidth = video.videoWidth;
     lastVideoHeight = video.videoHeight;

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -237,7 +237,7 @@ video.setAttribute('muted', '');
 function initDom() {
   document.body.appendChild(video);
   document.body.appendChild(overlay);
-  try { resizeOverlay(); } catch {}
+  try { resizeOverlay(); } catch (e) { console.warn('Initial resize failed:', e); }
   if (typeof ResizeObserver === 'function') {
     videoResizeObserver = new ResizeObserver(() => resizeOverlay());
     videoResizeObserver.observe(video);

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -228,12 +228,16 @@ let lastVideoWidth = 0;
 let lastVideoHeight = 0;
 let overlayWidth = 0;
 let overlayHeight = 0;
+let overlayDpr = 1;
+let videoResizeObserver: ResizeObserver | null = null;
 video.setAttribute('autoplay', '');
 video.setAttribute('playsinline', '');
 video.setAttribute('muted', '');
 function initDom() {
   document.body.appendChild(video);
   document.body.appendChild(overlay);
+  videoResizeObserver = new ResizeObserver(() => resizeOverlay());
+  videoResizeObserver.observe(video);
   const tap = document.createElement('div');
   tap.id = 'tapToStart';
   tap.innerText = tapToStartText;
@@ -468,8 +472,10 @@ function predictWebcam() {
         try {
           const ctx = overlay.getContext('2d');
           if (ctx) {
-            ctx.clearRect(0, 0, overlayWidth, overlayHeight);
+            ctx.clearRect(0, 0, overlay.width, overlay.height);
             ctx.save();
+            // Draw in CSS pixels while canvas is scaled for HiDPI
+            ctx.scale(overlayDpr, overlayDpr);
             // Mirror horizontally to match video when using the front camera
             if (mirrorOverlay) {
               ctx.scale(-1, 1);
@@ -554,11 +560,17 @@ function predictWebcam() {
 function resizeOverlay() {
   try {
     const rect = video.getBoundingClientRect();
-    const w = (rect.width || video.clientWidth || window.innerWidth) | 0;
-    const h = (rect.height || video.clientHeight || window.innerHeight) | 0;
+    const w = (rect.width || video.clientWidth || 0) | 0;
+    const h = (rect.height || video.clientHeight || 0) | 0;
+    const dpr = Math.max(1, window.devicePixelRatio || 1);
+    overlayDpr = dpr;
     if (overlayWidth !== w || overlayHeight !== h) {
-      overlay.width = overlayWidth = w;
-      overlay.height = overlayHeight = h;
+      overlay.style.width = w + 'px';
+      overlay.style.height = h + 'px';
+      overlay.width = Math.round(w * dpr);
+      overlay.height = Math.round(h * dpr);
+      overlayWidth = w;
+      overlayHeight = h;
     }
     lastVideoWidth = video.videoWidth;
     lastVideoHeight = video.videoHeight;
@@ -691,6 +703,8 @@ async function cleanup() {
   cleanedUp = true;
   running = false;
   await stopCamera();
+  videoResizeObserver?.disconnect();
+  videoResizeObserver = null;
   try {
     document.getElementById('tapToStart')?.remove();
   } catch (e) {

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -230,14 +230,21 @@ let overlayWidth = 0;
 let overlayHeight = 0;
 let overlayDpr = 1;
 let videoResizeObserver: ResizeObserver | null = null;
+let removeWindowResize: (() => void) | null = null;
 video.setAttribute('autoplay', '');
 video.setAttribute('playsinline', '');
 video.setAttribute('muted', '');
 function initDom() {
   document.body.appendChild(video);
   document.body.appendChild(overlay);
-  videoResizeObserver = new ResizeObserver(() => resizeOverlay());
-  videoResizeObserver.observe(video);
+  if (typeof ResizeObserver === 'function') {
+    videoResizeObserver = new ResizeObserver(() => resizeOverlay());
+    videoResizeObserver.observe(video);
+  } else {
+    const onWinResize = () => resizeOverlay();
+    window.addEventListener('resize', onWinResize);
+    removeWindowResize = () => window.removeEventListener('resize', onWinResize);
+  }
   const tap = document.createElement('div');
   tap.id = 'tapToStart';
   tap.innerText = tapToStartText;
@@ -708,6 +715,10 @@ async function cleanup() {
     videoResizeObserver.disconnect();
   }
   videoResizeObserver = null;
+  if (removeWindowResize) {
+    removeWindowResize();
+    removeWindowResize = null;
+  }
   try {
     const tapEl = document.getElementById('tapToStart');
     if (tapEl) {


### PR DESCRIPTION
## Summary
- cache video and overlay dimensions in gesture detector
- resize overlay only on window resize or dimension change

## Testing
- `npm ci --prefix app`
- `npm run build:webview --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b85e78c9d48322af0a930b54846483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overlay now tracks video size and device pixel ratio for HiDPI-aware rendering, stable placement, mirroring, and transforms; resize logic moved to an observer-first approach with a fallback.

* **Bug Fixes**
  * Avoids redundant resizes during frame processing and improves cleanup to reliably remove overlay/video/tap UI, improving responsiveness and stability.

* **New Features**
  * Added global APIs to support incremental model/data transfer for external integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->