### PR TITLE
feat: await MLP model transfer

### DIFF
--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -928,12 +928,21 @@
       const start = transferStart;
       try {
         if (active) {
-          const loadPromise = window.__setMlpModelB64?.(transferBuf);
+          if (!window.__setMlpModelB64) {
+            window.ReactNativeWebView?.postMessage?.(
+              JSON.stringify({
+                type: "telemetry",
+                event: "mlp_transfer_failed",
+                reason: "setter_missing"
+              })
+            );
+            return;
+          }
           const ms = Math.round(performance.now() - start);
           window.ReactNativeWebView?.postMessage?.(
             JSON.stringify({ type: "telemetry", event: "mlp_transfer", bytes, ms })
           );
-          if (loadPromise) await loadPromise;
+          await window.__setMlpModelB64(transferBuf);
         } else {
           window.ReactNativeWebView?.postMessage?.(
             JSON.stringify({ type: "telemetry", event: "mlp_transfer_skipped" })

--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -894,18 +894,18 @@
       const label = mlp.labels?.[bestI] ?? String(bestI);
       return { label, score: best };
     }
-    window.__setMlpModelB64 = (b64) => {
-      loadMlpFromB64(b64).then((ok) => {
-        if (ok) {
-          try {
-            window.ReactNativeWebView?.postMessage?.(
-              JSON.stringify({ type: "telemetry", event: "mlp_loaded" })
-            );
-          } catch (e) {
-            console.warn("Failed to send 'mlp_loaded' telemetry event:", e);
-          }
+    window.__setMlpModelB64 = async (b64) => {
+      const ok = await loadMlpFromB64(b64);
+      if (ok) {
+        try {
+          window.ReactNativeWebView?.postMessage?.(
+            JSON.stringify({ type: "telemetry", event: "mlp_loaded" })
+          );
+        } catch (e) {
+          console.warn("Failed to send 'mlp_loaded' telemetry event:", e);
         }
-      });
+      }
+      return ok;
     };
     window.__mlpPredict = mlpPredict;
     let transferBuf = "";
@@ -922,17 +922,18 @@
       if (!transferLock) return;
       transferBuf += chunk;
     };
-    window.__commitMlpTransfer = () => {
+    window.__commitMlpTransfer = async () => {
       const active = transferLock;
       const bytes = transferBuf.length;
       const start = transferStart;
       try {
         if (active) {
-          window.__setMlpModelB64?.(transferBuf);
+          const loadPromise = window.__setMlpModelB64?.(transferBuf);
           const ms = Math.round(performance.now() - start);
           window.ReactNativeWebView?.postMessage?.(
             JSON.stringify({ type: "telemetry", event: "mlp_transfer", bytes, ms })
           );
+          if (loadPromise) await loadPromise;
         } else {
           window.ReactNativeWebView?.postMessage?.(
             JSON.stringify({ type: "telemetry", event: "mlp_transfer_skipped" })
@@ -1184,7 +1185,8 @@
     document.body.appendChild(overlay);
     try {
       resizeOverlay();
-    } catch {
+    } catch (e) {
+      console.warn("Initial resize failed:", e);
     }
     if (typeof ResizeObserver === "function") {
       videoResizeObserver = new ResizeObserver(() => resizeOverlay());
@@ -1608,7 +1610,8 @@
       lastFrameTs = 0;
       try {
         resizeOverlay();
-      } catch {
+      } catch (e) {
+        console.warn("Resize on visibility change failed:", e);
       }
       window.requestAnimationFrame(predictWebcam);
     }

--- a/app/src/declarations.d.ts
+++ b/app/src/declarations.d.ts
@@ -39,8 +39,8 @@ declare global {
     __cleanupGestureDetector?: () => void;
     __beginMlpTransfer?: () => boolean;
     __pushMlpChunk?: (chunk: string) => void;
-    __commitMlpTransfer?: () => void;
-    __setMlpModelB64?: (b64: string) => void;
+    __commitMlpTransfer?: () => Promise<void>;
+    __setMlpModelB64?: (b64: string) => Promise<boolean>;
     fflate?: { unzip: typeof unzip; unzipSync: typeof unzipSync };
   }
 }

--- a/app/src/webview/installMlp.ts
+++ b/app/src/webview/installMlp.ts
@@ -292,12 +292,21 @@ export function installMlp() {
     const start = transferStart;
     try {
       if (active) {
-        const loadPromise = window.__setMlpModelB64?.(transferBuf);
+        if (!window.__setMlpModelB64) {
+          window.ReactNativeWebView?.postMessage?.(
+            JSON.stringify({
+              type: 'telemetry',
+              event: 'mlp_transfer_failed',
+              reason: 'setter_missing',
+            }),
+          );
+          return;
+        }
         const ms = Math.round(performance.now() - start);
         window.ReactNativeWebView?.postMessage?.(
           JSON.stringify({ type: 'telemetry', event: 'mlp_transfer', bytes, ms })
         );
-        if (loadPromise) await loadPromise;
+        await window.__setMlpModelB64(transferBuf);
       } else {
         window.ReactNativeWebView?.postMessage?.(
           JSON.stringify({ type: 'telemetry', event: 'mlp_transfer_skipped' })

--- a/app/src/webview/installMlp.ts
+++ b/app/src/webview/installMlp.ts
@@ -258,18 +258,18 @@ export function installMlp() {
     const label = mlp.labels?.[bestI] ?? String(bestI);
     return { label, score: best };
   }
-  window.__setMlpModelB64 = (b64: string) => {
-    loadMlpFromB64(b64).then((ok) => {
-      if (ok) {
-        try {
-          window.ReactNativeWebView?.postMessage?.(
-            JSON.stringify({ type: 'telemetry', event: 'mlp_loaded' })
-          );
-        } catch (e) {
-          console.warn("Failed to send 'mlp_loaded' telemetry event:", e);
-        }
+  window.__setMlpModelB64 = async (b64: string) => {
+    const ok = await loadMlpFromB64(b64);
+    if (ok) {
+      try {
+        window.ReactNativeWebView?.postMessage?.(
+          JSON.stringify({ type: 'telemetry', event: 'mlp_loaded' })
+        );
+      } catch (e) {
+        console.warn("Failed to send 'mlp_loaded' telemetry event:", e);
       }
-    });
+    }
+    return ok;
   };
   window.__mlpPredict = mlpPredict as any;
   let transferBuf = '';
@@ -286,17 +286,18 @@ export function installMlp() {
     if (!transferLock) return;
     transferBuf += chunk;
   };
-  window.__commitMlpTransfer = () => {
+  window.__commitMlpTransfer = async () => {
     const active = transferLock;
     const bytes = transferBuf.length;
     const start = transferStart;
     try {
       if (active) {
-        window.__setMlpModelB64?.(transferBuf);
+        const loadPromise = window.__setMlpModelB64?.(transferBuf);
         const ms = Math.round(performance.now() - start);
         window.ReactNativeWebView?.postMessage?.(
           JSON.stringify({ type: 'telemetry', event: 'mlp_transfer', bytes, ms })
         );
+        if (loadPromise) await loadPromise;
       } else {
         window.ReactNativeWebView?.postMessage?.(
           JSON.stringify({ type: 'telemetry', event: 'mlp_transfer_skipped' })

--- a/app/test/installMlp.test.ts
+++ b/app/test/installMlp.test.ts
@@ -97,4 +97,23 @@ describe('installMlp', () => {
       window.__mlpPredict!([TEST_HAND], [[{ categoryName: 'Left' }]])
     ).toBeNull();
   });
+
+  it('reports transfer failure when loader missing', async () => {
+    expect(window.__beginMlpTransfer!()).toBe(true);
+    window.__pushMlpChunk!(MINIMAL_MLP_ZIP_B64);
+    // Simulate loader removal before commit
+    (window as any).__setMlpModelB64 = undefined;
+    await window.__commitMlpTransfer!();
+
+    const messages = postMessage.mock.calls.map((c) => JSON.parse(c[0]));
+    expect(messages.map((m) => m.event)).toEqual([
+      'mlp_transfer_failed',
+      'mlp_transfer_complete',
+    ]);
+    const msg = messages.find((m) => m.event === 'mlp_transfer_failed')!;
+    expect(msg.reason).toBe('setter_missing');
+    expect(
+      window.__mlpPredict!([TEST_HAND], [[{ categoryName: 'Left' }]])
+    ).toBeNull();
+  });
 });

--- a/app/test/installMlp.test.ts
+++ b/app/test/installMlp.test.ts
@@ -25,8 +25,8 @@ describe('installMlp', () => {
     } as any;
     expect(postMessage).not.toHaveBeenCalled();
 
-    await window.__setMlpModelB64!('YQ==');
-    await Promise.resolve();
+    const success = await window.__setMlpModelB64!('YQ==');
+    expect(success).toBe(false);
     expect(postMessage).toHaveBeenCalledTimes(1);
     const msg = JSON.parse(postMessage.mock.calls[0][0]);
     expect(msg.event).toBe('mlp_load_failed');
@@ -34,9 +34,9 @@ describe('installMlp', () => {
   });
 
   it('loads minimal model and predicts', async () => {
-    window.__setMlpModelB64!(MINIMAL_MLP_ZIP_B64);
-    await new Promise((r) => setImmediate(r));
+    const success = await window.__setMlpModelB64!(MINIMAL_MLP_ZIP_B64);
 
+    expect(success).toBe(true);
     expect(postMessage).toHaveBeenCalledTimes(1);
     const evt = JSON.parse(postMessage.mock.calls[0][0]);
     expect(evt.event).toBe('mlp_loaded');
@@ -51,14 +51,13 @@ describe('installMlp', () => {
     const mid = Math.floor(MINIMAL_MLP_ZIP_B64.length / 2);
     window.__pushMlpChunk!(MINIMAL_MLP_ZIP_B64.slice(0, mid));
     window.__pushMlpChunk!(MINIMAL_MLP_ZIP_B64.slice(mid));
-    window.__commitMlpTransfer!();
-    await new Promise((r) => setImmediate(r));
+    await window.__commitMlpTransfer!();
 
     const events = postMessage.mock.calls.map((c) => JSON.parse(c[0]).event);
     expect(events).toEqual([
       'mlp_transfer',
-      'mlp_transfer_complete',
       'mlp_loaded',
+      'mlp_transfer_complete',
     ]);
 
     const res = window.__mlpPredict!([TEST_HAND], [[{ categoryName: 'Left' }]]);
@@ -75,25 +74,23 @@ describe('installMlp', () => {
     );
     const oversizeB64 = Buffer.from(oversizeZip).toString('base64');
     window.__pushMlpChunk!(oversizeB64);
-    window.__commitMlpTransfer!();
-    await new Promise((r) => setImmediate(r));
+    await window.__commitMlpTransfer!();
 
-    const events = postMessage.mock.calls.map((c) => JSON.parse(c[0]).event);
-    expect(events).toEqual([
+    const messages = postMessage.mock.calls.map((c) => JSON.parse(c[0]));
+    expect(messages.map((m) => m.event)).toEqual([
       'mlp_transfer',
-      'mlp_transfer_complete',
       'mlp_load_failed',
+      'mlp_transfer_complete',
     ]);
-    const last = postMessage.mock.calls[postMessage.mock.calls.length - 1];
-    const msg = JSON.parse(last[0]);
+    const msg = messages.find((m) => m.event === 'mlp_load_failed')!;
     expect(msg.reason).toMatch(/too many entries/);
     expect(
       window.__mlpPredict!([TEST_HAND], [[{ categoryName: 'Left' }]])
     ).toBeNull();
   });
 
-  it('skips commit when transfer not begun', () => {
-    window.__commitMlpTransfer!();
+  it('skips commit when transfer not begun', async () => {
+    await window.__commitMlpTransfer!();
     const events = postMessage.mock.calls.map((c) => JSON.parse(c[0]).event);
     expect(events).toEqual(['mlp_transfer_skipped', 'mlp_transfer_complete']);
     expect(

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -42,6 +42,7 @@ window.addEventListener('unhandledrejection', onUnhandledRejection);
 
 // Expose fflate for compatibility with older WebView bundles
 window.fflate = { unzip, unzipSync };
+// Install MLP helpers; model transfer functions now return Promises
 installMlp();
 try {
   window.ReactNativeWebView?.postMessage?.(


### PR DESCRIPTION
## Summary
- return a Promise from `window.__setMlpModelB64`
- await model load before completing transfer telemetry
- regenerate gestureDetector bundle from TypeScript source
- clarify in gestureDetector.ts that model transfer helpers return Promises
- return load result from `window.__setMlpModelB64`

## Testing
- `npm run build:webview --prefix app`
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx expo-doctor)` *(fails: needs install)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b8a92940908322923b764350971f05

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Model loading and transfer now run asynchronously and return explicit success indicators.

- Bug Fixes
  - Improved error handling and telemetry: clearer failure reasons (including missing loader), guaranteed completion events, skipped-transfer reporting, and additional warnings on telemetry failures.
  
- Documentation
  - Note added that model transfer helpers return Promises.

- Tests
  - Updated to await async model operations, assert boolean outcomes, and verify revised event ordering and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->