### PR TITLE
feat: await MLP model transfer

### DIFF
--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -894,18 +894,18 @@
       const label = mlp.labels?.[bestI] ?? String(bestI);
       return { label, score: best };
     }
-    window.__setMlpModelB64 = (b64) => {
-      loadMlpFromB64(b64).then((ok) => {
-        if (ok) {
-          try {
-            window.ReactNativeWebView?.postMessage?.(
-              JSON.stringify({ type: "telemetry", event: "mlp_loaded" })
-            );
-          } catch (e) {
-            console.warn("Failed to send 'mlp_loaded' telemetry event:", e);
-          }
+    window.__setMlpModelB64 = async (b64) => {
+      const ok = await loadMlpFromB64(b64);
+      if (ok) {
+        try {
+          window.ReactNativeWebView?.postMessage?.(
+            JSON.stringify({ type: "telemetry", event: "mlp_loaded" })
+          );
+        } catch (e) {
+          console.warn("Failed to send 'mlp_loaded' telemetry event:", e);
         }
-      });
+      }
+      return ok;
     };
     window.__mlpPredict = mlpPredict;
     let transferBuf = "";
@@ -922,21 +922,58 @@
       if (!transferLock) return;
       transferBuf += chunk;
     };
-    window.__commitMlpTransfer = () => {
+    window.__commitMlpTransfer = async () => {
       const active = transferLock;
       const bytes = transferBuf.length;
       const start = transferStart;
       try {
         if (active) {
-          window.__setMlpModelB64?.(transferBuf);
+          if (typeof window.__setMlpModelB64 !== "function") {
+            try {
+              window.ReactNativeWebView?.postMessage?.(
+                JSON.stringify({
+                  type: "telemetry",
+                  event: "mlp_transfer_failed",
+                  reason: "setter_missing"
+                })
+              );
+            } catch (e) {
+              console.warn(
+                "Failed to send 'mlp_transfer_failed' telemetry event:",
+                e
+              );
+            }
+            return;
+          }
+          const loadPromise = window.__setMlpModelB64(transferBuf);
           const ms = Math.round(performance.now() - start);
-          window.ReactNativeWebView?.postMessage?.(
-            JSON.stringify({ type: "telemetry", event: "mlp_transfer", bytes, ms })
-          );
+          try {
+            window.ReactNativeWebView?.postMessage?.(
+              JSON.stringify({
+                type: "telemetry",
+                event: "mlp_transfer",
+                bytes,
+                ms
+              })
+            );
+          } catch (e) {
+            console.warn("Failed to send 'mlp_transfer' telemetry event:", e);
+          }
+          await loadPromise;
         } else {
-          window.ReactNativeWebView?.postMessage?.(
-            JSON.stringify({ type: "telemetry", event: "mlp_transfer_skipped" })
-          );
+          try {
+            window.ReactNativeWebView?.postMessage?.(
+              JSON.stringify({
+                type: "telemetry",
+                event: "mlp_transfer_skipped"
+              })
+            );
+          } catch (e) {
+            console.warn(
+              "Failed to send 'mlp_transfer_skipped' telemetry event:",
+              e
+            );
+          }
         }
       } catch (err2) {
         console.warn("mlp_transfer failed:", err2);
@@ -946,7 +983,10 @@
         transferLock = false;
         try {
           window.ReactNativeWebView?.postMessage?.(
-            JSON.stringify({ type: "telemetry", event: "mlp_transfer_complete" })
+            JSON.stringify({
+              type: "telemetry",
+              event: "mlp_transfer_complete"
+            })
           );
         } catch (e) {
           console.warn(

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -28,6 +28,7 @@
         "react-native-gesture-handler": "2.24.0",
         "react-native-reanimated": "3.17.4",
         "react-native-safe-area-context": "5.4.0",
+        "react-native-screens": "~4.11.1",
         "react-native-svg": "15.11.2",
         "react-native-webview": "13.13.5"
       },
@@ -10085,6 +10086,18 @@
         }
       }
     },
+    "node_modules/react-freeze": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
+      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -10215,6 +10228,21 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
       "integrity": "sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-screens": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.11.1.tgz",
+      "integrity": "sha512-F0zOzRVa3ptZfLpD0J8ROdo+y1fEPw+VBFq1MTY/iyDu08al7qFUO5hLMd+EYMda5VXGaTFCa8q7bOppUszhJw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-freeze": "^1.0.0",
+        "react-native-is-edge-to-edge": "^1.1.7",
+        "warn-once": "^0.1.0"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,8 @@
     "react-native-reanimated": "3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-svg": "15.11.2",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "react-native-screens": "~4.11.1"
   },
   "devDependencies": {
     "@babel/core": "7.28.3",

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -81,7 +81,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
       );
     }
     webviewRef.current.injectJavaScript(
-      'window.__commitMlpTransfer&&window.__commitMlpTransfer();',
+      '(async()=>{window.__commitMlpTransfer&&await window.__commitMlpTransfer();})();',
     );
     if (transferWatchdogRef.current) clearTimeout(transferWatchdogRef.current);
     transferWatchdogRef.current = setTimeout(() => {

--- a/app/src/declarations.d.ts
+++ b/app/src/declarations.d.ts
@@ -39,8 +39,8 @@ declare global {
     __cleanupGestureDetector?: () => void;
     __beginMlpTransfer?: () => boolean;
     __pushMlpChunk?: (chunk: string) => void;
-    __commitMlpTransfer?: () => void;
-    __setMlpModelB64?: (b64: string) => void;
+    __commitMlpTransfer?: () => Promise<void>;
+    __setMlpModelB64?: (b64: string) => Promise<boolean>;
     fflate?: { unzip: typeof unzip; unzipSync: typeof unzipSync };
   }
 }

--- a/app/src/webview/installMlp.ts
+++ b/app/src/webview/installMlp.ts
@@ -258,18 +258,18 @@ export function installMlp() {
     const label = mlp.labels?.[bestI] ?? String(bestI);
     return { label, score: best };
   }
-  window.__setMlpModelB64 = (b64: string) => {
-    loadMlpFromB64(b64).then((ok) => {
-      if (ok) {
-        try {
-          window.ReactNativeWebView?.postMessage?.(
-            JSON.stringify({ type: 'telemetry', event: 'mlp_loaded' })
-          );
-        } catch (e) {
-          console.warn("Failed to send 'mlp_loaded' telemetry event:", e);
-        }
+  window.__setMlpModelB64 = async (b64: string) => {
+    const ok = await loadMlpFromB64(b64);
+    if (ok) {
+      try {
+        window.ReactNativeWebView?.postMessage?.(
+          JSON.stringify({ type: 'telemetry', event: 'mlp_loaded' })
+        );
+      } catch (e) {
+        console.warn("Failed to send 'mlp_loaded' telemetry event:", e);
       }
-    });
+    }
+    return ok;
   };
   window.__mlpPredict = mlpPredict as any;
   let transferBuf = '';
@@ -286,21 +286,58 @@ export function installMlp() {
     if (!transferLock) return;
     transferBuf += chunk;
   };
-  window.__commitMlpTransfer = () => {
+  window.__commitMlpTransfer = async () => {
     const active = transferLock;
     const bytes = transferBuf.length;
     const start = transferStart;
     try {
       if (active) {
-        window.__setMlpModelB64?.(transferBuf);
+        if (typeof window.__setMlpModelB64 !== 'function') {
+          try {
+            window.ReactNativeWebView?.postMessage?.(
+              JSON.stringify({
+                type: 'telemetry',
+                event: 'mlp_transfer_failed',
+                reason: 'setter_missing',
+              }),
+            );
+          } catch (e) {
+            console.warn(
+              "Failed to send 'mlp_transfer_failed' telemetry event:",
+              e,
+            );
+          }
+          return;
+        }
+        const loadPromise = window.__setMlpModelB64(transferBuf);
         const ms = Math.round(performance.now() - start);
-        window.ReactNativeWebView?.postMessage?.(
-          JSON.stringify({ type: 'telemetry', event: 'mlp_transfer', bytes, ms })
-        );
+        try {
+          window.ReactNativeWebView?.postMessage?.(
+            JSON.stringify({
+              type: 'telemetry',
+              event: 'mlp_transfer',
+              bytes,
+              ms,
+            }),
+          );
+        } catch (e) {
+          console.warn("Failed to send 'mlp_transfer' telemetry event:", e);
+        }
+        await loadPromise;
       } else {
-        window.ReactNativeWebView?.postMessage?.(
-          JSON.stringify({ type: 'telemetry', event: 'mlp_transfer_skipped' })
-        );
+        try {
+          window.ReactNativeWebView?.postMessage?.(
+            JSON.stringify({
+              type: 'telemetry',
+              event: 'mlp_transfer_skipped',
+            }),
+          );
+        } catch (e) {
+          console.warn(
+            "Failed to send 'mlp_transfer_skipped' telemetry event:",
+            e,
+          );
+        }
       }
     } catch (err) {
       console.warn('mlp_transfer failed:', err);
@@ -310,7 +347,10 @@ export function installMlp() {
       transferLock = false;
       try {
         window.ReactNativeWebView?.postMessage?.(
-          JSON.stringify({ type: 'telemetry', event: 'mlp_transfer_complete' }),
+          JSON.stringify({
+            type: 'telemetry',
+            event: 'mlp_transfer_complete',
+          }),
         );
       } catch (e) {
         console.warn(

--- a/app/test/installMlp.test.ts
+++ b/app/test/installMlp.test.ts
@@ -34,9 +34,8 @@ describe('installMlp', () => {
   });
 
   it('loads minimal model and predicts', async () => {
-    window.__setMlpModelB64!(MINIMAL_MLP_ZIP_B64);
-    await new Promise((r) => setImmediate(r));
-
+    const ok = await window.__setMlpModelB64!(MINIMAL_MLP_ZIP_B64);
+    expect(ok).toBe(true);
     expect(postMessage).toHaveBeenCalledTimes(1);
     const evt = JSON.parse(postMessage.mock.calls[0][0]);
     expect(evt.event).toBe('mlp_loaded');
@@ -51,15 +50,10 @@ describe('installMlp', () => {
     const mid = Math.floor(MINIMAL_MLP_ZIP_B64.length / 2);
     window.__pushMlpChunk!(MINIMAL_MLP_ZIP_B64.slice(0, mid));
     window.__pushMlpChunk!(MINIMAL_MLP_ZIP_B64.slice(mid));
-    window.__commitMlpTransfer!();
-    await new Promise((r) => setImmediate(r));
+    await window.__commitMlpTransfer!();
 
     const events = postMessage.mock.calls.map((c) => JSON.parse(c[0]).event);
-    expect(events).toEqual([
-      'mlp_transfer',
-      'mlp_transfer_complete',
-      'mlp_loaded',
-    ]);
+    expect(events).toEqual(['mlp_transfer', 'mlp_loaded', 'mlp_transfer_complete']);
 
     const res = window.__mlpPredict!([TEST_HAND], [[{ categoryName: 'Left' }]]);
     expect(res?.label).toBe('hi');
@@ -75,27 +69,38 @@ describe('installMlp', () => {
     );
     const oversizeB64 = Buffer.from(oversizeZip).toString('base64');
     window.__pushMlpChunk!(oversizeB64);
-    window.__commitMlpTransfer!();
-    await new Promise((r) => setImmediate(r));
+    await window.__commitMlpTransfer!();
 
     const events = postMessage.mock.calls.map((c) => JSON.parse(c[0]).event);
-    expect(events).toEqual([
-      'mlp_transfer',
-      'mlp_transfer_complete',
-      'mlp_load_failed',
-    ]);
-    const last = postMessage.mock.calls[postMessage.mock.calls.length - 1];
-    const msg = JSON.parse(last[0]);
+    expect(events).toEqual(['mlp_transfer', 'mlp_load_failed', 'mlp_transfer_complete']);
+    const failCall = postMessage.mock.calls.find((c) => JSON.parse(c[0]).event === 'mlp_load_failed')!;
+    const msg = JSON.parse(failCall[0]);
     expect(msg.reason).toMatch(/too many entries/);
     expect(
       window.__mlpPredict!([TEST_HAND], [[{ categoryName: 'Left' }]])
     ).toBeNull();
   });
 
-  it('skips commit when transfer not begun', () => {
-    window.__commitMlpTransfer!();
+  it('skips commit when transfer not begun', async () => {
+    await window.__commitMlpTransfer!();
     const events = postMessage.mock.calls.map((c) => JSON.parse(c[0]).event);
     expect(events).toEqual(['mlp_transfer_skipped', 'mlp_transfer_complete']);
+    expect(
+      window.__mlpPredict!([TEST_HAND], [[{ categoryName: 'Left' }]])
+    ).toBeNull();
+  });
+
+  it('reports missing loader', async () => {
+    expect(window.__beginMlpTransfer!()).toBe(true);
+    window.__pushMlpChunk!(MINIMAL_MLP_ZIP_B64);
+    // simulate missing loader
+    // @ts-ignore
+    delete window.__setMlpModelB64;
+    await window.__commitMlpTransfer!();
+    const events = postMessage.mock.calls.map((c) => JSON.parse(c[0]).event);
+    expect(events).toEqual(['mlp_transfer_failed', 'mlp_transfer_complete']);
+    const msg = JSON.parse(postMessage.mock.calls[0][0]);
+    expect(msg.reason).toBe('setter_missing');
     expect(
       window.__mlpPredict!([TEST_HAND], [[{ categoryName: 'Left' }]])
     ).toBeNull();


### PR DESCRIPTION
## Summary
- expose `__setMlpModelB64` and `__commitMlpTransfer` as promise-returning helpers
- await model transfer when injecting to the webview
- expand MLP transfer tests for new event ordering and missing loader case

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx --yes expo-doctor)` *(fails: Check Expo config (app.json/ app.config.js) schema; missing peer dependency react-native-screens; check that native modules use compatible support package versions for installed Expo SDK; Validate packages against React Native Directory package metadata)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b8d210eb8083229a28b40b22923a60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of on-device model loading and transfer, with proper cleanup and completion signals even after errors.
  - Gracefully handles missing loaders and oversized transfers with clearer error feedback.

- Refactor
  - Migrated model loading and transfer to an asynchronous workflow for smoother, more responsive behavior.
  - Hardened telemetry emissions with safer error handling.

- Chores
  - Added react-native-screens to enhance screen performance and transitions.

- Tests
  - Updated test suite to validate the new async flow, event ordering, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->