### PR TITLE
refactor: structure multi-hand gesture output

### DIFF
--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1343,7 +1343,7 @@
   var lastVideoTime = -1;
   var frameCount = 0;
   var lastSentAt = 0;
-  var lastSentGesture = null;
+  var lastSentGestureSerialized = null;
   var lastSentScore = 0;
   var running = true;
   var cleanedUp = false;
@@ -1411,7 +1411,7 @@
                 if (!right) right = others.shift() || null;
               }
               if (left && right) {
-                outGesture = left.label + "+" + right.label;
+                outGesture = { left: left.label, right: right.label };
                 outScore = Math.sqrt(left.score * right.score);
               }
             }
@@ -1486,15 +1486,16 @@
           const now = performance.now();
           const confidence = allLandmarks.length ? outScore : 0;
           const isTick = now - lastSentAt >= 100;
-          const changed = outGesture !== lastSentGesture || Math.abs(confidence - lastSentScore) >= 0.05;
+          const serializedGesture = outGesture === null ? null : typeof outGesture === "string" ? outGesture : JSON.stringify(outGesture);
+          const changed = serializedGesture !== lastSentGestureSerialized || Math.abs(confidence - lastSentScore) >= 0.05;
           if (changed || isTick) {
-            lastSentGesture = outGesture;
+            lastSentGestureSerialized = serializedGesture;
             lastSentScore = confidence;
             lastSentAt = now;
             try {
               const payload = {
                 type: "gesture",
-                gesture: outGesture || null,
+                gesture: outGesture,
                 confidence
               };
               if (changed) {

--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -196,7 +196,17 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({ onGestureDetected, o
       const data = JSON.parse(event.nativeEvent.data);
       
       if (data.type === 'gesture') {
-        onGestureDetected(data.gesture, data.confidence, data.landmarks, data.handednesses || []);
+        const g = data.gesture;
+        let gesture: string | null;
+        if (Array.isArray(g)) {
+          gesture = g.join('+');
+        } else if (g && typeof g === 'object') {
+          const { left, right } = g as { left?: string; right?: string };
+          gesture = left && right ? `${left}+${right}` : null;
+        } else {
+          gesture = g;
+        }
+        onGestureDetected(gesture, data.confidence, data.landmarks, data.handednesses || []);
       } else if (data.type === 'error') {
         console.error('WebView error:', data.message);
         onError(data.message);

--- a/app/test/MediaPipeGestureDetector.test.tsx
+++ b/app/test/MediaPipeGestureDetector.test.tsx
@@ -84,6 +84,41 @@ describe('MediaPipeGestureDetector', () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it('parses structured two-hand gestures', () => {
+    const onGestureDetected = jest.fn();
+    const onError = jest.fn();
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <MediaPipeGestureDetector onGestureDetected={onGestureDetected} onError={onError} />,
+      );
+    });
+
+    const webview = (component as renderer.ReactTestRenderer).root.findByType('mock-webview');
+    act(() => {
+      webview.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({
+            type: 'gesture',
+            gesture: { left: 'open_palm', right: 'fist' },
+            confidence: 0.8,
+            landmarks: [[[1, 2, 3]]],
+            handednesses: ['Left', 'Right'],
+          }),
+        },
+      });
+    });
+
+    expect(onGestureDetected).toHaveBeenCalledWith(
+      'open_palm+fist',
+      0.8,
+      [[[1, 2, 3]]],
+      ['Left', 'Right'],
+    );
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it('logs and forwards error messages from the WebView', () => {
     const onGestureDetected = jest.fn();
     const onError = jest.fn();

--- a/app/webview/gestureDetector.ts
+++ b/app/webview/gestureDetector.ts
@@ -358,7 +358,7 @@ async function createGestureRecognizer() {
 let lastVideoTime = -1; // Added for performance optimization
 let frameCount = 0;
 let lastSentAt = 0;
-let lastSentGesture = null;
+let lastSentGestureSerialized: string | null = null;
 let lastSentScore = 0;
 let running = true;
 let cleanedUp = false;
@@ -402,7 +402,7 @@ function predictWebcam() {
         const allLandmarks = (results?.landmarks || []).map((hand) =>
           hand.map((lm) => [lm.x, lm.y, lm.z ?? 0]),
         );
-        let outGesture = null;
+        let outGesture: string | { left: string; right: string } | null = null;
         let outScore = 0;
         const perHand: { hand: string; label: string; score: number }[] = [];
         let multiHand = (results?.landmarks?.length ?? 0) >= 2;
@@ -431,7 +431,7 @@ function predictWebcam() {
               if (!right) right = others.shift() || null;
             }
             if (left && right) {
-              outGesture = left.label + '+' + right.label;
+              outGesture = { left: left.label, right: right.label };
               // Geometric mean keeps confidence conservative without over-penalizing
               outScore = Math.sqrt(left.score * right.score);
             }
@@ -519,22 +519,29 @@ function predictWebcam() {
         const now = performance.now();
         const confidence = allLandmarks.length ? outScore : 0;
         const isTick = now - lastSentAt >= 100;
+        const serializedGesture =
+          outGesture === null
+            ? null
+            : typeof outGesture === 'string'
+            ? outGesture
+            : JSON.stringify(outGesture);
         const changed =
-          outGesture !== lastSentGesture || Math.abs(confidence - lastSentScore) >= 0.05;
+          serializedGesture !== lastSentGestureSerialized ||
+          Math.abs(confidence - lastSentScore) >= 0.05;
         if (changed || isTick) {
-          lastSentGesture = outGesture;
+          lastSentGestureSerialized = serializedGesture;
           lastSentScore = confidence;
           lastSentAt = now;
           try {
             const payload: {
               type: 'gesture';
-              gesture: string | null;
+              gesture: string | { left: string; right: string } | null;
               confidence: number;
               landmarks?: number[][][];
               handednesses?: string[];
             } = {
               type: 'gesture',
-              gesture: outGesture || null,
+              gesture: outGesture,
               confidence,
             };
             if (changed) {

--- a/server/db.json
+++ b/server/db.json
@@ -22,7 +22,7 @@
   "gestureDefinitions": [],
   "gestureTrainingData": [
     {
-      "id": "mf07cvwdosk31lxrz",
+      "id": "mf5297gydniww1oebx5",
       "gestureDefinitionId": "hello",
       "landmarkData": [
         1,
@@ -56,25 +56,25 @@
   ],
   "vocabularySetSymbols": [
     {
-      "id": "mf07cvmbeelgdytc9x8",
+      "id": "mf52978lfdnbrtf8zp8",
       "vocabularySetId": "basic",
       "symbolId": "hello"
     },
     {
-      "id": "mf07cvmcv3r4c76ruz",
+      "id": "mf52978m1lgf60sgpww",
       "vocabularySetId": "basic",
       "symbolId": "drink"
     }
   ],
   "usageStats": [
     {
-      "id": "mf07cvmcv2vmkr4qsj",
+      "id": "mf52978mzlzf17c67ln",
       "symbolId": "hello",
       "profileId": "default",
       "count": 0
     },
     {
-      "id": "mf07cvmcqb0o8alf247",
+      "id": "mf52978mjvcwk0kdv9n",
       "symbolId": "drink",
       "profileId": "default",
       "count": 0

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -451,17 +451,33 @@ app.post('/api/crash-reports', auth, async (req: Request, res: Response) => {
   }
 });
 
+const gestureToString = (g: unknown): string | null => {
+  if (typeof g === 'string') return g;
+  if (Array.isArray(g) && g.every((p) => typeof p === 'string')) {
+    return g.join('+');
+  }
+  if (g && typeof g === 'object') {
+    const left = (g as any).left;
+    const right = (g as any).right;
+    if (typeof left === 'string' && typeof right === 'string') {
+      return `${left}+${right}`;
+    }
+  }
+  return null;
+};
+
 app.post('/api/corrections', auth, async (req: Request, res: Response) => {
   const { gesture } = req.body || {};
-  if (typeof gesture !== 'string') {
+  const gestureStr = gestureToString(gesture);
+  if (!gestureStr) {
     return res.status(400).json({ error: 'Invalid correction' });
   }
   try {
-    logCorrection(dbInstance, 'unknown', gesture, null);
+    logCorrection(dbInstance, 'unknown', gestureStr, null);
     const record: Correction = {
       id: genId(),
-      predictedGesture: 'unknown', 
-      actualGesture: gesture,
+      predictedGesture: 'unknown',
+      actualGesture: gestureStr,
       confidence: 0,
       timestamp: Date.now(),
       isSynced: false,
@@ -476,23 +492,24 @@ app.post('/api/corrections', auth, async (req: Request, res: Response) => {
 });
 
 app.post('/api/negative-samples', auth, async (req: Request, res: Response) => {
-    const { gesture } = req.body || {};
-    if (typeof gesture !== 'string') {
-        return res.status(400).json({ error: 'Invalid negative sample' });
-    }
-    try {
-        const record: NegativeSample = {
-            id: genId(),
-            gesture,
-            timestamp: Date.now(),
-        };
-        addNegativeSample(dbInstance, record);
-        await saveDatabase(dbInstance, DB_FILE_PATH);
-        res.status(202).json({ status: 'queued' });
-    } catch (error) {
-        console.error('Error logging negative sample:', error);
-        res.status(500).json({ error: 'Failed to log negative sample' });
-    }
+  const { gesture } = req.body || {};
+  const gestureStr = gestureToString(gesture);
+  if (!gestureStr) {
+    return res.status(400).json({ error: 'Invalid negative sample' });
+  }
+  try {
+    const record: NegativeSample = {
+      id: genId(),
+      gesture: gestureStr,
+      timestamp: Date.now(),
+    };
+    addNegativeSample(dbInstance, record);
+    await saveDatabase(dbInstance, DB_FILE_PATH);
+    res.status(202).json({ status: 'queued' });
+  } catch (error) {
+    console.error('Error logging negative sample:', error);
+    res.status(500).json({ error: 'Failed to log negative sample' });
+  }
 });
 
 app.post('/dialog', auth, dialogLimiter, async (req: Request, res: Response) => {

--- a/server/test/test_training_queue.py
+++ b/server/test/test_training_queue.py
@@ -60,7 +60,7 @@ def stop_server(proc):
 
 def post_correction():
     url = f'http://localhost:{PORT}/api/corrections'
-    payload = json.dumps({"gesture": "wave"}).encode('utf-8')
+    payload = json.dumps({"gesture": ["wave", "fist"]}).encode('utf-8')
     headers = {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer testtoken',


### PR DESCRIPTION
## Summary
- represent simultaneous left/right gestures as a structured object and serialize for change detection
- parse structured gesture payloads from the WebView before invoking callbacks
- test dual-hand gesture parsing and rebuild the WebView bundle
- accept structured gesture payloads on the server for corrections and negative samples

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx --yes expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b9344cb25c8322a070f2bd1de3441e