### PR TITLE
perf: avoid redundant recognition path updates

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -185,7 +185,11 @@ export default function RecognitionScreen({
     let c = confidence;
     let path: RecognitionPath = 'local';
 
-    if (centroidsRef.current && (!g || c < OFFLINE_CLASSIFIER_TRIGGER_THRESHOLD)) {
+    if (
+      centroidsRef.current &&
+      Object.keys(centroidsRef.current).length > 0 &&
+      (!g || c < OFFLINE_CLASSIFIER_TRIGGER_THRESHOLD)
+    ) {
       const flat = flattenHandsWithHandedness(landmarks, handedness);
       const pts: Point[] = flat.map(([x, y, z]) => [x, y, z ?? 0] as Point);
       const res = classifyWithCentroids(pts, centroidsRef.current);
@@ -195,9 +199,7 @@ export default function RecognitionScreen({
         path = 'centroid';
       }
     }
-    if (path !== recognitionPath) {
-      setRecognitionPath(path);
-    }
+    setRecognitionPath((prev) => (prev === path ? prev : path));
 
     // Helper to apply a classification to UI + logs
     const handleOutcome = async (
@@ -321,7 +323,7 @@ export default function RecognitionScreen({
 
     // On-device classification only: use provided or locally-classified gesture
     await handleOutcome(g || 'unknown', c, path);
-  }, [dialogContext, startFeedbackAnimation, lastRecognizedGesture, screenReaderEnabled, recognitionPath]);
+  }, [dialogContext, startFeedbackAnimation, lastRecognizedGesture, screenReaderEnabled]);
 
   const handleGestureError = useCallback((errorMessage: string) => {
     // Avoid flooding the UI; only surface critical init/camera errors
@@ -469,7 +471,9 @@ export default function RecognitionScreen({
             {lastRecognizedGesture.label}
           </Animated.Text>
           <Text style={styles.gestureText}>{(gestureConfidence * 100).toFixed(0)}%</Text>
-          <Text style={styles.confidenceText}>via {recognitionPath}</Text>
+          <Text style={styles.confidenceText} testID="recognition-path">
+            via {recognitionPath}
+          </Text>
         </Animated.View>
       )}
 

--- a/app/test/screens/RecognitionScreen.test.tsx
+++ b/app/test/screens/RecognitionScreen.test.tsx
@@ -91,6 +91,9 @@ jest.mock('../../src/context/MessageContext', () => ({
 jest.mock('../../src/services/dgsModelClient', () => ({
   onMlpModelUpdated: jest.fn(() => () => {}),
 }));
+jest.mock('../../src/services/localCentroids', () => ({
+  buildLocalCentroids: jest.fn().mockResolvedValue({ foo: [[0, 0, 0]] }),
+}));
 const mockClassifyWithCentroids = jest.fn();
 jest.mock('../../src/services/offlineClassifier', () => ({
   classifyWithCentroids: (...args: any[]) => mockClassifyWithCentroids(...args),
@@ -202,17 +205,17 @@ describe('RecognitionScreen', () => {
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,
       );
     });
+    await act(async () => {});
     const detector = component.root.findByType('MediaPipeGestureDetector');
     await act(async () => {
       mockClassifyWithCentroids.mockReturnValue({ label: 'hello', confidence: 0.95 });
       await detector.props.onGestureDetected(null, 0.1, [], []);
     });
-    const pathNode = component.root
-      .findAllByType('Text')
-      .find(
-        (n) => Array.isArray(n.props.children) && n.props.children.join('') === 'via centroid',
-      );
-    expect(pathNode).toBeTruthy();
+    const pathNode = component.root.findByProps({ testID: 'recognition-path' });
+    const txt = Array.isArray(pathNode.props.children)
+      ? pathNode.props.children.join(' ')
+      : String(pathNode.props.children);
+    expect(txt.trim().toLowerCase()).toContain('centroid');
   });
 
   it('shows celebration when gesture recognized with high confidence', async () => {


### PR DESCRIPTION
## Summary
- avoid redundant recognition path state updates in RecognitionScreen to cut re-renders
- add tests covering centroid fallback classification

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `npx expo install --check` in `app`
- `npx --yes expo-doctor` in `app` *(fails: fetch failed)*
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68b9c5d008d08322899e9be456f6a417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognition screen now indicates when centroid-based classification is used as a fallback.

* **Bug Fixes**
  * Prevented centroid fallback when no centroids are available.
  * Reduced redundant recognition path updates to avoid unnecessary UI re-renders.
  * Added a test-accessible identifier for the recognition path text.

* **Tests**
  * Added tests covering centroid-fallback behavior under low-confidence detections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->