### PR TITLE
Add tests for sync service reliability

### DIFF
--- a/app/test/screens/RecognitionScreen.test.tsx
+++ b/app/test/screens/RecognitionScreen.test.tsx
@@ -104,15 +104,24 @@ jest.mock('../../src/services/handUtils', () => ({
 }));
 
 describe('RecognitionScreen', () => {
+  let component: renderer.ReactTestRenderer | null;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockClassifyWithCentroids.mockReset();
     mockClassifyWithCentroids.mockReturnValue(null);
+    component = null;
+  });
+
+  afterEach(() => {
+    if (component) {
+      act(() => component!.unmount());
+      component = null;
+    }
   });
 
   it('navigates to Correction screen when correction button is pressed', async () => {
     const navigate = jest.fn();
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate } as any} />,
@@ -127,7 +136,6 @@ describe('RecognitionScreen', () => {
 
   it('navigates to Teaching screen when teach button is pressed', async () => {
     const navigate = jest.fn();
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate } as any} />,
@@ -141,7 +149,6 @@ describe('RecognitionScreen', () => {
   });
 
   it('shows correction panel when help-me-choose button is pressed', async () => {
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,
@@ -156,7 +163,6 @@ describe('RecognitionScreen', () => {
   });
 
   it('exposes correction button accessibility label', async () => {
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,
@@ -167,7 +173,6 @@ describe('RecognitionScreen', () => {
   });
 
   it('provides positive feedback for all gesture attempts (Amy optimization)', async () => {
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,
@@ -184,7 +189,6 @@ describe('RecognitionScreen', () => {
   });
 
   it('shows DGS video when toggle enabled and gesture recognized', async () => {
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,
@@ -203,7 +207,6 @@ describe('RecognitionScreen', () => {
   });
 
   it('falls back to centroid classification when local detection is uncertain', async () => {
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,
@@ -223,7 +226,6 @@ describe('RecognitionScreen', () => {
   });
 
   it('shows celebration when gesture recognized with high confidence', async () => {
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,
@@ -242,7 +244,6 @@ describe('RecognitionScreen', () => {
   });
 
   it('does not spam celebration for repeated gestures', async () => {
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,
@@ -260,7 +261,6 @@ describe('RecognitionScreen', () => {
   });
 
   it('prioritizes emergency gestures immediately', async () => {
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,
@@ -275,7 +275,6 @@ describe('RecognitionScreen', () => {
   });
 
   it('processes every gesture immediately (Amy optimization - no throttling)', async () => {
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <RecognitionScreen navigation={{ navigate: jest.fn() } as any} />,

--- a/app/test/screens/TrainingScreen.test.tsx
+++ b/app/test/screens/TrainingScreen.test.tsx
@@ -71,9 +71,16 @@ jest.mock('react-native-svg', () => ({
 import TrainingScreen from '../../src/screens/TrainingScreen';
 
 describe('TrainingScreen', () => {
+  let component: renderer.ReactTestRenderer;
+
+  afterEach(() => {
+    act(() => {
+      component.unmount();
+    });
+  });
+
   it('records landmarks via MediaPipe gesture detector', async () => {
     const { saveTrainingSample } = require('../../src/storage');
-    let component!: renderer.ReactTestRenderer;
     await act(async () => {
       component = renderer.create(
         <TrainingScreen navigation={{ goBack: jest.fn() }} route={{ params: { gestureLabel: 'hello' } }} /> as any,

--- a/app/test/syncService.test.ts
+++ b/app/test/syncService.test.ts
@@ -28,10 +28,22 @@ jest.mock('../src/services/modelUpdate', () => ({
   refreshDgsModel: jest.fn(async () => 'centroid'),
 }));
 
+jest.mock('../src/telemetry/recorder', () => ({
+  telemetry: { dump: jest.fn(async () => []) },
+}));
+
+jest.mock('../src/services/analytics', () => ({
+  uploadTelemetry: jest.fn(async () => {})
+}));
+
 import { syncService } from '../src/services/syncService';
 import { refreshDgsModel } from '../src/services/modelUpdate';
+import { loadProfile } from '../src/storage';
+import { telemetry } from '../src/telemetry/recorder';
+import { uploadTelemetry } from '../src/services/analytics';
 
 beforeEach(() => {
+  jest.clearAllMocks();
   const sample: {
     landmarkData: string;
     gestureDefinition: { id: string };
@@ -52,7 +64,8 @@ beforeEach(() => {
   });
   mockDatabase.write.mockImplementation(async (fn: any) => { await fn(); });
   (global as any).fetch = jest.fn(async () => ({ ok: true }));
-  jest.clearAllMocks();
+  (telemetry.dump as jest.Mock).mockResolvedValue([]);
+  (uploadTelemetry as jest.Mock).mockResolvedValue(undefined);
 });
 
 describe('syncService.uploadPendingTrainingData', () => {
@@ -79,6 +92,73 @@ describe('syncService.uploadPendingTrainingData', () => {
     expect(mockDatabase.write).not.toHaveBeenCalled();
     expect(refreshDgsModel).not.toHaveBeenCalled();
   }, 10000);
+
+  it('retries transient failures before succeeding', async () => {
+    const timeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((fn: any) => {
+        fn();
+        return 0 as any;
+      });
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'fail' })
+      .mockResolvedValueOnce({ ok: true });
+    await syncService.uploadPendingTrainingData();
+    timeoutSpy.mockRestore();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(mockSamples[0].customSyncStatus).toBe('synced');
+  });
+
+  it('prevents concurrent uploads', async () => {
+    const spy = jest.spyOn(syncService as any, '_performUpload');
+    const p1 = syncService.uploadPendingTrainingData();
+    const p2 = syncService.uploadPendingTrainingData();
+    await Promise.all([p1, p2]);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info).toHaveBeenCalledWith('Upload already in progress, skipping...');
+    spy.mockRestore();
+  });
 });
 
+describe('consent caching', () => {
+  it('caches consent status with TTL', async () => {
+    jest.useFakeTimers();
+    mockSamples = [];
+    mockDatabase.get.mockReturnValue({
+      query: jest.fn(() => ({ fetch: jest.fn().mockResolvedValue([]) })),
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { syncService: freshSyncService } = require('../src/services/syncService');
+      const { loadProfile: lp } = require('../src/storage');
+
+      await freshSyncService.uploadPendingTrainingData();
+      expect(lp).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(60 * 1000); // within TTL
+      await freshSyncService.uploadPendingTrainingData();
+      expect(lp).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+      await freshSyncService.uploadPendingTrainingData();
+      expect(lp).toHaveBeenCalledTimes(2);
+    });
+    jest.useRealTimers();
+  });
+});
+
+describe('telemetry sync', () => {
+  it('uploads telemetry events even when no training data', async () => {
+    mockSamples = [];
+    mockDatabase.get.mockReturnValue({
+      query: jest.fn(() => ({ fetch: jest.fn().mockResolvedValue([]) })),
+    });
+    (telemetry.dump as jest.Mock).mockResolvedValue([{ e: 1 }]);
+
+    await syncService.uploadPendingTrainingData();
+    expect(telemetry.dump).toHaveBeenCalled();
+    expect(uploadTelemetry).toHaveBeenCalledWith([{ e: 1 }]);
+  });
+});
 


### PR DESCRIPTION
## Summary
- extend syncService tests to cover retry, concurrency lock, consent caching, and telemetry sync
- unmount screen components in tests to eliminate post-run logging

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx --yes expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`


------
https://chatgpt.com/codex/tasks/task_e_68bb19a89964832281b8a58c4bb4807e