### PR TITLE
refactor(server): centralize logging logic

### DIFF
--- a/server/src/services/logger.ts
+++ b/server/src/services/logger.ts
@@ -31,7 +31,7 @@ interface LogContext {
   statusCode?: number;
 }
 
-class Logger {
+export class Logger {
   private serviceName: string;
   private logLevel: LogLevel;
   private context: LogContext = {};

--- a/server/test/logger.test.ts
+++ b/server/test/logger.test.ts
@@ -1,6 +1,8 @@
 jest.unmock('../src/services/logger.js');
 
-let logger: any;
+import type { Logger } from '../src/services/logger.js';
+
+let logger: Logger;
 beforeAll(async () => {
   ({ logger } = await import('../src/services/logger.js'));
 });
@@ -14,13 +16,21 @@ describe('logger', () => {
     it('logs warning for 4xx/5xx responses', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       logger.apiRequest('GET', '/foo', 500, 100);
-      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [output] = warnSpy.mock.calls[0];
+      const entry = JSON.parse(output);
+      expect(entry.level).toBe('WARN');
+      expect(entry.message).toBe('GET /foo');
     });
 
     it('logs info for successful responses', () => {
       const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
       logger.apiRequest('GET', '/foo', 200, 50);
-      expect(logSpy).toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const [output] = logSpy.mock.calls[0];
+      const entry = JSON.parse(output);
+      expect(entry.level).toBe('INFO');
+      expect(entry.message).toBe('GET /foo');
     });
   });
 
@@ -28,13 +38,21 @@ describe('logger', () => {
     it('logs warning for error status codes', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       logger.requestEnd('GET', '/foo', 500, 123);
-      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [output] = warnSpy.mock.calls[0];
+      const entry = JSON.parse(output);
+      expect(entry.level).toBe('WARN');
+      expect(entry.message).toBe('GET /foo - Request completed');
     });
 
     it('logs info for successful status codes', () => {
       const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
       logger.requestEnd('GET', '/foo', 200, 123);
-      expect(logSpy).toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const [output] = logSpy.mock.calls[0];
+      const entry = JSON.parse(output);
+      expect(entry.level).toBe('INFO');
+      expect(entry.message).toBe('GET /foo - Request completed');
     });
   });
 });


### PR DESCRIPTION
## Summary
- route helper logs through new `log` method for consistent level handling
- cover `apiRequest` and `requestEnd` with unit tests to verify correct console output

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx --yes expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68c2d74eff108322aa6c90f6e4f47b99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated logging into a single, consistent flow to improve reliability and uniformity.
  * Standardized handling so responses and errors are logged with appropriate severity.

* **Tests**
  * Added tests to verify logging behavior, ensuring error responses produce warnings and successful responses produce informational logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->