### PR TITLE
refactor: centralize logging

### DIFF
--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -191,7 +191,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({
   const handleMessage = async (event: WebViewMessageEvent) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
-      console.log('WebView message:', data);
+      logger.debug('WebView message', data);
 
       // Use performance service for message processing
       if (data.type === 'gesture') {
@@ -325,7 +325,7 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({
           onError('webview_http_error');
         }}
         onConsoleMessage={(e: any) => {
-          console.log('WV:', e.nativeEvent?.message);
+          logger.debug('WebView console message', e.nativeEvent?.message);
         }}
         onPermissionRequest={(e: WebViewPermissionRequestEvent) => {
           const { origin, resources, grant, deny } = e.nativeEvent;

--- a/app/src/screens/ScheduleScreen.tsx
+++ b/app/src/screens/ScheduleScreen.tsx
@@ -4,6 +4,7 @@ import type { NavigationProp } from '@react-navigation/native';
 import VisualSchedule from '../components/VisualSchedule';
 import BottomNav from '../components/BottomNav';
 import type { RootStackParamList } from '../navigation/types';
+import { logger } from '../utils/logger';
 
 export default function ScheduleScreen({
   navigation,
@@ -17,7 +18,7 @@ export default function ScheduleScreen({
 
   const handleScheduleComplete = () => {
     // Could show a celebration or navigate somewhere
-    console.log('Schedule completed!');
+    logger.info('Schedule completed!');
   };
 
   return (

--- a/app/src/services/adaptivePracticeTimingService.ts
+++ b/app/src/services/adaptivePracticeTimingService.ts
@@ -12,6 +12,7 @@
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { logger } from '../utils/logger';
 
 export interface CommunicationSession {
   startTime: number;
@@ -217,7 +218,7 @@ class AdaptivePracticeTimingService {
 
       // If more than COMMUNICATION_TIMEOUT has passed, end the session
       if (timeSinceLastGesture > this.COMMUNICATION_TIMEOUT) {
-        console.log('Cleaning up stale communication session');
+        logger.debug('Cleaning up stale communication session');
         this.endCommunicationSession();
       }
     }

--- a/app/test/MediaPipeGestureDetector.test.tsx
+++ b/app/test/MediaPipeGestureDetector.test.tsx
@@ -101,6 +101,8 @@ jest.mock('../src/utils/logger', () => ({
   logger: {
     warn: jest.fn(),
     error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
   },
 }));
 
@@ -129,7 +131,7 @@ describe('MediaPipeGestureDetector', () => {
   it('logs and forwards error messages from the WebView', () => {
     const onGestureDetected = jest.fn();
     const onError = jest.fn();
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
 
     act(() => {
       component = renderer.create(
@@ -144,16 +146,16 @@ describe('MediaPipeGestureDetector', () => {
       });
     });
 
-    expect(consoleSpy).toHaveBeenCalledWith('WebView error:', 'Camera access denied');
+    expect(errorSpy).toHaveBeenCalledWith('WebView error', { message: 'Camera access denied' });
     expect(onError).toHaveBeenCalledWith('gesture_processing_error');
     expect(onGestureDetected).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('logs console messages from the WebView', () => {
     const onGestureDetected = jest.fn();
     const onError = jest.fn();
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
 
     act(() => {
       component = renderer.create(
@@ -166,8 +168,8 @@ describe('MediaPipeGestureDetector', () => {
       webview.props.onConsoleMessage({ nativeEvent: { message: 'test log' } });
     });
 
-    expect(logSpy).toHaveBeenCalledWith('WV:', 'test log');
-    logSpy.mockRestore();
+    expect(debugSpy).toHaveBeenCalledWith('WebView console message', 'test log');
+    debugSpy.mockRestore();
   });
 
   it('calls onError when the message data is invalid JSON', () => {

--- a/app/test/screens/ScheduleScreen.test.tsx
+++ b/app/test/screens/ScheduleScreen.test.tsx
@@ -10,6 +10,7 @@ jest.mock('react-native', () => {
 });
 
 import ScheduleScreen from '../../src/screens/ScheduleScreen';
+import { logger } from '../../src/utils/logger';
 
 jest.mock('../../src/components/VisualSchedule', () => {
   const React = require('react');
@@ -83,15 +84,15 @@ describe('ScheduleScreen', () => {
 
     const visualSchedule = component!.root.findByProps({ testID: 'visual-schedule' });
 
-    // Mock console.log to avoid console output in tests
-    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    // Mock logger to avoid console output in tests
+    const loggerSpy = jest.spyOn(logger, 'info').mockImplementation();
 
     act(() => {
       visualSchedule.props.onScheduleComplete();
     });
 
-    expect(consoleSpy).toHaveBeenCalledWith('Schedule completed!');
+    expect(loggerSpy).toHaveBeenCalledWith('Schedule completed!');
 
-    consoleSpy.mockRestore();
+    loggerSpy.mockRestore();
   });
 });

--- a/docs/CodebaseOverview.md
+++ b/docs/CodebaseOverview.md
@@ -56,3 +56,6 @@ These are target values and should be validated on real devices.
 - All persistent data lives in `server/db.json`
 - `GET /api/profiles/:id/export` returns a profile's stored data as JSON
 - `DELETE /api/profiles/:id` removes a profile and associated usage/correction records to honor caregiver deletion requests
+
+## 10. Logging
+- Unified logging is handled by `app/src/utils/logger.ts`, providing consistent formatting and log-level control across the app. Direct `console.*` calls are avoided.


### PR DESCRIPTION
## Summary
- replace stray console.log calls with shared logger in webview detector, schedule screen, and practice timing service
- document unified logging approach in CodebaseOverview
- adjust tests to assert logger output

## Testing
- `npm ci --prefix app`
- `npm run type-check --prefix app`
- `npm test --prefix app`
- `(cd app && npx expo install --check)`
- `(cd app && npx --yes expo-doctor || echo "expo-doctor skipped/failed (non-blocking)")`
- `npm ci --prefix server`
- `npm run type-check --prefix server`
- `pip install -r server/requirements.txt`
- `npm test --prefix server`
- `npm ci --prefix integration`
- `npm test --prefix integration`


------
https://chatgpt.com/codex/tasks/task_e_68c319634c2483229c5125299fce2f9e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized app logging by replacing console statements with the centralized logger for clearer, configurable diagnostics without changing behavior.

- Tests
  - Updated tests to verify logger outputs instead of console calls, improving reliability and alignment with the new logging strategy.

- Documentation
  - Added a Logging section explaining the centralized logging approach and guidance to avoid direct console usage.
  - Minor formatting tidy-up in existing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->