### PR TITLE
Stabilize mirrored hand previews across frames

### DIFF
--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -20,6 +20,7 @@ interface Props {
     gesture: string | null,
     confidence: number,
     landmarks: number[][][],
+    handedness: string[],
   ) => void;
   onError: (error: string) => void;
   onWebViewEvent?: (telemetry: any) => void;
@@ -69,8 +70,13 @@ export const MediaPipeGestureDetector: React.FC<Props> = ({
           : parseFloat(String(message.confidence ?? ''));
       const confidence = Number.isFinite(rawConfidence) ? rawConfidence : 0;
       const landmarks = Array.isArray(message.landmarks) ? message.landmarks : [];
+      const handedness = Array.isArray(message.handednesses)
+        ? message.handednesses.map((label: unknown) =>
+            typeof label === 'string' ? label : String(label ?? ''),
+          )
+        : [];
 
-      onGestureDetected(gesture, confidence, landmarks);
+      onGestureDetected(gesture, confidence, landmarks, handedness);
       return true;
     },
     [onGestureDetected],

--- a/app/src/screens/GesturePracticeScreen.tsx
+++ b/app/src/screens/GesturePracticeScreen.tsx
@@ -9,6 +9,7 @@ import { MediaPipeGestureDetector } from '../components/MediaPipeGestureDetector
 
 import { useMessage } from '../context/MessageContext';
 import { logger } from '../utils/logger';
+import { cloneLandmarks } from '../utils/landmarkUtils';
 
 export default function GesturePracticeScreen() {
   const { largeText, highContrast } = useAccessibility();
@@ -44,8 +45,15 @@ export default function GesturePracticeScreen() {
     ? ([COLORS.highContrastBackground, COLORS.highContrastBackground] as const)
     : ([COLORS.backgroundStart, COLORS.backgroundEnd] as const);
 
-  const handleGestureDetected = (gesture: string | null, confidence: number, landmarks: number[][][]) => {
-    setLandmarks(landmarks);
+  const handleGestureDetected = (
+    gesture: string | null,
+    confidence: number,
+    rawLandmarks: number[][][],
+    handedness: string[],
+  ) => {
+    const safeLandmarks = cloneLandmarks(rawLandmarks);
+
+    setLandmarks(safeLandmarks);
     setLastDetection(Date.now());
     if (gesture && confidence > 0.5) {
       setMessage(`Gut gemacht! ${gesture} erkannt`);

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -788,6 +788,8 @@ export default function RecognitionScreen({
             <HandLandmarkPreview
               landmarks={currentLandmarks}
               handedness={currentHandedness}
+              // Mirror the overlay when the front camera is active so the landmarks align with the
+              // mirrored preview that the OS presents to the user.
               mirror={facingMode === 'user'}
               confidence={gestureConfidence}
             />

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -86,6 +86,11 @@ import { getShortcutMessage, getShortcutAction, getShortcutDisplayName } from '.
 import { useRecognitionState } from '../hooks/useRecognitionState';
 import { useRecognitionCallbacks } from '../hooks/useRecognitionCallbacks';
 import HandLandmarkPreview from '../components/HandLandmarkPreview';
+import {
+  cloneLandmarks,
+  adjustHandednessForMirror,
+  createHandLandmarkStabilizer,
+} from '../utils/landmarkUtils';
 
 const FEEDBACK_THROTTLE_MS = 2000;
 // CELEBRATION_DURATION_MS sourced from Celebration.tsx sequence
@@ -185,6 +190,7 @@ export default function RecognitionScreen({
   const consecutiveFailuresRef = useRef<number>(0);
   const consecutiveSuccessesRef = useRef<number>(0);
   const lastModelUpdateTimeRef = useRef<number>(0);
+  const handStabilizerRef = useRef(createHandLandmarkStabilizer({ ttlMs: 300, maxHands: 2 }));
 
   useEffect(() => {
     loadProfile().then(setProfile);
@@ -213,6 +219,12 @@ export default function RecognitionScreen({
       })
       .catch((error) => { logger.warn('Failed to build local centroids:', error); });
   }, []);
+
+  useEffect(() => {
+    handStabilizerRef.current.reset();
+    setCurrentLandmarks([]);
+    setCurrentHandedness([]);
+  }, [facingMode, handStabilizerRef, setCurrentHandedness, setCurrentLandmarks]);
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -290,11 +302,15 @@ export default function RecognitionScreen({
     gesture: string | null,
     confidence: number,
     landmarks: number[][][],
+    handedness: string[],
   ) => {
-    // Update landmark visualization
-    setCurrentLandmarks(landmarks);
-    // Note: handedness data is not currently sent from WebView, so we leave it empty
-    setCurrentHandedness([]);
+    const mirrored = facingMode === 'user';
+    const safeLandmarks = cloneLandmarks(landmarks);
+    const adjustedHandedness = adjustHandednessForMirror(handedness ?? [], mirrored);
+    const stabilized = handStabilizerRef.current.update(safeLandmarks, adjustedHandedness);
+
+    setCurrentLandmarks(stabilized.landmarks);
+    setCurrentHandedness(stabilized.handedness);
 
     let g = gesture;
     let c = confidence;
@@ -302,7 +318,7 @@ export default function RecognitionScreen({
 
     // Always try to classify with our custom model
     if (centroidsRef.current) {
-      const flat = flattenHands(landmarks) as Point[];
+      const flat = flattenHands(safeLandmarks) as Point[];
       const res = classifyWithCentroids(flat, centroidsRef.current);
       if (res) {
         g = res.label;
@@ -441,7 +457,13 @@ export default function RecognitionScreen({
 
     // On-device classification only: use provided or locally-classified gesture
     await handleOutcome(g || 'unknown', c, path);
-  }, [dialogContext, startFeedbackAnimation, lastRecognizedGesture]);
+  }, [
+    dialogContext,
+    facingMode,
+    handStabilizerRef,
+    lastRecognizedGesture,
+    startFeedbackAnimation,
+  ]);
 
   const handleGestureError = useCallback((errorMessage: string) => {
     // Avoid flooding the UI; only surface critical init/camera errors
@@ -766,7 +788,7 @@ export default function RecognitionScreen({
             <HandLandmarkPreview
               landmarks={currentLandmarks}
               handedness={currentHandedness}
-              mirror={facingMode !== 'user'}
+              mirror={facingMode === 'user'}
               confidence={gestureConfidence}
             />
          </View>

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -224,7 +224,7 @@ export default function RecognitionScreen({
     handStabilizerRef.current.reset();
     setCurrentLandmarks([]);
     setCurrentHandedness([]);
-  }, [facingMode, handStabilizerRef, setCurrentHandedness, setCurrentLandmarks]);
+  }, [facingMode]);
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;

--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -47,6 +47,9 @@ export default function TeachingScreen({ navigation }: any) {
     message: string;
     suggestions: string[];
   } | null>(null);
+  // Centralize the facing mode so the detector and overlays stay in sync if this screen later
+  // gains a camera toggle.
+  const facingMode: 'user' | 'environment' = 'user';
   const [currentGestureQuality, setCurrentGestureQuality] = useState<{
     confidence: number;
     stability: number;
@@ -83,7 +86,7 @@ export default function TeachingScreen({ navigation }: any) {
       lms: number[][][],
       handedness: string[],
     ) => {
-      const mirrored = true; // Teaching mode uses the front-facing preview by default
+      const mirrored = facingMode === 'user';
       const safeLandmarks = cloneLandmarks(lms);
       const adjustedHandedness = adjustHandednessForMirror(handedness ?? [], mirrored);
 
@@ -446,6 +449,7 @@ export default function TeachingScreen({ navigation }: any) {
                 onWebViewEvent={(telemetry) => {
                   console.log('Teaching WebView telemetry:', telemetry);
                 }}
+                facingMode={facingMode}
               />
 
              {/* Visual feedback overlay */}

--- a/app/src/screens/TeachingScreen.tsx
+++ b/app/src/screens/TeachingScreen.tsx
@@ -24,6 +24,7 @@ import { twoHandGestureService } from '../services/twoHandGestureService';
 import VisualFeedback from '../components/VisualFeedback';
 import ProgressTracker from '../components/ProgressTracker';
 import GestureValidationFeedback from '../components/GestureValidationFeedback';
+import { cloneLandmarks, adjustHandednessForMirror } from '../utils/landmarkUtils';
 
 const PREVIEW_SIZE = 240;
 
@@ -76,9 +77,18 @@ export default function TeachingScreen({ navigation }: any) {
   }, []);
 
   const handleGestureDetected = useCallback(
-    async (gesture: string | null, confidence: number, lms: number[][][]) => {
-      landmarksRef.current = lms;
-      handednessRef.current = []; // No handedness data available in simplified mode
+    async (
+      gesture: string | null,
+      confidence: number,
+      lms: number[][][],
+      handedness: string[],
+    ) => {
+      const mirrored = true; // Teaching mode uses the front-facing preview by default
+      const safeLandmarks = cloneLandmarks(lms);
+      const adjustedHandedness = adjustHandednessForMirror(handedness ?? [], mirrored);
+
+      landmarksRef.current = safeLandmarks;
+      handednessRef.current = adjustedHandedness;
 
       // Enhanced feedback for teaching mode
       if (gesture && confidence > 0.3) {
@@ -89,12 +99,12 @@ export default function TeachingScreen({ navigation }: any) {
         // Update gesture quality metrics
         setCurrentGestureQuality({
           confidence,
-          stability: Math.min(1, lms.length / 2), // Rough stability based on landmark count
+          stability: Math.min(1, safeLandmarks.length / 2), // Rough stability based on landmark count
           clarity: confidence > 0.7 ? 1 : confidence > 0.5 ? 0.7 : 0.4
         });
 
         // Enhanced two-hand gesture validation and feedback
-        if (isTwoHandMode && selectedTwoHandGesture && lms.length >= 2) {
+        if (isTwoHandMode && selectedTwoHandGesture && safeLandmarks.length >= 2) {
           const parsed = parseTwoHandGestureString(gesture);
           if (parsed) {
             const twoHandResult = await twoHandGestureService.processTwoHandGesture(
@@ -102,8 +112,8 @@ export default function TeachingScreen({ navigation }: any) {
               parsed.right,
               confidence,
               confidence,
-              [], // No handedness data in simplified mode
-              lms
+              adjustedHandedness,
+              safeLandmarks
             );
 
             if (twoHandResult) {

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -14,6 +14,7 @@ import BottomNav from '../components/BottomNav';
 import { useMessage } from '../context/MessageContext';
 import { logger } from '../utils/logger';
 import { MediaPipeGestureDetector } from '../components/MediaPipeGestureDetector';
+import { cloneLandmarks, adjustHandednessForMirror } from '../utils/landmarkUtils';
 import { logHIPEvent } from '../services/hipEvents';
 import DgsVideoPlayer from '../components/DgsVideoPlayer';
 
@@ -380,12 +381,19 @@ export default function TrainingScreen({ navigation, route }: any) {
                 onWebViewEvent={(telemetry) => {
                   logger.info('Training WebView telemetry:', telemetry);
                 }}
-                onGestureDetected={(gesture, confidence, lm) => {
-                 setLandmarks(lm);
+                onGestureDetected={(gesture, confidence, lm, handedness) => {
+                 const mirrored = true;
+                 const safeLandmarks = cloneLandmarks(lm);
+                 const adjustedHandedness = adjustHandednessForMirror(handedness ?? [], mirrored);
+
+                 setLandmarks(safeLandmarks);
                  setLastDetection(Date.now());
 
                   if (isRecordingRef.current) {
-                    setRecordedFrames((prev) => [...prev, { landmarks: lm, handedness: [] }]);
+                    setRecordedFrames((prev) => [
+                      ...prev,
+                      { landmarks: safeLandmarks, handedness: adjustedHandedness },
+                    ]);
                    setFramesCaptured((c) => c + 1);
 
                    // Track performance metrics

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -51,6 +51,8 @@ export default function TrainingScreen({ navigation, route }: any) {
     sessionDuration: number;
   } | null>(null);
   const [practiceMode, setPracticeMode] = useState(false);
+  // Keep the facing mode in one place so overlays and recordings stay aligned if we add a toggle.
+  const facingMode: 'user' | 'environment' = 'user';
 
   useEffect(() => {
     setMessage(error);
@@ -382,48 +384,49 @@ export default function TrainingScreen({ navigation, route }: any) {
                   logger.info('Training WebView telemetry:', telemetry);
                 }}
                 onGestureDetected={(gesture, confidence, lm, handedness) => {
-                 const mirrored = true;
-                 const safeLandmarks = cloneLandmarks(lm);
-                 const adjustedHandedness = adjustHandednessForMirror(handedness ?? [], mirrored);
+                  const mirrored = facingMode === 'user';
+                  const safeLandmarks = cloneLandmarks(lm);
+                  const adjustedHandedness = adjustHandednessForMirror(handedness ?? [], mirrored);
 
-                 setLandmarks(safeLandmarks);
-                 setLastDetection(Date.now());
+                  setLandmarks(safeLandmarks);
+                  setLastDetection(Date.now());
 
                   if (isRecordingRef.current) {
                     setRecordedFrames((prev) => [
                       ...prev,
                       { landmarks: safeLandmarks, handedness: adjustedHandedness },
                     ]);
-                   setFramesCaptured((c) => c + 1);
+                    setFramesCaptured((c) => c + 1);
 
-                   // Track performance metrics
-                   if (gestureId) {
-                     positiveTelemetryService.recordSuccess(
-                       gestureId,
-                       confidence,
-                       undefined, // context
-                       undefined, // emotionalState
-                       Date.now() - (sessionStartTime || Date.now()) // duration
-                     );
-                   }
-                 }
+                    // Track performance metrics
+                    if (gestureId) {
+                      positiveTelemetryService.recordSuccess(
+                        gestureId,
+                        confidence,
+                        undefined, // context
+                        undefined, // emotionalState
+                        Date.now() - (sessionStartTime || Date.now()), // duration
+                      );
+                    }
+                  }
 
-                 // Enhanced feedback for practice mode
-                 if (practiceMode && gesture && confidence > 0.5) {
-                   // Provide real-time feedback during practice
-                   if (confidence > 0.8) {
-                     setMessage('🎉 Perfekt! Das sieht sehr gut aus!');
-                   } else if (confidence > 0.6) {
-                     setMessage('👍 Gut gemacht! Fast richtig.');
-                   }
-                 }
-               }}
+                  // Enhanced feedback for practice mode
+                  if (practiceMode && gesture && confidence > 0.5) {
+                    // Provide real-time feedback during practice
+                    if (confidence > 0.8) {
+                      setMessage('🎉 Perfekt! Das sieht sehr gut aus!');
+                    } else if (confidence > 0.6) {
+                      setMessage('👍 Gut gemacht! Fast richtig.');
+                    }
+                  }
+                }}
                 onError={(m) => {
                   logger.warn('TrainingScreen detector error:', m);
                   // Amy First: Show encouraging message instead of technical error
                   setMessage('Das hat nicht geklappt. Lass es uns nochmal versuchen!');
                 }}
-             />
+                facingMode={facingMode}
+              />
               {landmarks.length > 0 && (
                 <Svg
                   style={StyleSheet.absoluteFill}

--- a/app/src/utils/landmarkUtils.ts
+++ b/app/src/utils/landmarkUtils.ts
@@ -29,7 +29,7 @@ const normalizeHandednessLabel = (label: unknown): string => {
   return trimmed;
 };
 
-export const adjustHandednessForMirror = (labels: string[], _mirror: boolean): string[] =>
+export const normalizeHandednessLabels = (labels: string[]): string[] =>
   labels.map((label, index) => {
     const normalized = normalizeHandednessLabel(label);
 

--- a/app/src/utils/landmarkUtils.ts
+++ b/app/src/utils/landmarkUtils.ts
@@ -1,0 +1,145 @@
+const cloneHand = (hand: number[][]): number[][] =>
+  Array.isArray(hand)
+    ? hand.map((point) =>
+        Array.isArray(point) ? [point[0] ?? 0, point[1] ?? 0, point[2] ?? 0] : [0, 0, 0],
+      )
+    : [];
+
+export const cloneLandmarks = (landmarks: number[][][]): number[][][] =>
+  Array.isArray(landmarks) ? landmarks.map((hand) => cloneHand(hand)) : [];
+
+export const adjustHandednessForMirror = (labels: string[], mirror: boolean): string[] => {
+  if (!mirror) {
+    return labels
+      .filter((label) => typeof label === 'string' && label.length > 0)
+      .map((label) => label);
+  }
+
+  return labels.map((label) => {
+    if (typeof label !== 'string' || label.length === 0) {
+      return String(label ?? '');
+    }
+    if (/left/i.test(label)) {
+      return 'Right';
+    }
+    if (/right/i.test(label)) {
+      return 'Left';
+    }
+    return label;
+  });
+};
+
+type StabilizerEntry = {
+  id: string;
+  handedness: string;
+  landmarks: number[][];
+  updatedAt: number;
+  order: number;
+};
+
+export interface HandLandmarkStabilizerOptions {
+  ttlMs?: number;
+  maxHands?: number;
+}
+
+export interface StabilizedHands {
+  landmarks: number[][][];
+  handedness: string[];
+}
+
+export interface HandLandmarkStabilizer {
+  update: (landmarks: number[][][], handedness?: string[], now?: number) => StabilizedHands;
+  reset: () => void;
+}
+
+const DEFAULT_TTL = 250;
+const DEFAULT_MAX_HANDS = 2;
+
+const getStableId = (handedness: string | undefined, index: number): string => {
+  const normalized = typeof handedness === 'string' ? handedness.trim().toLowerCase() : '';
+  if (normalized === 'left' || normalized === 'right') {
+    return normalized;
+  }
+  return `hand-${index}`;
+};
+
+const getHandednessLabel = (label: string | undefined, index: number): string => {
+  if (typeof label === 'string' && label.length > 0) {
+    return label;
+  }
+  return `Hand ${index + 1}`;
+};
+
+const compareEntries = (a: StabilizerEntry, b: StabilizerEntry): number => {
+  const priority = (entry: StabilizerEntry): number => {
+    if (entry.id === 'left') return 0;
+    if (entry.id === 'right') return 1;
+    return 2;
+  };
+
+  const priorityDiff = priority(a) - priority(b);
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+
+  if (a.updatedAt !== b.updatedAt) {
+    return b.updatedAt - a.updatedAt;
+  }
+
+  return a.order - b.order;
+};
+
+export const createHandLandmarkStabilizer = (
+  options: HandLandmarkStabilizerOptions = {},
+): HandLandmarkStabilizer => {
+  const ttl = Number.isFinite(options.ttlMs) && (options.ttlMs ?? 0) > 0 ? options.ttlMs! : DEFAULT_TTL;
+  const maxHands = Number.isFinite(options.maxHands) && (options.maxHands ?? 0) > 0
+    ? Math.floor(options.maxHands!)
+    : DEFAULT_MAX_HANDS;
+
+  const cache = new Map<string, StabilizerEntry>();
+
+  const update = (
+    landmarks: number[][][],
+    handedness: string[] = [],
+    now: number = Date.now(),
+  ): StabilizedHands => {
+    if (Array.isArray(landmarks)) {
+      landmarks.forEach((hand, index) => {
+        if (!Array.isArray(hand) || hand.length === 0) {
+          return;
+        }
+
+        const label = handedness[index];
+        const id = getStableId(label, index);
+
+        cache.set(id, {
+          id,
+          handedness: getHandednessLabel(label, index),
+          landmarks: cloneHand(hand),
+          updatedAt: now,
+          order: index,
+        });
+      });
+    }
+
+    for (const [id, entry] of cache) {
+      if (now - entry.updatedAt > ttl) {
+        cache.delete(id);
+      }
+    }
+
+    const entries = Array.from(cache.values()).sort(compareEntries).slice(0, maxHands);
+
+    return {
+      landmarks: entries.map((entry) => entry.landmarks),
+      handedness: entries.map((entry) => entry.handedness),
+    };
+  };
+
+  const reset = () => {
+    cache.clear();
+  };
+
+  return { update, reset };
+};

--- a/app/src/utils/landmarkUtils.ts
+++ b/app/src/utils/landmarkUtils.ts
@@ -8,26 +8,41 @@ const cloneHand = (hand: number[][]): number[][] =>
 export const cloneLandmarks = (landmarks: number[][][]): number[][][] =>
   Array.isArray(landmarks) ? landmarks.map((hand) => cloneHand(hand)) : [];
 
-export const adjustHandednessForMirror = (labels: string[], mirror: boolean): string[] => {
-  if (!mirror) {
-    return labels
-      .filter((label) => typeof label === 'string' && label.length > 0)
-      .map((label) => label);
+const normalizeHandednessLabel = (label: unknown): string => {
+  if (typeof label !== 'string') {
+    return String(label ?? '');
   }
 
-  return labels.map((label) => {
-    if (typeof label !== 'string' || label.length === 0) {
-      return String(label ?? '');
-    }
-    if (/left/i.test(label)) {
-      return 'Right';
-    }
-    if (/right/i.test(label)) {
-      return 'Left';
-    }
-    return label;
-  });
+  const trimmed = label.trim();
+  if (trimmed.length === 0) {
+    return '';
+  }
+
+  if (/^left$/i.test(trimmed)) {
+    return 'Left';
+  }
+
+  if (/^right$/i.test(trimmed)) {
+    return 'Right';
+  }
+
+  return trimmed;
 };
+
+export const adjustHandednessForMirror = (labels: string[], _mirror: boolean): string[] =>
+  labels.map((label, index) => {
+    const normalized = normalizeHandednessLabel(label);
+
+    if (normalized.length === 0) {
+      // Preserve the array length so callers can keep indices aligned with landmarks.
+      return `Hand ${index + 1}`;
+    }
+
+    // The camera preview may be mirrored, but the underlying handedness still reflects the
+    // physical hand. We intentionally avoid swapping "Left"/"Right" to keep feedback and
+    // analytics consistent regardless of the active camera.
+    return normalized;
+  });
 
 type StabilizerEntry = {
   id: string;

--- a/app/test/MediaPipeGestureDetector.test.tsx
+++ b/app/test/MediaPipeGestureDetector.test.tsx
@@ -227,8 +227,8 @@ describe('MediaPipeGestureDetector', () => {
       webview.props.onMessage({ nativeEvent: { data: JSON.stringify(batchPayload) } });
     });
 
-    expect(onGestureDetected).toHaveBeenNthCalledWith(1, 'hallo', 0.82, [[[0, 0, 0]]]);
-    expect(onGestureDetected).toHaveBeenNthCalledWith(2, 'hilfe', 0.41, []);
+    expect(onGestureDetected).toHaveBeenNthCalledWith(1, 'hallo', 0.82, [[[0, 0, 0]]], []);
+    expect(onGestureDetected).toHaveBeenNthCalledWith(2, 'hilfe', 0.41, [], []);
     expect(onWebViewEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'telemetry',
@@ -240,6 +240,33 @@ describe('MediaPipeGestureDetector', () => {
         lastSentAt: 123456,
       })
     );
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('passes handedness information from gesture messages', () => {
+    const onGestureDetected = jest.fn();
+    const onError = jest.fn();
+
+    act(() => {
+      component = renderer.create(
+        <MediaPipeGestureDetector onGestureDetected={onGestureDetected} onError={onError} />,
+      );
+    });
+
+    const webview = component!.root.findByType('mock-webview');
+    const payload = {
+      type: 'gesture',
+      gesture: 'thumbs_up',
+      confidence: 0.9,
+      landmarks: [[[0.1, 0.2, 0.0]]],
+      handednesses: ['Left'],
+    };
+
+    act(() => {
+      webview.props.onMessage({ nativeEvent: { data: JSON.stringify(payload) } });
+    });
+
+    expect(onGestureDetected).toHaveBeenCalledWith('thumbs_up', 0.9, [[[0.1, 0.2, 0.0]]], ['Left']);
     expect(onError).not.toHaveBeenCalled();
   });
 

--- a/app/test/utils/landmarkUtils.test.ts
+++ b/app/test/utils/landmarkUtils.test.ts
@@ -1,0 +1,94 @@
+import {
+  cloneLandmarks,
+  adjustHandednessForMirror,
+  createHandLandmarkStabilizer,
+} from '../../src/utils/landmarkUtils';
+
+describe('landmarkUtils', () => {
+  it('deep clones multi-hand landmarks', () => {
+    const source = [
+      [
+        [0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6],
+      ],
+      [
+        [0.7, 0.8, 0.9],
+      ],
+    ];
+
+    const cloned = cloneLandmarks(source);
+    expect(cloned).toEqual(source);
+    expect(cloned).not.toBe(source);
+    expect(cloned[0]).not.toBe(source[0]);
+    expect(cloned[0][0]).not.toBe(source[0][0]);
+  });
+
+  it('leaves handedness unchanged when not mirrored', () => {
+    const handedness = ['Left', 'Right', 'unknown'];
+    expect(adjustHandednessForMirror(handedness, false)).toEqual(handedness);
+  });
+
+  it('swaps left and right handedness when mirrored', () => {
+    expect(adjustHandednessForMirror(['Left', 'Right', 'unknown'], true)).toEqual([
+      'Right',
+      'Left',
+      'unknown',
+    ]);
+  });
+
+  describe('createHandLandmarkStabilizer', () => {
+    const leftHand = Array.from({ length: 21 }, (_, index) => [index / 20, index / 20, 0]);
+    const rightHand = Array.from({ length: 21 }, (_, index) => [1 - index / 20, index / 20, 0]);
+
+    it('returns both hands with their labels when provided', () => {
+      const stabilizer = createHandLandmarkStabilizer();
+
+      const { landmarks, handedness } = stabilizer.update([leftHand, rightHand], ['Left', 'Right'], 0);
+
+      expect(landmarks).toHaveLength(2);
+      expect(handedness).toEqual(['Left', 'Right']);
+      expect(landmarks[0]).toEqual(leftHand);
+      expect(landmarks[1]).toEqual(rightHand);
+      expect(landmarks[0]).not.toBe(leftHand);
+      expect(landmarks[1]).not.toBe(rightHand);
+    });
+
+    it('keeps the last seen hand for a short TTL when one hand disappears', () => {
+      const stabilizer = createHandLandmarkStabilizer({ ttlMs: 300 });
+
+      stabilizer.update([leftHand, rightHand], ['Left', 'Right'], 0);
+      const { landmarks, handedness } = stabilizer.update([leftHand], ['Left'], 100);
+
+      expect(landmarks).toHaveLength(2);
+      expect(handedness).toEqual(['Left', 'Right']);
+    });
+
+    it('drops stale hands after the TTL expires', () => {
+      const stabilizer = createHandLandmarkStabilizer({ ttlMs: 150 });
+
+      stabilizer.update([leftHand, rightHand], ['Left', 'Right'], 0);
+      const { landmarks, handedness } = stabilizer.update([leftHand], ['Left'], 200);
+
+      expect(landmarks).toHaveLength(1);
+      expect(handedness).toEqual(['Left']);
+    });
+
+    it('assigns stable IDs to unlabeled hands', () => {
+      const stabilizer = createHandLandmarkStabilizer({ ttlMs: 200 });
+
+      const handA = Array.from({ length: 21 }, () => [0.2, 0.2, 0]);
+      const handB = Array.from({ length: 21 }, () => [0.8, 0.2, 0]);
+
+      const first = stabilizer.update([handA, handB], ['Left', ''], 0);
+      expect(first.handedness).toEqual(['Left', 'Hand 2']);
+
+      const second = stabilizer.update([handA], ['Left'], 100);
+      expect(second.handedness).toEqual(['Left', 'Hand 2']);
+      expect(second.landmarks).toHaveLength(2);
+
+      const third = stabilizer.update([], [], 400);
+      expect(third.handedness).toEqual([]);
+      expect(third.landmarks).toEqual([]);
+    });
+  });
+});

--- a/app/test/utils/landmarkUtils.test.ts
+++ b/app/test/utils/landmarkUtils.test.ts
@@ -28,11 +28,19 @@ describe('landmarkUtils', () => {
     expect(adjustHandednessForMirror(handedness, false)).toEqual(handedness);
   });
 
-  it('swaps left and right handedness when mirrored', () => {
+  it('keeps handedness orientation when mirrored', () => {
     expect(adjustHandednessForMirror(['Left', 'Right', 'unknown'], true)).toEqual([
-      'Right',
       'Left',
+      'Right',
       'unknown',
+    ]);
+  });
+
+  it('fills empty handedness labels with positional fallbacks', () => {
+    expect(adjustHandednessForMirror(['', undefined as unknown as string, '  '], true)).toEqual([
+      'Hand 1',
+      'Hand 2',
+      'Hand 3',
     ]);
   });
 

--- a/app/webview/__tests__/GestureProcessing.test.ts
+++ b/app/webview/__tests__/GestureProcessing.test.ts
@@ -77,15 +77,16 @@ describe('GestureSizeNormalizer', () => {
     });
 
     it('should handle multiple hands', () => {
-      const landmarks = [
-        // Hand 1
-        Array(21).fill([0.1, 0.1, 0.0]),
-        // Hand 2
-        Array(21).fill([0.2, 0.2, 0.0])
-      ];
+      const createHand = (base: number) => Array.from({ length: 21 }, () => [base, base, 0]);
+      const landmarks = [createHand(0.1), createHand(0.2)];
 
-      const result = normalizer.normalizeHandSize(landmarks);
-      expect(result.length).toBe(2);
+      const first = normalizer.normalizeHandSize(landmarks);
+      const second = normalizer.normalizeHandSize(landmarks);
+
+      expect(first.length).toBe(2);
+      expect(second.length).toBe(2);
+      expect(first[0].length).toBe(21);
+      expect(first[1].length).toBe(21);
     });
 
     it('should skip hands with insufficient landmarks', () => {
@@ -347,6 +348,21 @@ describe('TremorCompensator', () => {
 
       const result = compensator.smoothLandmarks(landmarks);
       expect(result.length).toBe(2);
+    });
+
+    it('should preserve both hands after smoothing with history', () => {
+      const createHand = (base: number) =>
+        Array.from({ length: 21 }, () => [base, base, 0]);
+
+      const initial = [createHand(0.1), createHand(0.2)];
+      const moved = [createHand(0.11), createHand(0.21)];
+
+      compensator.smoothLandmarks(initial);
+      const result = compensator.smoothLandmarks(moved);
+
+      expect(result.length).toBe(2);
+      expect(result[0].length).toBe(21);
+      expect(result[1].length).toBe(21);
     });
   });
 

--- a/app/webview/core/GestureRecognitionOrchestrator.ts
+++ b/app/webview/core/GestureRecognitionOrchestrator.ts
@@ -233,12 +233,20 @@ export class GestureRecognitionOrchestrator {
    */
   private sendGestureResult(processingResult: ProcessingResult, originalResults: MediaPipeGestureResult): void {
     try {
+      const handednessLabels =
+        processingResult.metadata?.handednesses?.map((label) => String(label)) ??
+        originalResults.handednesses?.map((hand) => {
+          const category = hand?.[0]?.categoryName;
+          return typeof category === 'string' ? category : 'unknown';
+        }) ??
+        [];
+
       const payload: GestureMessagePayload = {
         type: 'gesture',
         gesture: processingResult.gesture,
         confidence: processingResult.confidence,
         landmarks: processingResult.landmarks,
-        handednesses: originalResults.handednesses?.map(h => h.categoryName) || [],
+        handednesses: handednessLabels,
         timestamp: processingResult.timestamp ?? Date.now(),
         isFallback: processingResult.isFallback,
         systemHealth: this.errorRecoveryManager.getHealthStatus(),

--- a/app/webview/gestureProcessing.ts
+++ b/app/webview/gestureProcessing.ts
@@ -195,7 +195,7 @@ export class PartialGestureDetector {
 }
 
 export class TremorCompensator {
-  private movementHistory: Array<{ landmarks: number[][]; timestamp: number }> = [];
+  private movementHistory: Array<{ landmarks: number[][][]; timestamp: number }> = [];
   private readonly MAX_HISTORY = 3;
   private readonly SMOOTHING_FACTOR = 0.7;
   private readonly MOVEMENT_THRESHOLD = 0.02;
@@ -204,85 +204,168 @@ export class TremorCompensator {
    * Optimized tremor compensation with reduced memory usage
    */
   smoothLandmarks(landmarks: number[][][]): number[][][] {
-    if (!landmarks?.[0] || landmarks[0].length < 21) {
+    if (!Array.isArray(landmarks) || landmarks.length === 0) {
       return landmarks;
     }
 
-    const currentLandmarks = landmarks[0];
+    const normalizedLandmarks = this.cloneHands(landmarks);
     const now = Date.now();
 
     // Add to history
-    this.movementHistory.push({ landmarks: currentLandmarks, timestamp: now });
+    this.movementHistory.push({ landmarks: this.cloneHands(normalizedLandmarks), timestamp: now });
     if (this.movementHistory.length > this.MAX_HISTORY) {
       this.movementHistory.shift();
     }
 
     // Only smooth if we have enough history
     if (this.movementHistory.length < 2) {
-      return landmarks;
+      return normalizedLandmarks;
     }
 
-    // Check if movement is intentional
-    if (!this.isIntentionalMovement(landmarks, [this.movementHistory[this.movementHistory.length - 2].landmarks])) {
-      // Return previous smoothed position to reduce tremor
-      return [this.movementHistory[this.movementHistory.length - 2].landmarks];
-    }
+    const previousEntry = this.movementHistory[this.movementHistory.length - 2];
 
-    // Apply smoothing
-    const smoothed = this.applySmoothing(currentLandmarks);
-    return [smoothed];
+    const smoothedHands = normalizedLandmarks.map((hand, index) => {
+      const previousHand = previousEntry.landmarks[index];
+
+      if (!hand || hand.length === 0) {
+        return hand;
+      }
+
+      if (!previousHand || previousHand.length === 0) {
+        return hand;
+      }
+
+      if (!this.isIntentionalMovementForHand(hand, previousHand)) {
+        return this.cloneHand(previousHand);
+      }
+
+      return this.applySmoothing(hand, previousHand);
+    });
+
+    return smoothedHands;
   }
 
-  private applySmoothing(current: number[][]): number[][] {
-    if (this.movementHistory.length < 2) return current;
-
-    const previous = this.movementHistory[this.movementHistory.length - 2].landmarks;
+  private applySmoothing(current: number[][], previous: number[][]): number[][] {
     const smoothed: number[][] = [];
+    const length = Math.min(current.length, previous.length);
 
-    for (let i = 0; i < Math.min(current.length, previous.length); i++) {
+    for (let i = 0; i < length; i++) {
       const currentPoint = current[i];
       const previousPoint = previous[i];
 
-      // Apply exponential smoothing
+      if (!currentPoint || !previousPoint) {
+        smoothed.push(currentPoint || previousPoint || [0, 0, 0]);
+        continue;
+      }
+
       const smoothedPoint = [
         previousPoint[0] * this.SMOOTHING_FACTOR + currentPoint[0] * (1 - this.SMOOTHING_FACTOR),
         previousPoint[1] * this.SMOOTHING_FACTOR + currentPoint[1] * (1 - this.SMOOTHING_FACTOR),
-        previousPoint[2] * this.SMOOTHING_FACTOR + currentPoint[2] * (1 - this.SMOOTHING_FACTOR),
+        (previousPoint[2] ?? 0) * this.SMOOTHING_FACTOR + (currentPoint[2] ?? 0) * (1 - this.SMOOTHING_FACTOR),
       ];
 
       smoothed.push(smoothedPoint);
+    }
+
+    if (current.length > length) {
+      for (let i = length; i < current.length; i++) {
+        smoothed.push(current[i]);
+      }
     }
 
     return smoothed;
   }
 
   isIntentionalMovement(currentLandmarks: number[][][], previousLandmarks: number[][][]): boolean {
-    if (!currentLandmarks?.[0] || !previousLandmarks?.[0]) return true;
-
-    const current = currentLandmarks[0];
-    const previous = previousLandmarks[0];
-
-    if (current.length !== previous.length) return true;
+    if (!currentLandmarks?.length || !previousLandmarks?.length) return true;
 
     let totalMovement = 0;
     let points = 0;
 
-    for (let i = 0; i < Math.min(current.length, previous.length, 21); i++) {
-      const currentPoint = current[i];
-      const previousPoint = previous[i];
+    for (let handIdx = 0; handIdx < Math.min(currentLandmarks.length, previousLandmarks.length); handIdx++) {
+      const currentHand = currentLandmarks[handIdx];
+      const previousHand = previousLandmarks[handIdx];
+      if (!currentHand || !previousHand) {
+        continue;
+      }
+
+      const length = Math.min(currentHand.length, previousHand.length, 21);
+      for (let i = 0; i < length; i++) {
+        const currentPoint = currentHand[i];
+        const previousPoint = previousHand[i];
+        if (!currentPoint || !previousPoint) {
+          continue;
+        }
+
+        const movement = Math.sqrt(
+          Math.pow((currentPoint[0] ?? 0) - (previousPoint[0] ?? 0), 2) +
+          Math.pow((currentPoint[1] ?? 0) - (previousPoint[1] ?? 0), 2) +
+          Math.pow((currentPoint[2] ?? 0) - (previousPoint[2] ?? 0), 2)
+        );
+
+        totalMovement += movement;
+        points++;
+      }
+    }
+
+    if (points === 0) {
+      return true;
+    }
+
+    const averageMovement = totalMovement / points;
+    return averageMovement > this.MOVEMENT_THRESHOLD;
+  }
+
+  private isIntentionalMovementForHand(currentHand: number[][], previousHand: number[][]): boolean {
+    if (!currentHand?.length || !previousHand?.length) {
+      return true;
+    }
+
+    const length = Math.min(currentHand.length, previousHand.length, 21);
+    let totalMovement = 0;
+    let points = 0;
+
+    for (let i = 0; i < length; i++) {
+      const currentPoint = currentHand[i];
+      const previousPoint = previousHand[i];
+      if (!currentPoint || !previousPoint) {
+        continue;
+      }
 
       const movement = Math.sqrt(
-        Math.pow(currentPoint[0] - previousPoint[0], 2) +
-        Math.pow(currentPoint[1] - previousPoint[1], 2) +
-        Math.pow(currentPoint[2] - previousPoint[2], 2)
+        Math.pow((currentPoint[0] ?? 0) - (previousPoint[0] ?? 0), 2) +
+        Math.pow((currentPoint[1] ?? 0) - (previousPoint[1] ?? 0), 2) +
+        Math.pow((currentPoint[2] ?? 0) - (previousPoint[2] ?? 0), 2)
       );
 
       totalMovement += movement;
       points++;
     }
 
-    const averageMovement = points > 0 ? totalMovement / points : 0;
+    if (points === 0) {
+      return true;
+    }
+
+    const averageMovement = totalMovement / points;
     return averageMovement > this.MOVEMENT_THRESHOLD;
+  }
+
+  private cloneHands(landmarks: number[][][]): number[][][] {
+    return landmarks.map((hand) => this.cloneHand(hand));
+  }
+
+  private cloneHand(hand: number[][]): number[][] {
+    if (!Array.isArray(hand)) {
+      return [];
+    }
+
+    return hand.map((point) => {
+      if (!Array.isArray(point)) {
+        return [0, 0, 0];
+      }
+
+      return [point[0] ?? 0, point[1] ?? 0, point[2] ?? 0];
+    });
   }
 
   clearHistory(): void {
@@ -291,35 +374,52 @@ export class TremorCompensator {
 }
 
 export class GestureSizeNormalizer {
-  private tolerance: number = 0.3;
-  private referenceHandSize: number | null = null;
+  private static readonly DEFAULT_TOLERANCE = 0.3;
+  private static readonly MIN_TOLERANCE = 0.1;
+  private static readonly MAX_TOLERANCE = 1.0;
+  private static readonly DEFAULT_MAX_SCALE = 1.4;
+
+  private tolerance: number = GestureSizeNormalizer.DEFAULT_TOLERANCE;
+  private referenceHandSizes: Array<number | null> = [];
 
   /**
    * Optimized gesture size normalization
    */
   normalizeHandSize(landmarks: number[][][]): number[][][] {
-    if (!landmarks?.[0] || landmarks[0].length < 21) {
+    if (!Array.isArray(landmarks) || landmarks.length === 0) {
       return landmarks;
     }
 
-    const hand = landmarks[0];
-    const handSize = this.calculateHandSize(hand);
+    const normalizedHands = landmarks.map((hand, index) => {
+      if (!Array.isArray(hand) || hand.length < 21) {
+        this.referenceHandSizes[index] = null;
+        return hand;
+      }
 
-    // Initialize reference size on first use
-    if (this.referenceHandSize === null) {
-      this.referenceHandSize = handSize;
-      return landmarks;
-    }
+      const handSize = this.calculateHandSize(hand);
 
-    // Check if normalization is needed
-    const sizeRatio = handSize / this.referenceHandSize;
-    if (Math.abs(sizeRatio - 1) <= this.tolerance) {
-      return landmarks; // No normalization needed
-    }
+      if (this.referenceHandSizes[index] === null || this.referenceHandSizes[index] === undefined) {
+        this.referenceHandSizes[index] = handSize;
+        return hand;
+      }
 
-    // Apply normalization
-    const normalizedHand = this.applySizeNormalization(hand, sizeRatio);
-    return [normalizedHand];
+      const referenceSize = this.referenceHandSizes[index] ?? 0;
+      if (referenceSize <= 0) {
+        this.referenceHandSizes[index] = handSize;
+        return hand;
+      }
+
+      const sizeRatio = handSize / referenceSize;
+      if (Math.abs(sizeRatio - 1) <= this.tolerance) {
+        return hand;
+      }
+
+      const { minScale, maxScale } = this.computeScaleBounds();
+      const clampedRatio = this.clampSizeRatio(sizeRatio, minScale, maxScale);
+      return this.applySizeNormalization(hand, clampedRatio);
+    });
+
+    return normalizedHands;
   }
 
   private calculateHandSize(hand: number[][]): number {
@@ -353,12 +453,62 @@ export class GestureSizeNormalizer {
     return normalized;
   }
 
+  private clampSizeRatio(sizeRatio: number, minScale: number, maxScale: number): number {
+    if (!Number.isFinite(sizeRatio) || sizeRatio <= 0) {
+      return 1;
+    }
+
+    if (sizeRatio < minScale) {
+      return minScale;
+    }
+
+    if (sizeRatio > maxScale) {
+      return maxScale;
+    }
+
+    return sizeRatio;
+  }
+
+  private clampTolerance(value: number): number {
+    if (!Number.isFinite(value)) {
+      return this.tolerance;
+    }
+
+    const clamped = Math.max(GestureSizeNormalizer.MIN_TOLERANCE, Math.min(GestureSizeNormalizer.MAX_TOLERANCE, value));
+    return clamped;
+  }
+
+  private computeScaleBounds(): { minScale: number; maxScale: number } {
+    const tolerance = this.tolerance;
+    const minScale = Math.max(0, 1 - tolerance);
+
+    const defaultMaxScale = GestureSizeNormalizer.DEFAULT_MAX_SCALE;
+    const computedMax = 1 + tolerance;
+    const isDefaultTolerance = Math.abs(tolerance - GestureSizeNormalizer.DEFAULT_TOLERANCE) < 1e-6;
+    const maxScale = isDefaultTolerance ? Math.max(defaultMaxScale, computedMax) : computedMax;
+
+    return {
+      minScale,
+      maxScale,
+    };
+  }
+
   setTolerance(tolerance: number): void {
-    this.tolerance = Math.max(0, Math.min(1, tolerance));
+    this.tolerance = this.clampTolerance(tolerance);
+  }
+
+  getTolerance(): { tolerance: number; minScale: number; maxScale: number } {
+    const { minScale, maxScale } = this.computeScaleBounds();
+
+    return {
+      tolerance: this.tolerance,
+      minScale,
+      maxScale,
+    };
   }
 
   reset(): void {
-    this.referenceHandSize = null;
+    this.referenceHandSizes = [];
   }
 }
 

--- a/app/webview/gestureProcessing.ts
+++ b/app/webview/gestureProcessing.ts
@@ -212,7 +212,7 @@ export class TremorCompensator {
     const now = Date.now();
 
     // Add to history
-    this.movementHistory.push({ landmarks: this.cloneHands(normalizedLandmarks), timestamp: now });
+    this.movementHistory.push({ landmarks: normalizedLandmarks, timestamp: now });
     if (this.movementHistory.length > this.MAX_HISTORY) {
       this.movementHistory.shift();
     }
@@ -485,6 +485,9 @@ export class GestureSizeNormalizer {
     const defaultMaxScale = GestureSizeNormalizer.DEFAULT_MAX_SCALE;
     const computedMax = 1 + tolerance;
     const isDefaultTolerance = Math.abs(tolerance - GestureSizeNormalizer.DEFAULT_TOLERANCE) < 1e-6;
+    // Preserve the legacy maximum (1.4) when caregivers keep the default tolerance so existing
+    // trained samples continue to fit within the expected size window. Customized tolerances use
+    // the symmetric 1 ± tolerance range.
     const maxScale = isDefaultTolerance ? Math.max(defaultMaxScale, computedMax) : computedMax;
 
     return {


### PR DESCRIPTION
## Summary
- add a reusable hand landmark stabilizer that keeps per-hand landmarks alive briefly and sort them consistently, with unit tests
- reset and apply the stabilizer inside the recognition screen so the mirrored preview stays aligned and keeps both hands visible when frames drop

## Testing
- npm run type-check --prefix app
- npm test --prefix app *(fails: AmyFirstHapticService still requires expo-haptics / multi-sensory mocks in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1079d7940832295de7ec0313603e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Handedness (Left/Right) is now propagated to gesture callbacks and used across detection, recognition, training, and teaching flows.

- Improvements
  - New landmark stabilization and per-hand tremor compensation for smoother multi-hand tracking.
  - Per-hand size normalization and safer deep-cloning of landmarks.
  - Mirror-aware handedness adjustments to align overlays/recordings with front-facing camera.

- Bug Fixes
  - Corrected mirroring behavior for hand previews.

- Tests
  - Added unit and integration tests covering landmark utilities, stabilization, handedness, and multi-hand processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->