### PR TITLE
Use stabilized landmarks for centroid classification

### DIFF
--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -318,7 +318,7 @@ export default function RecognitionScreen({
 
     // Always try to classify with our custom model
     if (centroidsRef.current) {
-      const flat = flattenHands(safeLandmarks) as Point[];
+      const flat = flattenHands(stabilized.landmarks) as Point[];
       const res = classifyWithCentroids(flat, centroidsRef.current);
       if (res) {
         g = res.label;


### PR DESCRIPTION
## Summary
- ensure centroid classification uses stabilized landmark ordering when available to honor handedness adjustments

## Testing
- npm test --prefix app -- --watch=false *(fails: ScreenFlash test suite cannot run due to Modal mock accessing undefined create function)*

------
https://chatgpt.com/codex/tasks/task_e_68d16f1d9fec83228bb50eb94ceef6e5