### PR TITLE
Allow overriding MediaPipe loader without require

### DIFF
--- a/app/assets/gestureDetector.js
+++ b/app/assets/gestureDetector.js
@@ -1945,7 +1945,7 @@
   }
 
   // webview/core/GestureDetector.ts
-  var GestureDetector = class {
+  var GestureDetector = class _GestureDetector {
     constructor(video2, overlay2) {
       this.gestureRecognizer = null;
       this.running = false;
@@ -1958,6 +1958,15 @@
       this.overlayRenderer = new OverlayRenderer(overlay2);
       this.healthMonitor = new HealthMonitor();
     }
+    static {
+      this.loadTasksVisionImpl = loadTasksVision;
+    }
+    /**
+     * Allows tests to override the MediaPipe loader implementation
+     */
+    static setLoadTasksVisionImplementation(loader) {
+      _GestureDetector.loadTasksVisionImpl = loader ?? loadTasksVision;
+    }
     /**
      * Set callback for gesture results
      */
@@ -1969,8 +1978,15 @@
      */
     async initialize() {
       try {
-        const components = await loadTasksVision();
-        const vision = await components.FilesetResolver.forVisionTasks(components.wasmBase);
+        const components = await _GestureDetector.loadTasksVisionImpl();
+        if (!components) {
+          throw new Error("Tasks Vision components not available");
+        }
+        const filesetResolver = components.FilesetResolver ?? window?.fileset_resolver?.FilesetResolver;
+        if (!filesetResolver || typeof filesetResolver.forVisionTasks !== "function") {
+          throw new Error("Tasks Vision FilesetResolver not available");
+        }
+        const vision = await filesetResolver.forVisionTasks(components.wasmBase);
         const baseOptions = {
           modelAssetPath: "https://storage.googleapis.com/mediapipe-models/gesture_recognizer/gesture_recognizer/float16/1/gesture_recognizer.task",
           delegate: "GPU"
@@ -2574,14 +2590,16 @@
             detectedGesture = stepResult.gesture;
             currentConfidence = stepResult.confidence;
           }
-          const stepTime = performance.now() - stepStartTime;
-          this.recordStepPerformance(step.name, stepTime);
+          const stepEnd = performance.now();
+          const stepDuration = this.sanitizeDuration(stepEnd - stepStartTime);
+          this.recordStepPerformance(step.name, stepDuration);
         } catch (error) {
           console.warn(`Processing step ${step.name} failed:`, error);
           stepsExecuted.push(step.name);
         }
       }
-      const totalTime = performance.now() - startTime;
+      const endTime = performance.now();
+      const totalTime = this.sanitizeDuration(endTime - startTime);
       this.performanceOptimizer.recordProcessingTime(totalTime);
       aggregated.timestamp = aggregated.timestamp ?? context.timestamp;
       const result = {
@@ -2595,6 +2613,12 @@
       };
       this.lastProcessingResult = result;
       return result;
+    }
+    sanitizeDuration(duration) {
+      if (!Number.isFinite(duration)) {
+        return 0.01;
+      }
+      return duration <= 0 ? 0.01 : duration;
     }
     /**
      * Determine if an expensive step should be skipped
@@ -2644,7 +2668,7 @@
         gesture: this.lastProcessingResult?.gesture,
         confidence: this.lastProcessingResult?.confidence || 0,
         landmarks: context.landmarks,
-        processingTime: performance.now() - startTime,
+        processingTime: this.sanitizeDuration(performance.now() - startTime),
         stepsExecuted: [],
         skippedSteps: ["frame_skipped"]
       };

--- a/app/webview/__tests__/GestureDetector.test.ts
+++ b/app/webview/__tests__/GestureDetector.test.ts
@@ -23,6 +23,7 @@ describe('GestureDetector', () => {
   let mockOverlay: HTMLCanvasElement;
   let mockGestureRecognizer: any;
   let mockComponents: MediaPipeComponents;
+  let mockLoadTasksVision: jest.Mock;
   let mockCameraManager: jest.Mocked<CameraManager>;
   let mockOverlayRenderer: jest.Mocked<OverlayRenderer>;
   let mockResourceManager: jest.Mocked<ResourceManager>;
@@ -71,13 +72,13 @@ describe('GestureDetector', () => {
     } as any;
 
     // Setup mocks
-    const mockLoadTasksVision = jest.fn().mockResolvedValue(mockComponents);
     const mockLoadConfig = jest.fn().mockReturnValue({
       performance: { telemetrySampleRate: 1000 },
       thresholds: { mlpConfidence: 0.8 },
     });
 
-    require('../core/MediaPipeLoader').loadTasksVision = mockLoadTasksVision;
+    mockLoadTasksVision = jest.fn().mockResolvedValue(mockComponents);
+    GestureDetector.setLoadTasksVisionImplementation(mockLoadTasksVision);
     require('../config/GestureConfig').loadConfig = mockLoadConfig;
 
     (CameraManager as jest.MockedClass<typeof CameraManager>).mockImplementation(() => mockCameraManager);
@@ -87,6 +88,7 @@ describe('GestureDetector', () => {
   });
 
   afterEach(() => {
+    GestureDetector.setLoadTasksVisionImplementation(null);
     jest.clearAllMocks();
   });
 
@@ -173,7 +175,6 @@ describe('GestureDetector', () => {
 
   describe('error handling', () => {
     it('should handle initialization errors gracefully', async () => {
-      const mockLoadTasksVision = require('../core/MediaPipeLoader').loadTasksVision;
       mockLoadTasksVision.mockRejectedValue(new Error('Network error'));
 
       const detector = new GestureDetector(mockVideo, mockOverlay);

--- a/app/webview/core/GestureDetector.ts
+++ b/app/webview/core/GestureDetector.ts
@@ -3,7 +3,7 @@
  * Coordinates all gesture detection components
  */
 
-import { loadTasksVision, MediaPipeComponents } from './MediaPipeLoader';
+import { loadTasksVision, type MediaPipeComponents } from './MediaPipeLoader';
 import { CameraManager } from './CameraManager';
 import { OverlayRenderer } from './OverlayRenderer';
 import { ResourceManager } from '../utils/ResourceManager';
@@ -19,6 +19,8 @@ import {
 } from '../utils/FrameCaptureManager';
 
 export class GestureDetector {
+  private static loadTasksVisionImpl: () => Promise<MediaPipeComponents | undefined> = loadTasksVision;
+
   private config: GestureDetectorConfig;
   private resourceManager: ResourceManager;
   private cameraManager: CameraManager;
@@ -42,6 +44,15 @@ export class GestureDetector {
   }
 
   /**
+   * Allows tests to override the MediaPipe loader implementation
+   */
+  static setLoadTasksVisionImplementation(
+    loader: (() => Promise<MediaPipeComponents | undefined>) | null,
+  ): void {
+    GestureDetector.loadTasksVisionImpl = loader ?? loadTasksVision;
+  }
+
+  /**
    * Set callback for gesture results
    */
   setResultCallback(callback: (results: MediaPipeGestureResult, timestamp: number) => void): void {
@@ -54,10 +65,21 @@ export class GestureDetector {
   async initialize(): Promise<void> {
     try {
       // Load MediaPipe components
-      const components: MediaPipeComponents = await loadTasksVision();
+      const components: MediaPipeComponents | undefined = await GestureDetector.loadTasksVisionImpl();
+
+      if (!components) {
+        throw new Error('Tasks Vision components not available');
+      }
 
       // Create gesture recognizer
-      const vision = await components.FilesetResolver.forVisionTasks(components.wasmBase);
+      const filesetResolver =
+        components.FilesetResolver ?? (window as any)?.fileset_resolver?.FilesetResolver;
+
+      if (!filesetResolver || typeof filesetResolver.forVisionTasks !== 'function') {
+        throw new Error('Tasks Vision FilesetResolver not available');
+      }
+
+      const vision = await filesetResolver.forVisionTasks(components.wasmBase);
       const baseOptions = {
         modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/gesture_recognizer/gesture_recognizer/float16/1/gesture_recognizer.task',
         delegate: 'GPU' as const,

--- a/app/webview/utils/ProcessingPipeline.ts
+++ b/app/webview/utils/ProcessingPipeline.ts
@@ -140,8 +140,9 @@ export class ProcessingPipeline {
         }
 
         // Record step performance
-        const stepTime = performance.now() - stepStartTime;
-        this.recordStepPerformance(step.name, stepTime);
+        const stepEnd = performance.now();
+        const stepDuration = this.sanitizeDuration(stepEnd - stepStartTime);
+        this.recordStepPerformance(step.name, stepDuration);
 
       } catch (error) {
         console.warn(`Processing step ${step.name} failed:`, error);
@@ -151,7 +152,8 @@ export class ProcessingPipeline {
       }
     }
 
-    const totalTime = performance.now() - startTime;
+    const endTime = performance.now();
+    const totalTime = this.sanitizeDuration(endTime - startTime);
     this.performanceOptimizer.recordProcessingTime(totalTime);
 
     aggregated.timestamp = aggregated.timestamp ?? context.timestamp;
@@ -173,6 +175,13 @@ export class ProcessingPipeline {
 
     this.lastProcessingResult = result;
     return result;
+  }
+
+  private sanitizeDuration(duration: number): number {
+    if (!Number.isFinite(duration)) {
+      return 0.01;
+    }
+    return duration <= 0 ? 0.01 : duration;
   }
 
   /**
@@ -238,7 +247,7 @@ export class ProcessingPipeline {
       gesture: this.lastProcessingResult?.gesture,
       confidence: this.lastProcessingResult?.confidence || 0,
       landmarks: context.landmarks,
-      processingTime: performance.now() - startTime,
+      processingTime: this.sanitizeDuration(performance.now() - startTime),
       stepsExecuted: [],
       skippedSteps: ['frame_skipped']
     };


### PR DESCRIPTION
## Summary
- add a static override hook so GestureDetector can swap the MediaPipe loader without relying on CommonJS require at runtime
- adjust gesture detector tests to inject mocked loaders via the new helper and cleanly reset between cases
- keep processing timing finite when frames are skipped and regenerate the bundled webview script

## Testing
- npx jest webview/__tests__/GestureDetector.test.ts --runInBand
- npx jest webview/__tests__/PerformanceOptimizations.test.ts --runInBand
- npm run build:webview --prefix app

------
https://chatgpt.com/codex/tasks/task_e_68d2a6a6337c8322be00eb37b867d5e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable loader for vision components to improve testability without affecting production use.
- Bug Fixes
  - Improved initialization with clear errors when required vision components are unavailable.
  - Sanitized timing calculations to prevent negative or non-finite processing times, ensuring reliable performance metrics.
- Refactor
  - Streamlined gesture detection initialization flow with stronger guards and clearer control paths.
- Tests
  - Updated tests to inject a custom vision loader via a public API, simplifying setup and teardown while reducing brittle module mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->