### PR TITLE
Handle training bundle uploads and align MLP artifact naming

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,18 +12,18 @@
         "@babel/runtime": "7.28.4",
         "@types/bcrypt": "6.0.0",
         "@types/jsonwebtoken": "9.0.10",
-        "@types/multer": "^1.4.11",
+        "adm-zip": "^0.5.16",
         "bcrypt": "6.0.0",
         "express": "5.1.0",
         "express-rate-limit": "6.7.0",
         "jsonwebtoken": "9.0.2",
-        "multer": "^1.4.5-lts.1",
         "openai": "^4.28.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.25.4",
         "@babel/preset-typescript": "^7.24.7",
+        "@types/adm-zip": "^0.5.7",
         "@types/express": "5.0.3",
         "@types/jest": "^29.5.14",
         "@types/node": "24.1.0",
@@ -2556,6 +2556,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
+      "integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2614,6 +2624,7 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -2624,6 +2635,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2647,6 +2659,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
       "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -2658,6 +2671,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
       "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2680,6 +2694,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -2748,6 +2763,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
@@ -2755,15 +2771,6 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
-    },
-    "node_modules/@types/multer": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
-      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "24.1.0",
@@ -2788,18 +2795,21 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
       "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -2810,6 +2820,7 @@
       "version": "1.15.8",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
       "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -3200,6 +3211,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -3284,12 +3304,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/append-field": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
-      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -3597,18 +3611,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3821,21 +3825,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -3902,12 +3891,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -5321,12 +5304,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6448,94 +6425,11 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/multer": {
-      "version": "1.4.5-lts.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
-      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
-      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
-      "license": "MIT",
-      "dependencies": {
-        "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/multer/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/multer/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/multer/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/multer/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6648,15 +6542,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -6994,12 +6879,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -7119,27 +6998,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/regenerate": {
@@ -7576,29 +7434,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -7892,12 +7727,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -8011,12 +7840,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -8146,15 +7969,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
     "@babel/runtime": "7.28.4",
     "@types/bcrypt": "6.0.0",
     "@types/jsonwebtoken": "9.0.10",
+    "adm-zip": "^0.5.16",
     "bcrypt": "6.0.0",
     "express": "5.1.0",
     "express-rate-limit": "6.7.0",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.25.4",
     "@babel/preset-typescript": "^7.24.7",
+    "@types/adm-zip": "^0.5.7",
     "@types/express": "5.0.3",
     "@types/jest": "^29.5.14",
     "@types/node": "24.1.0",

--- a/server/src/constants/modelPaths.ts
+++ b/server/src/constants/modelPaths.ts
@@ -63,13 +63,23 @@ export function getTrainedModelPath(profileId?: string): string {
 // MLP model path (.npz)
 export const TRAINED_MLP_MODEL_PATH = path.join(DATA_DIR, 'amy_model.npz');
 export function getMlpModelPath(profileId?: string): string {
-  return getProfiledPath(TRAINED_MLP_MODEL_PATH, profileId);
+  if (!profileId) {
+    return TRAINED_MLP_MODEL_PATH;
+  }
+  if (!PROFILE_ID_PATTERN.test(profileId)) {
+    throw new Error('Invalid profileId');
+  }
+  return path.join(DATA_DIR, `dgs_model_${profileId}.npz`);
 }
 export const BASELINE_MLP_MODEL_PATH = path.join(SERVER_DIR, '..', 'data', 'amy_model.npz');
 export const GESTURE_LABELS_PATH = path.join(
   SERVER_DIR,
   '../app/assets/models/gesture_labels.json',
 );
+
+export const TRAINING_UPLOADS_DIR = path.join(DATA_DIR, 'uploads');
+export const TRAINING_DATASETS_DIR = path.join(DATA_DIR, 'datasets');
+export const TRAINING_MANIFEST_PATH = path.join(TRAINING_DATASETS_DIR, 'training_manifest.json');
 
 // Ensure DATA_DIR exists before any read/write
 export async function ensureDataDir(): Promise<void> {

--- a/server/src/routes/trainingBundleRoute.ts
+++ b/server/src/routes/trainingBundleRoute.ts
@@ -1,0 +1,150 @@
+import express, { Request, Response } from 'express';
+import type { Express } from 'express';
+import path from 'path';
+import { promises as fs } from 'fs';
+import AdmZip, { IZipEntry } from 'adm-zip';
+
+import { atomicWriteJson, atomicWriteBuffer } from '../utils/atomicFs.js';
+import {
+  ensureDataDir,
+  TRAINING_UPLOADS_DIR,
+  TRAINING_DATASETS_DIR,
+  TRAINING_MANIFEST_PATH,
+  DATA_DIR,
+  PROFILE_ID_PATTERN,
+} from '../constants/modelPaths.js';
+import { legacyAuth } from '../middleware/auth.js';
+import { withFileLock } from '../utils/fileLock.js';
+
+interface TrainingBundleManifestEntry {
+  id: string;
+  profileId: string | null;
+  label: string;
+  capturedAt: string | null;
+  source: string | null;
+  storage: {
+    directory: string;
+    bundle: string;
+    files: string[];
+  };
+  metadata: unknown;
+  receivedAt: string;
+}
+
+interface TrainingBundleManifestFile {
+  entries: TrainingBundleManifestEntry[];
+}
+
+const trainingBundleUpload = express.raw({ type: 'application/zip', limit: '64mb' });
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function registerTrainingBundleRoute(app: Express, genId: () => string): void {
+  app.post('/api/v1/dgs/sample-bundles', legacyAuth, trainingBundleUpload, async (req: Request, res: Response) => {
+    try {
+      if (!Buffer.isBuffer(req.body) || req.body.length === 0) {
+        return res.status(400).json({ error: 'ZIP payload required' });
+      }
+
+      await ensureDataDir();
+      await fs.mkdir(TRAINING_UPLOADS_DIR, { recursive: true });
+
+      let zip: AdmZip;
+      try {
+        zip = new AdmZip(req.body as Buffer);
+      } catch (error) {
+        console.error('Invalid training bundle ZIP:', error);
+        return res.status(400).json({ error: 'Invalid training bundle ZIP' });
+      }
+
+      const metadataEntry = zip.getEntry('metadata.json');
+      if (!metadataEntry) {
+        return res.status(400).json({ error: 'metadata.json missing from bundle' });
+      }
+
+      let metadataContent: string;
+      try {
+        metadataContent = metadataEntry.getData().toString('utf8');
+      } catch (error) {
+        console.error('Failed to read metadata.json from bundle:', error);
+        return res.status(400).json({ error: 'Failed to read metadata.json' });
+      }
+
+      let metadata: any;
+      try {
+        metadata = JSON.parse(metadataContent);
+      } catch (error) {
+        console.error('metadata.json is not valid JSON:', error);
+        return res.status(400).json({ error: 'metadata.json must be valid JSON' });
+      }
+
+      const label = isNonEmptyString(metadata.label) ? metadata.label.trim() : '';
+      if (!label) {
+        return res.status(400).json({ error: 'metadata.label is required' });
+      }
+
+      const profileIdRaw = isNonEmptyString(metadata.profileId) ? metadata.profileId.trim() : undefined;
+      if (profileIdRaw && !PROFILE_ID_PATTERN.test(profileIdRaw)) {
+        return res.status(400).json({ error: 'metadata.profileId is invalid' });
+      }
+
+      const bundleId = genId();
+      const profileBucket = profileIdRaw ?? 'unassigned';
+      const bundleRoot = path.join(TRAINING_UPLOADS_DIR, profileBucket, bundleId);
+      await fs.mkdir(bundleRoot, { recursive: true });
+
+      const bundleZipPath = path.join(bundleRoot, 'bundle.zip');
+      await atomicWriteBuffer(bundleZipPath, req.body as Buffer);
+
+      try {
+        zip.extractAllTo(bundleRoot, true);
+      } catch (error) {
+        console.error('Failed to extract training bundle payload:', error);
+        return res.status(400).json({ error: 'Failed to extract training bundle' });
+      }
+
+      const manifestEntry: TrainingBundleManifestEntry = {
+        id: bundleId,
+        profileId: profileIdRaw ?? null,
+        label,
+        capturedAt: isNonEmptyString(metadata.capturedAt) ? metadata.capturedAt : null,
+        source: isNonEmptyString(metadata.source) ? metadata.source : null,
+        storage: {
+          directory: path.relative(DATA_DIR, bundleRoot),
+          bundle: path.relative(DATA_DIR, bundleZipPath),
+          files: zip
+            .getEntries()
+            .filter((entry: IZipEntry) => !entry.isDirectory)
+            .map((entry: IZipEntry) => entry.entryName),
+        },
+        metadata,
+        receivedAt: new Date().toISOString(),
+      };
+
+      await withFileLock(TRAINING_MANIFEST_PATH, async () => {
+        await fs.mkdir(TRAINING_DATASETS_DIR, { recursive: true });
+
+        let manifest: TrainingBundleManifestFile = { entries: [] };
+        try {
+          const raw = await fs.readFile(TRAINING_MANIFEST_PATH, 'utf8');
+          const parsed = JSON.parse(raw);
+          if (parsed && Array.isArray(parsed.entries)) {
+            manifest.entries = parsed.entries as TrainingBundleManifestEntry[];
+          }
+        } catch (error: any) {
+          if (error?.code !== 'ENOENT') throw error;
+        }
+
+        manifest.entries.push(manifestEntry);
+        await atomicWriteJson(TRAINING_MANIFEST_PATH, manifest);
+      });
+
+      res.status(202).json({ status: 'queued', id: bundleId });
+    } catch (error) {
+      console.error('Error saving training bundle:', error);
+      res.status(500).json({ error: 'Failed to save training bundle' });
+    }
+  });
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -8,8 +8,37 @@ import readline from 'readline';
 import { fileURLToPath } from 'url';
 
 import config from './config/index.js';
+import { withFileLock } from './utils/fileLock.js';
+import { registerTrainingBundleRoute } from './routes/trainingBundleRoute.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+function resolveServerModuleDir(): string {
+  if (typeof __dirname !== 'undefined') {
+    return __dirname;
+  }
+  let metaUrl: string | undefined;
+  try {
+    metaUrl = (0, eval)('import.meta.url') as string;
+  } catch {
+    metaUrl = undefined;
+  }
+  if (metaUrl) {
+    try {
+      return path.dirname(fileURLToPath(metaUrl));
+    } catch {
+      // fall through to cwd fallback
+    }
+  }
+  if (Array.isArray(process.argv) && process.argv[1]) {
+    try {
+      return path.dirname(path.resolve(process.argv[1]));
+    } catch {
+      // ignore
+    }
+  }
+  return path.resolve('.');
+}
+
+const serverModuleDir = resolveServerModuleDir();
 import { getCentroids, normalize } from './services/dgsModelService.js';
 import type { Point } from './services/dgsModelService.js';
 import { z } from 'zod';
@@ -109,11 +138,11 @@ const apiLimiter = rateLimit({
 });
 
 // Serve static files from the portal directory
-app.use('/portal', express.static(path.join(__dirname, 'portal')));
+app.use('/portal', express.static(path.join(serverModuleDir, 'portal')));
 
 // Serve the main portal HTML file
 app.get('/portal', (_req: Request, res: Response) => {
-  res.sendFile(path.join(__dirname, 'portal', 'index.html'));
+  res.sendFile(path.join(serverModuleDir, 'portal', 'index.html'));
 });
 
 // Basic health check endpoint for monitoring
@@ -251,12 +280,10 @@ app.get('/auth/me', auth, (req: Request, res: Response) => {
 app.use('/portal', portalRouter);
 
 // Serve static files from the caregiver portal directory
-app.use('/caregiver-portal', express.static(path.join(__dirname, 'caregiver-portal')));
+app.use('/caregiver-portal', express.static(path.join(serverModuleDir, 'caregiver-portal')));
 
 app.use('/api/caregiver-portal', auth, caregiverPortalApiRouter);
 
-// Simple per-file async lock
-const fileLocks = new Map<string, Promise<void>>();
 async function logTraining(message: string): Promise<void> {
   try {
     await fs.mkdir(DATA_DIR, { recursive: true });
@@ -267,28 +294,6 @@ async function logTraining(message: string): Promise<void> {
     console.warn('training log failed:', err);
   }
 }
-async function withFileLock<T>(file: string, fn: () => Promise<T>): Promise<T> {
-  const prev = fileLocks.get(file) ?? Promise.resolve();
-  let release!: () => void;
-  const next = new Promise<void>((res) => (release = res));
-  fileLocks.set(file, prev.finally(() => next));
-
-  let result: T;
-  try {
-    result = await fn();
-  } catch (error) {
-    // Ensure cleanup happens even if fn throws
-    release();
-    if (fileLocks.get(file) === next) fileLocks.delete(file);
-    throw error;
-  }
-
-  // Normal cleanup
-  release();
-  if (fileLocks.get(file) === next) fileLocks.delete(file);
-  return result;
-}
-
 // Apply generic rate limiting to API namespace
 app.use('/api', apiLimiter);
 
@@ -594,8 +599,10 @@ app.get('/api/v1/dgs/mlp-model', legacyAuth, async (req: Request, res: Response)
   }
 });
 
-  // Add a labeled DGS sample (landmarks normalized [0..1])
- app.post('/api/v1/dgs/samples', legacyAuth, async (req: Request, res: Response) => {
+registerTrainingBundleRoute(app, genId);
+
+// Add a labeled DGS sample (landmarks normalized [0..1])
+app.post('/api/v1/dgs/samples', legacyAuth, async (req: Request, res: Response) => {
   try {
     const Body = z.object({
       label: z.string().min(1),
@@ -938,7 +945,7 @@ app.post('/train-model', legacyAuth, async (req: Request, res: Response) => {
 
     // Fire-and-forget full training script for richer models
     const scriptPath = config.mlpScript;
-    const serverRoot = path.join(__dirname, '..');
+    const serverRoot = path.join(serverModuleDir, '..');
     const proc = spawn('python3', [path.isAbsolute(scriptPath) ? scriptPath : path.join(serverRoot, scriptPath)], {
       cwd: serverRoot,
     });
@@ -991,7 +998,7 @@ app.get('/api/training-status/:id', auth, (req: Request, res: Response) => {
 
 app.get('/model-version', legacyAuth, async (_req: Request, res: Response) => {
   try {
-    const pkgPath = path.join(__dirname, '..', 'package.json');
+    const pkgPath = path.join(serverModuleDir, '..', 'package.json');
     const pkgRaw = await fs.readFile(pkgPath, 'utf8');
     const { version } = JSON.parse(pkgRaw);
     res.json({ version, modelPath: 'latest-model' });
@@ -1049,19 +1056,25 @@ function isProfileAuthorized(req: Request, profileId: string): boolean {
 const CDN_CACHE_MAX_AGE_SECONDS = 3600; // 1 hour
 
 async function writeMinimalMlpModel(filePath: string, gestureCounts: Record<string, number>): Promise<void> {
-  try {
-    await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.copyFile(BASELINE_MLP_MODEL_PATH, filePath);
-    await fs.chmod(filePath, 0o640);
-    await logTraining(`seeded MLP from baseline into ${filePath}`);
-    return;
-  } catch (copyErr) {
-    await logTraining(`failed to copy baseline MLP (${String(copyErr)}), falling back to minimal generation`);
+  const entries = Object.entries(gestureCounts).map(([label, count]) => [label, Number(count) || 0] as const);
+  const hasCounts = entries.some(([, count]) => count > 0);
+
+  if (!hasCounts) {
+    try {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.copyFile(BASELINE_MLP_MODEL_PATH, filePath);
+      await fs.chmod(filePath, 0o640);
+      await logTraining(`seeded MLP from baseline into ${filePath}`);
+      return;
+    } catch (copyErr) {
+      await logTraining(`failed to copy baseline MLP (${String(copyErr)}), falling back to minimal generation`);
+    }
   }
 
-  const labels = Object.keys(gestureCounts);
-  const counts = labels.map((label) => Number(gestureCounts[label] ?? 0));
+  const labels = entries.map(([label]) => label);
+  const counts = entries.map(([, count]) => count);
   const payload = JSON.stringify({ labels, counts });
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
   const script = `import json, numpy as np, os, sys\n` +
     `path = sys.argv[1]\n` +
     `payload = json.loads(sys.argv[2])\n` +
@@ -1075,7 +1088,7 @@ async function writeMinimalMlpModel(filePath: string, gestureCounts: Record<stri
 
   await new Promise<void>((resolve, reject) => {
     const proc = spawn('python3', ['-c', script, filePath, payload], {
-      cwd: path.join(__dirname, '..'),
+      cwd: path.join(serverModuleDir, '..'),
       stdio: ['ignore', 'ignore', 'pipe'],
     });
     let stderr = '';
@@ -1205,7 +1218,7 @@ app.get('/model-metadata', legacyAuth, async (req: Request, res: Response) => {
   const resolvedFile = await resolveModelFile(profileId, res, getTrainedModelPath);
   if (!resolvedFile) return;
   try {
-    const pkgPath = path.join(__dirname, '..', 'package.json');
+    const pkgPath = path.join(serverModuleDir, '..', 'package.json');
     const pkgRaw = await fs.readFile(pkgPath, 'utf8');
     const { version } = JSON.parse(pkgRaw);
     const stat = await fs.stat(resolvedFile);

--- a/server/src/utils/fileLock.ts
+++ b/server/src/utils/fileLock.ts
@@ -1,0 +1,21 @@
+const fileLocks = new Map<string, Promise<void>>();
+
+export async function withFileLock<T>(file: string, fn: () => Promise<T>): Promise<T> {
+  const prev = fileLocks.get(file) ?? Promise.resolve();
+  let release!: () => void;
+  const next = new Promise<void>((res) => (release = res));
+  fileLocks.set(file, prev.finally(() => next));
+
+  let result: T;
+  try {
+    result = await fn();
+  } catch (error) {
+    release();
+    if (fileLocks.get(file) === next) fileLocks.delete(file);
+    throw error;
+  }
+
+  release();
+  if (fileLocks.get(file) === next) fileLocks.delete(file);
+  return result;
+}

--- a/server/test/trainingBundles.test.ts
+++ b/server/test/trainingBundles.test.ts
@@ -1,0 +1,120 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import AdmZip from 'adm-zip';
+import request from 'supertest';
+import express from 'express';
+import type { Express } from 'express';
+import type { registerTrainingBundleRoute as RegisterTrainingBundleRoute } from '../src/routes/trainingBundleRoute.js';
+
+const repoRoot = path.basename(process.cwd()) === 'server'
+  ? path.resolve(process.cwd(), '..')
+  : process.cwd();
+const SAMPLES_PATH = path.join(repoRoot, 'server', 'data', 'dgs_samples.json');
+
+async function loadSampleLandmarks(): Promise<number[][]> {
+  try {
+    const raw = await fs.readFile(SAMPLES_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed?.samples || parsed.samples.length === 0) {
+      throw new Error('No sample landmarks available');
+    }
+    const first = parsed.samples[0];
+    if (!Array.isArray(first.landmarks)) {
+      throw new Error('Sample landmarks missing');
+    }
+    return first.landmarks as number[][];
+  } catch (error: any) {
+    if (error?.code !== 'ENOENT') {
+      throw error;
+    }
+    return Array.from({ length: 42 }, (_, idx) => {
+      const base = idx / 100;
+      return [base, base, base / 2];
+    });
+  }
+}
+
+describe('POST /api/v1/dgs/sample-bundles', () => {
+  let app: Express;
+  let dataDir: string;
+  let manifestPath: string;
+
+  beforeAll(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'amy-bundle-'));
+    process.env.AMY_ECHO_DATA_DIR = dataDir;
+    process.env.API_TOKEN = 'bundle-token';
+    const mod = await import('../src/routes/trainingBundleRoute.js');
+    const registerRoute: RegisterTrainingBundleRoute = mod.registerTrainingBundleRoute;
+    app = express();
+    let counter = 0;
+    registerRoute(app, () => `bundle-${++counter}`);
+    manifestPath = path.join(dataDir, 'datasets', 'training_manifest.json');
+  });
+
+  afterAll(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+    delete process.env.AMY_ECHO_DATA_DIR;
+    delete process.env.API_TOKEN;
+  });
+
+  it('stores manifest entry for zipped training bundle', async () => {
+    const metadata = {
+      profileId: 'p-test-123',
+      label: 'HILFE',
+      capturedAt: '2024-05-28T12:03:11Z',
+      source: 'app://mediapipe',
+    };
+    const landmarks = await loadSampleLandmarks();
+
+    const zip = new AdmZip();
+    zip.addFile('metadata.json', Buffer.from(JSON.stringify(metadata, null, 2)));
+    zip.addFile('landmarks.json', Buffer.from(JSON.stringify({ landmarks }, null, 2)));
+    zip.addFile('clip.mp4', Buffer.from('fake-video-data'));
+
+    const response = await request(app)
+      .post('/api/v1/dgs/sample-bundles')
+      .set('Authorization', 'Bearer bundle-token')
+      .set('Content-Type', 'application/zip')
+      .send(zip.toBuffer())
+      .expect(202);
+
+    expect(response.body).toHaveProperty('status', 'queued');
+    expect(typeof response.body.id).toBe('string');
+
+    const manifestRaw = await fs.readFile(manifestPath, 'utf8');
+    const manifest = JSON.parse(manifestRaw) as {
+      entries: Array<{
+        id: string;
+        profileId: string | null;
+        label: string;
+        storage: { directory: string; bundle: string; files: string[] };
+        metadata: any;
+      }>;
+    };
+
+    expect(Array.isArray(manifest.entries)).toBe(true);
+    expect(manifest.entries.length).toBe(1);
+    const entry = manifest.entries[0];
+    expect(entry.id).toBe(response.body.id);
+    expect(entry.profileId).toBe(metadata.profileId);
+    expect(entry.label).toBe(metadata.label);
+    expect(entry.storage.files).toEqual(
+      expect.arrayContaining(['metadata.json', 'landmarks.json', 'clip.mp4']),
+    );
+    expect(entry.metadata).toMatchObject(metadata);
+
+    const storedDir = path.join(dataDir, entry.storage.directory);
+    const storedMetadataRaw = await fs.readFile(path.join(storedDir, 'metadata.json'), 'utf8');
+    const storedMetadata = JSON.parse(storedMetadataRaw);
+    expect(storedMetadata).toMatchObject(metadata);
+
+    const storedLandmarksRaw = await fs.readFile(path.join(storedDir, 'landmarks.json'), 'utf8');
+    const storedLandmarks = JSON.parse(storedLandmarksRaw);
+    expect(storedLandmarks.landmarks[0]).toEqual(landmarks[0]);
+
+    const bundleZipPath = path.join(dataDir, entry.storage.bundle);
+    const bundleStat = await fs.stat(bundleZipPath);
+    expect(bundleStat.isFile()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add an authenticated /api/v1/dgs/sample-bundles endpoint that unpacks training bundles into the uploads directory and records manifest entries
- share a reusable file-lock helper plus constants for upload and manifest paths
- ensure MLP artifacts use amy_model.npz for the global model, generate per-profile npz files, and fall back to the baseline file when no counts exist

## Testing
- npm test --prefix server

------
https://chatgpt.com/codex/tasks/task_e_68d4f9bc8c748322b40956b4dc183cc1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an API to upload training sample bundles (ZIP). Validates metadata, supports optional profile assignment, extracts contents, and queues processing. Responds with 202 and a bundle ID.

- Refactor
  - Improved server path resolution for static assets and model files, with more robust directory creation and model writing. Enhanced concurrency safety for file updates to improve reliability.

- Tests
  - Added integration tests covering training bundle uploads and manifest creation.

- Chores
  - Added ZIP handling dependency and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->