### PR TITLE
chore: align expo dependencies with sdk

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "amys-echo-app",
       "version": "1.0.0",
       "dependencies": {
-        "@expo/metro-config": "^54.0.4",
         "@nozbe/watermelondb": "0.28.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "11.4.1",
@@ -16,10 +15,10 @@
         "@react-navigation/stack": "6.4.1",
         "buffer": "^6.0.3",
         "crypto-js": "4.2.0",
-        "expo": "^54.0.9",
+        "expo": "~54.0.10",
         "expo-audio": "^1.0.13",
         "expo-camera": "^17.0.8",
-        "expo-file-system": "^19.0.14",
+        "expo-file-system": "~19.0.15",
         "expo-haptics": "^15.0.7",
         "expo-linear-gradient": "^15.0.7",
         "expo-secure-store": "^15.0.7",
@@ -2233,9 +2232,9 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "54.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.7.tgz",
-      "integrity": "sha512-vpZDbIhN2eyb5u2o2iIL2Glu9+9eIY8U30wqeIxh0BUHLoMxFejvEBfS+90A0PtEHoQ1Zi9QxusK5UuyoEvweg==",
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.8.tgz",
+      "integrity": "sha512-bRJXvtjgxpyElmJuKLotWyIW5j9a2K3rGUjd2A8LRcFimrZp0wwuKPQjlUK0sFNbU7zHWfxubNq/B+UkUNkCxw==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
@@ -2248,13 +2247,13 @@
         "@expo/json-file": "^10.0.7",
         "@expo/mcp-tunnel": "~0.0.7",
         "@expo/metro": "~54.0.0",
-        "@expo/metro-config": "~54.0.4",
+        "@expo/metro-config": "~54.0.5",
         "@expo/osascript": "^2.3.7",
         "@expo/package-manager": "^1.9.8",
         "@expo/plist": "^0.4.7",
         "@expo/prebuild-config": "^54.0.3",
         "@expo/schema-utils": "^0.1.7",
-        "@expo/server": "^0.7.4",
+        "@expo/server": "^0.7.5",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
         "@expo/xcpretty": "^4.3.0",
@@ -2614,9 +2613,9 @@
       }
     },
     "node_modules/@expo/mcp-tunnel": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/mcp-tunnel/-/mcp-tunnel-0.0.7.tgz",
-      "integrity": "sha512-ht8Q1nKtiHobZqkUqt/7awwjW2D59ardP6XDVmGceGjQtoZELVaJDHyMIX+aVG9SZ9aj8+uGlhQYeBi57SZPMA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/mcp-tunnel/-/mcp-tunnel-0.0.8.tgz",
+      "integrity": "sha512-6261obzt6h9TQb6clET7Fw4Ig4AY2hfTNKI3gBt0gcTNxZipwMg8wER7ssDYieA9feD/FfPTuCPYFcR280aaWA==",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.3",
@@ -2653,9 +2652,9 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "54.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.4.tgz",
-      "integrity": "sha512-syzvZGFGrOSQOWjpo+lHHwMV8XOLK5Ev/E+e0Or3fJvsAi4o7h62qbbPuAicrfFUPxlAm7XBvkWmAwPr2jIAYA==",
+      "version": "54.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.5.tgz",
+      "integrity": "sha512-Y+oYtLg8b3L4dHFImfu8+yqO+KOcBpLLjxN7wGbs7miP/BjntBQ6tKbPxyKxHz5UUa1s+buBzZlZhsFo9uqKMg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2773,9 +2772,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/server": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@expo/server/-/server-0.7.4.tgz",
-      "integrity": "sha512-8bfRzL7h1Qgrmf3auR71sPAcAuxnmNkRJs+8enL8vZi2+hihevLhrayDu7P0A/XGEq7wySAGvBBFfIB00Et/AA==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@expo/server/-/server-0.7.5.tgz",
+      "integrity": "sha512-aNVcerBSJEcUspvXRWChEgFhix1gTNIcgFDevaU/A1+TkfbejNIjGX4rfLEpfyRzzdLIRuOkBNjD+uTYMzohyg==",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -5495,9 +5494,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "54.0.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.2.tgz",
-      "integrity": "sha512-wIlweUhun2+soWQf8slGrURU8ZZYrIqPGuvsvTpm03YE8aCZF9YZe1WvsMJCAlywIhQQ+970wSKzLncfPqK2hQ==",
+      "version": "54.0.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.3.tgz",
+      "integrity": "sha512-zC6g96Mbf1bofnCI8yI0VKAp8/ER/gpfTsWOpQvStbHU+E4jFZ294n3unW8Hf6nNP4NoeNq9Zc6Prp0vwhxbow==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
@@ -6724,9 +6723,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
-      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -7712,29 +7711,29 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "54.0.9",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.9.tgz",
-      "integrity": "sha512-hCWkBkftiSSoKCV83CKm5oaA613arl9311mjXCDb7Fn/9FzQWh1koL4Q3nflnYiiCRhFQnecbDOa6YxN+GKVEQ==",
+      "version": "54.0.10",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.10.tgz",
+      "integrity": "sha512-49+IginEoKC+g125ZlRvUYNl9jKjjHcDiDnQvejNWlMQ0LtcFIWiFad/PLjmi7YqF/0rj9u3FNxqM6jNP16O0w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.7",
+        "@expo/cli": "54.0.8",
         "@expo/config": "~12.0.9",
         "@expo/config-plugins": "~54.0.1",
         "@expo/devtools": "0.1.7",
         "@expo/fingerprint": "0.15.1",
         "@expo/metro": "~54.0.0",
-        "@expo/metro-config": "54.0.4",
+        "@expo/metro-config": "54.0.5",
         "@expo/vector-icons": "^15.0.2",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~54.0.2",
+        "babel-preset-expo": "~54.0.3",
         "expo-asset": "~12.0.9",
         "expo-constants": "~18.0.9",
-        "expo-file-system": "~19.0.14",
+        "expo-file-system": "~19.0.15",
         "expo-font": "~14.0.8",
         "expo-keep-awake": "~15.0.7",
-        "expo-modules-autolinking": "3.0.12",
-        "expo-modules-core": "3.0.17",
+        "expo-modules-autolinking": "3.0.13",
+        "expo-modules-core": "3.0.18",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -7824,9 +7823,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "19.0.14",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.14.tgz",
-      "integrity": "sha512-0CA7O5IYhab11TlxQlJAx0Xm9pdkk/zEHNiW+Hh/T4atWi9U/J38CIp7iNYSrBvy9dC3rJbze5D1ANcKKr4mSQ==",
+      "version": "19.0.15",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.15.tgz",
+      "integrity": "sha512-sRLW+3PVJDiuoCE2LuteHhC7OxPjh1cfqLylf1YG1TDEbbQXnzwjfsKeRm6dslEPZLkMWfSLYIrVbnuq5mF7kQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -7878,9 +7877,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.12.tgz",
-      "integrity": "sha512-vZijQgdtmhAhL8H3C0gEjWC0gGBVPVQdVZM92Zqcu2vXjRNDSqIxYXRTS3UT0nZzFltdqmeZAGxvWspxQLYtOQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.13.tgz",
+      "integrity": "sha512-58WnM15ESTyT2v93Rba7jplXtGvh5cFbxqUCi2uTSpBf3nndDRItLzBQaoWBzAvNUhpC2j1bye7Dn/E+GJFXmw==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -7895,9 +7894,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.17.tgz",
-      "integrity": "sha512-P1jZn8yjWi4jSCH+r9A1NykLR+0JtFYprJgYwnZ1EVFRtw+DoMjir0OexM9ehCuBg8sKDCbzCUAgm/JFnpjQww==",
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.18.tgz",
+      "integrity": "sha512-9JPnjlXEFaq/uACZ7I4wb/RkgPYCEsfG75UKMvfl7P7rkymtpRGYj8/gTL2KId8Xt1fpmIPOF57U8tKamjtjXg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
@@ -12296,9 +12295,9 @@
       }
     },
     "node_modules/minizlib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -13904,15 +13903,15 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.3.1.tgz",
-      "integrity": "sha512-DzcswPr252wEr7Qz8AyAVbfyBDKLoYp6eRA1We2Fa9qirRFSdtkP5sHr3yglDKy2BbA0fd2T+j/CUSKes3FeVQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+      "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.2.2",
         "regjsgen": "^0.8.0",
-        "regjsparser": "^0.12.0",
+        "regjsparser": "^0.13.0",
         "unicode-match-property-ecmascript": "^2.0.0",
         "unicode-match-property-value-ecmascript": "^2.2.1"
       },
@@ -13927,27 +13926,15 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
-      "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
+      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "jsesc": "~3.0.2"
+        "jsesc": "~3.1.0"
       },
       "bin": {
         "regjsparser": "bin/parser"
-      }
-    },
-    "node_modules/regjsparser/node_modules/jsesc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/require-directory": {
@@ -15312,35 +15299,19 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
+      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
       "license": "ISC",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
         "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
+        "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tar/node_modules/yallist": {

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,6 @@
     "clean": "rm -rf node_modules/.cache && rm -rf .expo && rm -rf dist"
   },
   "dependencies": {
-    "@expo/metro-config": "^54.0.4",
     "@nozbe/watermelondb": "0.28.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.4.1",
@@ -29,10 +28,10 @@
     "@react-navigation/stack": "6.4.1",
     "buffer": "^6.0.3",
     "crypto-js": "4.2.0",
-    "expo": "^54.0.9",
+    "expo": "~54.0.10",
     "expo-audio": "^1.0.13",
     "expo-camera": "^17.0.8",
-    "expo-file-system": "^19.0.14",
+    "expo-file-system": "~19.0.15",
     "expo-haptics": "^15.0.7",
     "expo-linear-gradient": "^15.0.7",
     "expo-secure-store": "^15.0.7",


### PR DESCRIPTION
## Summary
- remove the direct @expo/metro-config dependency and rely on expo's metro helper
- bump expo and expo-file-system to the SDK 54.0.10-compatible patch releases
- refresh the npm lockfile to capture the dependency removals and version updates

## Testing
- npx expo install --check
- npx --yes expo-doctor *(fails: network fetch for Expo API)*

------
https://chatgpt.com/codex/tasks/task_e_68d52d49607883228585af9c36405f93