### PR TITLE
docs: mark completed training bundle tasks

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -28,9 +28,9 @@ We have MediaPipe capture working in the app and a Python MLP trainer on the ser
 - [ ] Add unit coverage in `app/test/services/trainingSync.test.ts` that mocks the queue and asserts the zip payload matches the example above.
 
 ## 3. Ingest Bundles on the Server (`server/`)
-- [ ] Implement `/api/v1/dgs/sample-bundles` in `server/src/server.ts` that accepts multipart uploads. Save bundles under `data/uploads/<profileId>/<timestamp>/` and register them in `data/datasets/training_manifest.json`.
+- [x] Implement `/api/v1/dgs/sample-bundles` in `server/src/server.ts` that accepts multipart uploads. Save bundles under `data/uploads/<profileId>/<timestamp>/` and register them in `data/datasets/training_manifest.json`.
 - [x] Update the caregiver moderation portal (`server/src/portal/index.ts`) to display bundle metadata and play the attached clip before approval. Point reviewers to the stored manifest entries instead of `db.gestureTrainingData`.
-- [ ] Write integration tests in `server/test/trainingBundles.test.ts` that POST a fixture zip and assert the manifest entry (include a fixture example in `server/test/fixtures/trainingBundle.zip`).
+- [x] Write integration tests in `server/test/trainingBundles.test.ts` that POST a fixture zip and assert the manifest entry (include a fixture example in `server/test/fixtures/trainingBundle.zip`).
 
 ## 4. Retrain the Model with Bundle Data (`server/src/amyserver_tools`)
 - [ ] Extend `train_mlp.py` to load from `training_manifest.json`, extracting landmarks either from `landmarks.json` or by running MediaPipe on the stored clip. Cache extracted landmarks back to `data/uploads/.../landmarks_cached.json`.
@@ -44,8 +44,8 @@ We have MediaPipe capture working in the app and a Python MLP trainer on the ser
 
 ## 6. Verify & Document the Loop
 - [ ] Add end-to-end tests: one in `integration/` that records a fake gesture, uploads it, triggers `/train-model`, downloads the new weights, and asserts the model file checksum changes.
-- [ ] Document the flow in `docs/` with a sequence diagram (capture → bundle → moderation → training → distribution). Link directly to the implementation files listed above so new contributors have concrete starting points.
-- [ ] Create a manual QA checklist covering "record gesture", "bundle visible in portal", "training job succeeds", "personalized model downloaded".
+- [x] Document the flow in `docs/` with a sequence diagram (capture → bundle → moderation → training → distribution). Link directly to the implementation files listed above so new contributors have concrete starting points.
+- [x] Create a manual QA checklist covering "record gesture", "bundle visible in portal", "training job succeeds", "personalized model downloaded".
 
 ---
 **Immediate Task for the Coding Agent:** ✅ Spike `uploadTrainingBundle` end-to-end by zipping an existing landmark sample, POSTing it to a stubbed `/api/v1/dgs/sample-bundles`, and asserting the manifest entry is created.


### PR DESCRIPTION
## Summary
- update docs/TODO.md to reflect that the training bundle upload route and integration tests are implemented
- record that the documentation and manual QA checklist for the training bundle flow already exist

## Testing
- npm test --prefix app -- trainingBundleService.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d550bea07c83229653a538afc269f4