### PR TITLE
Fix parental navigation crash by wiring services context

### DIFF
--- a/app/src/context/AppServicesProvider.tsx
+++ b/app/src/context/AppServicesProvider.tsx
@@ -2,7 +2,7 @@ import { runDailyJobs, checkAllGesturesForDecliningAccuracy, checkPracticeRecomm
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const LAST_DAILY_JOB_KEY = 'lastDailyJob';
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect, useMemo } from 'react';
 import { audioService, backupService, checkForModelUpdate, syncService, syncTrainingData, gestureDataProtector, gdprService } from '../services';
 import { adaptiveLearningService } from '../services/adaptiveLearningService';
 import LoadingIndicator from '../components/LoadingIndicator';
@@ -12,6 +12,7 @@ import { logger } from '../utils/logger';
 import { uploadTelemetry } from '../services';
 import { telemetry } from '../telemetry/recorder';
 import { useServicesStore, type Services } from '../stores/servicesStore';
+import { ServicesContext } from './ServicesContext';
 
 interface ProviderProps {
   children: ReactNode;
@@ -22,7 +23,14 @@ const services: Services = { audioService, adaptiveLearningService, backupServic
 
 export const AppServicesProvider = ({ children, offline = false }: ProviderProps) => {
   const { setMessage } = useMessage();
-  const { setServices, setReady, isReady } = useServicesStore();
+  const setServices = useServicesStore((state) => state.setServices);
+  const setReady = useServicesStore((state) => state.setReady);
+  const isReady = useServicesStore((state) => state.isReady);
+  const audioServiceInstance = useServicesStore((state) => state.audioService);
+  const adaptiveLearningServiceInstance = useServicesStore((state) => state.adaptiveLearningService);
+  const backupServiceInstance = useServicesStore((state) => state.backupService);
+  const gestureDataProtectorInstance = useServicesStore((state) => state.gestureDataProtector);
+  const gdprServiceInstance = useServicesStore((state) => state.gdprService);
 
   useEffect(() => {
     let interval: ReturnType<typeof setInterval>;
@@ -121,9 +129,26 @@ export const AppServicesProvider = ({ children, offline = false }: ProviderProps
     };
   }, [offline, setMessage, setReady, setServices]);
 
+  const contextValue = useMemo(
+    () => ({
+      audioService: audioServiceInstance,
+      adaptiveLearningService: adaptiveLearningServiceInstance,
+      backupService: backupServiceInstance,
+      gestureDataProtector: gestureDataProtectorInstance,
+      gdprService: gdprServiceInstance,
+    }),
+    [
+      audioServiceInstance,
+      adaptiveLearningServiceInstance,
+      backupServiceInstance,
+      gestureDataProtectorInstance,
+      gdprServiceInstance,
+    ],
+  );
+
   if (!isReady) {
     return <LoadingIndicator />;
   }
 
-  return <>{children}</>;
+  return <ServicesContext.Provider value={contextValue}>{children}</ServicesContext.Provider>;
 };

--- a/app/test/appServicesProvider.test.tsx
+++ b/app/test/appServicesProvider.test.tsx
@@ -123,6 +123,7 @@ jest.mock('../src/services/dailyJobs', () => ({
 
 
 const { AppServicesProvider } = require('../src/context/AppServicesProvider');
+const { useServices } = require('../src/context/ServicesContext');
 const ErrorMessage = require('../src/components/ErrorMessage').default;
 const { MessageProvider } = require('../src/context/MessageContext');
 
@@ -377,6 +378,28 @@ describe('AppServicesProvider', () => {
 
     await expectEventually(() => {
       expect(audioServiceMock.dispose).toHaveBeenCalled();
+    });
+  });
+
+  it('provides initialized services through context', async () => {
+    audioServiceMock.initialize.mockResolvedValueOnce();
+
+    const Consumer = () => {
+      const services = useServices();
+      return (
+        <div
+          data-audio-service-ready={services.audioService?.initialize === audioServiceMock.initialize}
+        />
+      );
+    };
+
+    const component = await renderProvider({ child: <Consumer /> });
+
+    await expectEventually(() => {
+      const nodes = component.root.findAll(
+        (node) => node.props['data-audio-service-ready'] === true,
+      );
+      expect(nodes.length).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- wrap AppServicesProvider children in ServicesContext so screens using useServices no longer crash
- derive the provided value from the initialized zustand store to keep services up to date
- extend the provider test suite to confirm services are exposed through the context

## Testing
- npx jest appServicesProvider.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d854658f1883228dc7adffe034319d