### PR TITLE
Apply ScreenBackground to remaining screens

### DIFF
--- a/app/src/screens/ParentalGateScreen.tsx
+++ b/app/src/screens/ParentalGateScreen.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
+import { Text, TextInput, Pressable, StyleSheet } from 'react-native';
 import { COLORS, SPACING, DEFAULT_RADIUS } from '../constants/ui';
 import { useAccessibility } from '../components/AccessibilityContext';
 import { childHaptic } from '../services/feedbackService';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function ParentalGateScreen({ route, navigation }: any) {
   const { largeText, highContrast } = useAccessibility();
@@ -36,7 +37,7 @@ export default function ParentalGateScreen({ route, navigation }: any) {
       justifyContent: 'center',
       alignItems: 'center',
       padding: SPACING.lg,
-      backgroundColor: highContrast ? COLORS.highContrastBackground : COLORS.surface,
+      backgroundColor: 'transparent',
     },
     title: {
       fontSize: largeText ? 28 : 24,
@@ -87,7 +88,7 @@ export default function ParentalGateScreen({ route, navigation }: any) {
   });
 
   return (
-    <View style={styles.container}>
+    <ScreenBackground style={styles.container}>
       <Text style={styles.title}>{problem}</Text>
       <TextInput
         style={styles.input}
@@ -154,6 +155,6 @@ export default function ParentalGateScreen({ route, navigation }: any) {
           Zurück
         </Text>
       </Pressable>
-    </View>
+    </ScreenBackground>
   );
 }

--- a/app/src/screens/PracticeSchedulerScreen.tsx
+++ b/app/src/screens/PracticeSchedulerScreen.tsx
@@ -8,6 +8,7 @@ import BottomNav from '../components/BottomNav';
 import { loadProfile, Profile } from '../storage';
 import { childHaptic } from '../services/feedbackService';
 import { childFriendlyStyles } from '../styles/touchTargets';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function PracticeSchedulerScreen({ navigation }: any) {
   const { largeText, highContrast } = useAccessibility();
@@ -30,7 +31,7 @@ export default function PracticeSchedulerScreen({ navigation }: any) {
   }, []);
 
   const styles = StyleSheet.create({
-    container: { flex: 1, padding: SPACING.lg, backgroundColor: highContrast ? COLORS.highContrastBackground : COLORS.surface },
+    container: { flex: 1, padding: SPACING.lg, backgroundColor: 'transparent' },
     title: { fontSize: largeText ? 24 : 20, marginBottom: SPACING.md, color: highContrast ? COLORS.highContrastText : COLORS.text },
     row: { flexDirection: 'row', alignItems: 'center', marginBottom: SPACING.sm },
     label: { color: highContrast ? COLORS.highContrastText : COLORS.text, marginRight: SPACING.sm },
@@ -97,76 +98,97 @@ export default function PracticeSchedulerScreen({ navigation }: any) {
   });
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Übungsplaner</Text>
-      <View style={styles.row}>
-        <Text style={styles.label}>Geste</Text>
-        <FlatList
-          data={gestureModel.gestures}
-          horizontal
-          keyExtractor={(g) => g.id}
-          renderItem={({ item }) => (
-             <Pressable
-               style={({ pressed }) => [
-                 childFriendlyStyles.minTouchTarget,
-                 styles.gestureButton,
-                 highContrast && styles.gestureButtonHC,
-                 gestureId === item.id && (highContrast ? styles.gestureButtonSelectedHC : styles.gestureButtonSelected),
-                 pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-               ]}
-               onPress={() => {
-                 void childHaptic();
-                 setGestureId(item.id);
-               }}
-               accessibilityRole="button"
-               accessibilityLabel={`Geste ${item.label} auswählen`}
-               accessibilityState={{ selected: gestureId === item.id }}
-             >
-               <Text style={[
-                 styles.buttonText,
-                 largeText && styles.buttonTextLarge,
-                 highContrast && styles.buttonTextHC,
-                 gestureId === item.id && highContrast && { color: COLORS.highContrastBackground },
-               ]}>
-                 {item.label}
-               </Text>
-             </Pressable>
-           )}
-          style={{ maxHeight: 44 }}
-        />
-      </View>
-      <View style={styles.row}>
-        <Text style={styles.label}>Zeit (24h)</Text>
-        <TextInput style={styles.input} keyboardType="number-pad" value={hour} onChangeText={setHour} accessibilityLabel="Stunde" />
-        <Text style={styles.label}>:</Text>
-        <TextInput style={styles.input} keyboardType="number-pad" value={minute} onChangeText={setMinute} accessibilityLabel="Minute" />
-        <Pressable
-          style={({ pressed }) => [
-            childFriendlyStyles.minTouchTarget,
-            styles.button,
-            highContrast && styles.buttonHC,
-            pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-          ]}
-          onPress={async () => {
-            void childHaptic();
-            const h = Math.max(0, Math.min(23, parseInt(hour || '0', 10)));
-            const m = Math.max(0, Math.min(59, parseInt(minute || '0', 10)));
-            await addSchedule({ gestureId, hour: h, minute: m, daysOfWeek: days, enabled: true } as any);
-            setDays([]);
-            await load();
-          }}
-          accessibilityRole="button"
-          accessibilityLabel="Plan hinzufügen"
-        >
-          <Text style={[
-            styles.buttonText,
-            largeText && styles.buttonTextLarge,
-            highContrast && styles.buttonTextHC,
-          ]}>
-            Hinzufügen
-          </Text>
-        </Pressable>
-      </View>
+    <>
+      <ScreenBackground style={styles.container}>
+        <Text style={styles.title}>Übungsplaner</Text>
+        <View style={styles.row}>
+          <Text style={styles.label}>Geste</Text>
+          <FlatList
+            data={gestureModel.gestures}
+            horizontal
+            keyExtractor={(g) => g.id}
+            renderItem={({ item }) => (
+              <Pressable
+                style={({ pressed }) => [
+                  childFriendlyStyles.minTouchTarget,
+                  styles.gestureButton,
+                  highContrast && styles.gestureButtonHC,
+                  gestureId === item.id &&
+                    (highContrast
+                      ? styles.gestureButtonSelectedHC
+                      : styles.gestureButtonSelected),
+                  pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+                ]}
+                onPress={() => {
+                  void childHaptic();
+                  setGestureId(item.id);
+                }}
+                accessibilityRole="button"
+                accessibilityLabel={`Geste ${item.label} auswählen`}
+                accessibilityState={{ selected: gestureId === item.id }}
+              >
+                <Text
+                  style={[
+                    styles.buttonText,
+                    largeText && styles.buttonTextLarge,
+                    highContrast && styles.buttonTextHC,
+                    gestureId === item.id &&
+                      highContrast && { color: COLORS.highContrastBackground },
+                  ]}
+                >
+                  {item.label}
+                </Text>
+              </Pressable>
+            )}
+            style={{ maxHeight: 44 }}
+          />
+        </View>
+        <View style={styles.row}>
+          <Text style={styles.label}>Zeit (24h)</Text>
+          <TextInput
+            style={styles.input}
+            keyboardType="number-pad"
+            value={hour}
+            onChangeText={setHour}
+            accessibilityLabel="Stunde"
+          />
+          <Text style={styles.label}>:</Text>
+          <TextInput
+            style={styles.input}
+            keyboardType="number-pad"
+            value={minute}
+            onChangeText={setMinute}
+            accessibilityLabel="Minute"
+          />
+          <Pressable
+            style={({ pressed }) => [
+              childFriendlyStyles.minTouchTarget,
+              styles.button,
+              highContrast && styles.buttonHC,
+              pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+            ]}
+            onPress={async () => {
+              void childHaptic();
+              const h = Math.max(0, Math.min(23, parseInt(hour || '0', 10)));
+              const m = Math.max(0, Math.min(59, parseInt(minute || '0', 10)));
+              await addSchedule({ gestureId, hour: h, minute: m, daysOfWeek: days, enabled: true } as any);
+              setDays([]);
+              await load();
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Plan hinzufügen"
+          >
+            <Text
+              style={[
+                styles.buttonText,
+                largeText && styles.buttonTextLarge,
+                highContrast && styles.buttonTextHC,
+              ]}
+            >
+              Hinzufügen
+            </Text>
+          </Pressable>
+        </View>
 
       <View style={styles.row}>
         <Text style={styles.label}>Tage</Text>
@@ -204,65 +226,70 @@ export default function PracticeSchedulerScreen({ navigation }: any) {
                 : 'täglich'})
             </Text>
             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-              <Switch value={item.enabled} onValueChange={async (v) => { await setScheduleEnabled(item.id, v); await load(); }} />
-               <Pressable
-                 style={({ pressed }) => [
-             {
-              minWidth: 60,
-              minHeight: 60,
-              padding: SPACING.sm,
-              alignItems: 'center',
-              justifyContent: 'center',
-            },
-                   styles.button,
-                   highContrast && styles.buttonHC,
-                   pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-                 ]}
-                 onPress={async () => {
-                   void childHaptic();
-                   await removeSchedule(item.id);
-                   await load();
-                 }}
-                 accessibilityRole="button"
-                 accessibilityLabel="Plan löschen"
-               >
-                 <Text style={[
-                   styles.buttonText,
-                   largeText && styles.buttonTextLarge,
-                   highContrast && styles.buttonTextHC,
-                 ]}>
-                   Löschen
-                 </Text>
-               </Pressable>
+              <Switch
+                value={item.enabled}
+                onValueChange={async (v) => {
+                  await setScheduleEnabled(item.id, v);
+                  await load();
+                }}
+              />
+              <Pressable
+                style={({ pressed }) => [
+                  childFriendlyStyles.minTouchTarget,
+                  styles.button,
+                  highContrast && styles.buttonHC,
+                  pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+                ]}
+                onPress={async () => {
+                  void childHaptic();
+                  await removeSchedule(item.id);
+                  await load();
+                }}
+                accessibilityRole="button"
+                accessibilityLabel="Plan löschen"
+              >
+                <Text
+                  style={[
+                    styles.buttonText,
+                    largeText && styles.buttonTextLarge,
+                    highContrast && styles.buttonTextHC,
+                  ]}
+                >
+                  Löschen
+                </Text>
+              </Pressable>
             </View>
           </View>
         )}
         ListEmptyComponent={<Text style={styles.label}>Keine Pläne</Text>}
       />
 
-      <Pressable
-        style={({ pressed }) => [
-          childFriendlyStyles.minTouchTarget,
-          styles.button,
-          highContrast && styles.buttonHC,
-          pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-        ]}
-        onPress={() => {
-          void childHaptic();
-          navigation.goBack();
-        }}
-        accessibilityRole="button"
-        accessibilityLabel="Zurück"
-      >
-        <Text style={[
-          styles.buttonText,
-          largeText && styles.buttonTextLarge,
-          highContrast && styles.buttonTextHC,
-        ]}>
-          Zurück
-        </Text>
-      </Pressable>
+        <Pressable
+          style={({ pressed }) => [
+            childFriendlyStyles.minTouchTarget,
+            styles.button,
+            highContrast && styles.buttonHC,
+            pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+          ]}
+          onPress={() => {
+            void childHaptic();
+            navigation.goBack();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel="Zurück"
+        >
+          <Text
+            style={[
+              styles.buttonText,
+              largeText && styles.buttonTextLarge,
+              highContrast && styles.buttonTextHC,
+            ]}
+          >
+            Zurück
+          </Text>
+        </Pressable>
+      </ScreenBackground>
       {profile && <BottomNav active="schedule" profileId={profile.id} />}
-    </View>
+    </>
   );
 }

--- a/app/src/screens/PrivacySettingsScreen.tsx
+++ b/app/src/screens/PrivacySettingsScreen.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import type { NavigationProp } from '@react-navigation/native';
 import PrivacySettings from '../components/PrivacySettings';
 import BottomNav from '../components/BottomNav';
+import ScreenBackground from '../components/ScreenBackground';
 
 import type { RootStackParamList } from '../navigation/types';
 
@@ -16,15 +17,18 @@ export default function PrivacySettingsScreen({
   };
 
   return (
-    <View style={styles.container}>
-      <PrivacySettings onClose={handleClose} />
+    <>
+      <ScreenBackground style={styles.container}>
+        <PrivacySettings onClose={handleClose} />
+      </ScreenBackground>
       <BottomNav active="parent" profileId="default" />
-    </View>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: 'transparent',
   },
 });

--- a/app/src/screens/ProfileManagerScreen.tsx
+++ b/app/src/screens/ProfileManagerScreen.tsx
@@ -16,6 +16,7 @@ import { childHaptic } from '../services/feedbackService';
 import GestureHistoryViewer from '../components/GestureHistoryViewer';
 import ProfileAnalytics from '../components/ProfileAnalytics';
 import { gestureHistoryService } from '../services/gestureHistoryService';
+import ScreenBackground from '../components/ScreenBackground';
 
 
 export default function ProfileManagerScreen({ navigation, route }: any) {
@@ -273,7 +274,7 @@ export default function ProfileManagerScreen({ navigation, route }: any) {
   };
 
   const styles = StyleSheet.create({
-    container: { flex: 1, padding: SPACING.lg, backgroundColor: highContrast ? COLORS.highContrastBackground : COLORS.surface },
+    container: { flex: 1, padding: SPACING.lg, backgroundColor: 'transparent' },
     title: { fontSize: largeText ? 28 : 24, marginBottom: SPACING.lg, textAlign: 'center', color: highContrast ? COLORS.highContrastText : COLORS.text },
     row: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: SPACING.sm },
     name: { fontSize: largeText ? 22 : 18, color: highContrast ? COLORS.highContrastText : COLORS.text },
@@ -390,7 +391,8 @@ export default function ProfileManagerScreen({ navigation, route }: any) {
   });
 
   return (
-    <View style={styles.container}>
+    <>
+      <ScreenBackground style={styles.container}>
       <Text style={styles.title}>Profile</Text>
 
       {/* Trusted Device Section */}
@@ -629,58 +631,62 @@ export default function ProfileManagerScreen({ navigation, route }: any) {
         </View>
 
         <FlatList
-        data={profiles}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={styles.row}>
-            <Text style={styles.name}>{item.name}</Text>
-            <Pressable
-              style={({ pressed }) => [
-                childFriendlyStyles.minTouchTarget,
-                styles.button,
-                highContrast && styles.buttonHC,
-                pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-              ]}
-              onPress={() => {
-                void childHaptic();
-                handleSelect(item.id);
-              }}
-              accessibilityRole="button"
-              accessibilityLabel={`Profil ${item.name} auswählen`}
-            >
-              <Text style={[
-                styles.buttonText,
-                largeText && styles.buttonTextLarge,
-                highContrast && styles.buttonTextHC,
-              ]}>
-                Auswählen
-              </Text>
-            </Pressable>
-            <Pressable
-              style={({ pressed }) => [
-                childFriendlyStyles.minTouchTarget,
-                styles.button,
-                highContrast && styles.buttonHC,
-                pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-              ]}
-              onPress={() => {
-                void childHaptic();
-                handleDelete(item.id);
-              }}
-              accessibilityRole="button"
-              accessibilityLabel={`Profil ${item.name} löschen`}
-            >
-              <Text style={[
-                styles.buttonText,
-                largeText && styles.buttonTextLarge,
-                highContrast && styles.buttonTextHC,
-              ]}>
-                Löschen
-              </Text>
-            </Pressable>
-          </View>
-        )}
-      />
+          data={profiles}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <View style={styles.row}>
+              <Text style={styles.name}>{item.name}</Text>
+              <Pressable
+                style={({ pressed }) => [
+                  childFriendlyStyles.minTouchTarget,
+                  styles.button,
+                  highContrast && styles.buttonHC,
+                  pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+                ]}
+                onPress={() => {
+                  void childHaptic();
+                  handleSelect(item.id);
+                }}
+                accessibilityRole="button"
+                accessibilityLabel={`Profil ${item.name} auswählen`}
+              >
+                <Text
+                  style={[
+                    styles.buttonText,
+                    largeText && styles.buttonTextLarge,
+                    highContrast && styles.buttonTextHC,
+                  ]}
+                >
+                  Auswählen
+                </Text>
+              </Pressable>
+              <Pressable
+                style={({ pressed }) => [
+                  childFriendlyStyles.minTouchTarget,
+                  styles.button,
+                  highContrast && styles.buttonHC,
+                  pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+                ]}
+                onPress={() => {
+                  void childHaptic();
+                  handleDelete(item.id);
+                }}
+                accessibilityRole="button"
+                accessibilityLabel={`Profil ${item.name} löschen`}
+              >
+                <Text
+                  style={[
+                    styles.buttonText,
+                    largeText && styles.buttonTextLarge,
+                    highContrast && styles.buttonTextHC,
+                  ]}
+                >
+                  Löschen
+                </Text>
+              </Pressable>
+            </View>
+          )}
+        />
       <Pressable
         style={({ pressed }) => [
           childFriendlyStyles.minTouchTarget,
@@ -703,37 +709,37 @@ export default function ProfileManagerScreen({ navigation, route }: any) {
           Neues Profil
         </Text>
       </Pressable>
-       {/* Gesture History Overlay */}
-       {showGestureHistory && (
-         <View style={styles.overlay}>
-           <GestureHistoryViewer
-             gestureHistory={gestureHistory}
-             onClose={() => setShowGestureHistory(false)}
-             onGestureSelect={(gesture) => {
-               // Could navigate to practice this specific gesture
-               setShowGestureHistory(false);
-               navigation.navigate('Training', { gestureLabel: gesture.id });
-             }}
-           />
-         </View>
-       )}
+        {/* Gesture History Overlay */}
+        {showGestureHistory && (
+          <View style={styles.overlay}>
+            <GestureHistoryViewer
+              gestureHistory={gestureHistory}
+              onClose={() => setShowGestureHistory(false)}
+              onGestureSelect={(gesture) => {
+                // Could navigate to practice this specific gesture
+                setShowGestureHistory(false);
+                navigation.navigate('Training', { gestureLabel: gesture.id });
+              }}
+            />
+          </View>
+        )}
 
-       {/* Profile Analytics Overlay */}
-       {showProfileAnalytics && profileStats && (
-         <View style={styles.overlay}>
-           <ProfileAnalytics
-             stats={profileStats}
-             onClose={() => setShowProfileAnalytics(false)}
-             onViewDetails={() => {
-               // Could show more detailed analytics
-               setShowProfileAnalytics(false);
-             }}
-           />
-         </View>
-       )}
-
-       {profileId && <BottomNav active="parent" profileId={profileId} />}
-     </View>
-   );
- }
+        {/* Profile Analytics Overlay */}
+        {showProfileAnalytics && profileStats && (
+          <View style={styles.overlay}>
+            <ProfileAnalytics
+              stats={profileStats}
+              onClose={() => setShowProfileAnalytics(false)}
+              onViewDetails={() => {
+                // Could show more detailed analytics
+                setShowProfileAnalytics(false);
+              }}
+            />
+          </View>
+        )}
+      </ScreenBackground>
+      {profileId && <BottomNav active="parent" profileId={profileId} />}
+    </>
+  );
+}
 

--- a/app/src/screens/ProfileSelectScreen.tsx
+++ b/app/src/screens/ProfileSelectScreen.tsx
@@ -4,6 +4,7 @@ import { COLORS, SPACING, DEFAULT_RADIUS } from '../constants/ui';
 import { loadProfile, Profile } from '../storage';
 import { useAccessibility } from '../components/AccessibilityContext';
 import { childHaptic } from '../services/feedbackService';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function ProfileSelectScreen({ navigation }: any) {
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -19,10 +20,7 @@ export default function ProfileSelectScreen({ navigation }: any) {
       justifyContent: 'center',
       alignItems: 'center',
       padding: SPACING.lg,
-      backgroundColor: COLORS.surface,
-    },
-    containerHC: {
-      backgroundColor: COLORS.highContrastBackground,
+      backgroundColor: 'transparent',
     },
     title: {
       fontSize: 24,
@@ -123,7 +121,7 @@ export default function ProfileSelectScreen({ navigation }: any) {
   );
 
   return (
-    <View style={[styles.container, highContrast && styles.containerHC]}>
+    <ScreenBackground style={styles.container}>
       <Text style={[styles.title, largeText && styles.titleLarge, highContrast && styles.titleHC]}>
         Was möchtest du tun?
       </Text>
@@ -157,6 +155,6 @@ export default function ProfileSelectScreen({ navigation }: any) {
           accessibilityLabel="Profile verwalten"
         />
       </View>
-    </View>
+    </ScreenBackground>
   );
 }

--- a/app/src/screens/ProgressChartScreen.tsx
+++ b/app/src/screens/ProgressChartScreen.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 import { Svg, G, Line, Text as SvgText } from 'react-native-svg';
 import { loadHistoricalHealthData, HistoricalHealthEntry } from '../services/healthScore';
 import { useAccessibility } from '../components/AccessibilityContext';
 import { COLORS, SPACING } from '../constants/ui';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function ProgressChartScreen({ route }: any) {
   const { gestureId } = route.params;
@@ -18,7 +19,7 @@ export default function ProgressChartScreen({ route }: any) {
     container: {
       flex: 1,
       padding: SPACING.lg,
-      backgroundColor: highContrast ? COLORS.highContrastBackground : COLORS.surface,
+      backgroundColor: 'transparent',
     },
     title: {
       fontSize: largeText ? 24 : 20,
@@ -35,7 +36,7 @@ export default function ProgressChartScreen({ route }: any) {
   const yScale = (value: number) => height - padding - (height - 2 * padding) * value;
 
   return (
-    <View style={styles.container}>
+    <ScreenBackground style={styles.container}>
       <Text style={styles.title}>Fortschritt für {gestureId}</Text>
       <Svg height={height} width={width}>
         <G y={height}>
@@ -97,6 +98,6 @@ export default function ProgressChartScreen({ route }: any) {
           )}
         </G>
       </Svg>
-    </View>
+    </ScreenBackground>
   );
 }

--- a/app/src/screens/ProgressScreen.tsx
+++ b/app/src/screens/ProgressScreen.tsx
@@ -8,6 +8,7 @@ import { useAccessibility } from '../components/AccessibilityContext';
 import { COLORS, SPACING, DEFAULT_RADIUS } from '../constants/ui';
 import BottomNav from '../components/BottomNav';
 import { childHaptic } from '../services/feedbackService';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function ProgressScreen({ navigation }: any) {
   const { largeText, highContrast } = useAccessibility();
@@ -33,7 +34,7 @@ export default function ProgressScreen({ navigation }: any) {
     container: {
       flex: 1,
       padding: SPACING.lg,
-      backgroundColor: highContrast ? COLORS.highContrastBackground : COLORS.surface,
+      backgroundColor: 'transparent',
     },
     title: {
       fontSize: largeText ? 24 : 20,
@@ -88,84 +89,90 @@ export default function ProgressScreen({ navigation }: any) {
   });
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Fortschritt</Text>
-      <View style={styles.summaryItem}>
-        <Text style={styles.label}>Sitzungen</Text>
-        <Text style={styles.label}>{engagement.totalSessions}</Text>
-      </View>
-      <View style={styles.summaryItem}>
-        <Text style={styles.label}>Durchschnittliche Sitzungsdauer (s)</Text>
-        <Text style={styles.label}>{Math.round(engagement.averageDurationMs / 1000)}</Text>
-      </View>
-      <FlatList
-        data={entries}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={styles.item}>
-            <Text style={styles.label}>{item.label}</Text>
-            <Pressable
-              style={({ pressed }) => [
-          {
-            minWidth: 60,
-            minHeight: 60,
-            padding: SPACING.sm,
-            alignItems: 'center',
-            justifyContent: 'center',
-          },
-                styles.button,
-                highContrast && styles.buttonHC,
-                pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-              ]}
-              onPress={() => {
-                void childHaptic();
-                navigation.navigate('ProgressChart', { gestureId: item.id });
-              }}
-              accessibilityRole="button"
-              accessibilityLabel={`Details für ${item.label} anzeigen`}
-            >
-              <Text style={[
-                styles.buttonText,
-                largeText && styles.buttonTextLarge,
-                highContrast && styles.buttonTextHC,
-              ]}>
-                Details
-              </Text>
-            </Pressable>
-            <Text style={styles.label}>{item.count}</Text>
-          </View>
-        )}
-        ListEmptyComponent={<Text style={styles.label}>Noch keine Nutzung</Text>}
-      />
-      <Pressable
-        style={({ pressed }) => [
-          {
-            minWidth: 60,
-            minHeight: 60,
-            padding: SPACING.md,
-            alignItems: 'center',
-            justifyContent: 'center',
-          },
-          styles.button,
-          highContrast && styles.buttonHC,
-          pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-        ]}
-        onPress={() => {
-          void childHaptic();
-          navigation.goBack();
-        }}
-        accessibilityRole="button"
-        accessibilityLabel="Zurück"
-      >
-        <Text style={[
-          styles.buttonText,
-          largeText && styles.buttonTextLarge,
-          highContrast && styles.buttonTextHC,
-        ]}>
-          Zurück
-        </Text>
-      </Pressable>
+    <>
+      <ScreenBackground style={styles.container}>
+        <Text style={styles.title}>Fortschritt</Text>
+        <View style={styles.summaryItem}>
+          <Text style={styles.label}>Sitzungen</Text>
+          <Text style={styles.label}>{engagement.totalSessions}</Text>
+        </View>
+        <View style={styles.summaryItem}>
+          <Text style={styles.label}>Durchschnittliche Sitzungsdauer (s)</Text>
+          <Text style={styles.label}>{Math.round(engagement.averageDurationMs / 1000)}</Text>
+        </View>
+        <FlatList
+          data={entries}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <View style={styles.item}>
+              <Text style={styles.label}>{item.label}</Text>
+              <Pressable
+                style={({ pressed }) => [
+                  {
+                    minWidth: 60,
+                    minHeight: 60,
+                    padding: SPACING.sm,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  },
+                  styles.button,
+                  highContrast && styles.buttonHC,
+                  pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+                ]}
+                onPress={() => {
+                  void childHaptic();
+                  navigation.navigate('ProgressChart', { gestureId: item.id });
+                }}
+                accessibilityRole="button"
+                accessibilityLabel={`Details für ${item.label} anzeigen`}
+              >
+                <Text
+                  style={[
+                    styles.buttonText,
+                    largeText && styles.buttonTextLarge,
+                    highContrast && styles.buttonTextHC,
+                  ]}
+                >
+                  Details
+                </Text>
+              </Pressable>
+              <Text style={styles.label}>{item.count}</Text>
+            </View>
+          )}
+          ListEmptyComponent={<Text style={styles.label}>Noch keine Nutzung</Text>}
+        />
+        <Pressable
+          style={({ pressed }) => [
+            {
+              minWidth: 60,
+              minHeight: 60,
+              padding: SPACING.md,
+              alignItems: 'center',
+              justifyContent: 'center',
+            },
+            styles.button,
+            highContrast && styles.buttonHC,
+            pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+          ]}
+          onPress={() => {
+            void childHaptic();
+            navigation.goBack();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel="Zurück"
+        >
+          <Text
+            style={[
+              styles.buttonText,
+              largeText && styles.buttonTextLarge,
+              highContrast && styles.buttonTextHC,
+            ]}
+          >
+            Zurück
+          </Text>
+        </Pressable>
+      </ScreenBackground>
       {profile && <BottomNav active="parent" profileId={profile.id} />}
-    </View>
+    </>
   );
 }

--- a/app/src/screens/ScheduleScreen.tsx
+++ b/app/src/screens/ScheduleScreen.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import type { NavigationProp } from '@react-navigation/native';
 import VisualSchedule from '../components/VisualSchedule';
 import BottomNav from '../components/BottomNav';
 import type { RootStackParamList } from '../navigation/types';
 import { logger } from '../utils/logger';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function ScheduleScreen({
   navigation,
@@ -22,18 +23,21 @@ export default function ScheduleScreen({
   };
 
   return (
-    <View style={styles.container}>
-      <VisualSchedule
-        onActivityPress={handleActivityPress}
-        onScheduleComplete={handleScheduleComplete}
-      />
+    <>
+      <ScreenBackground style={styles.container}>
+        <VisualSchedule
+          onActivityPress={handleActivityPress}
+          onScheduleComplete={handleScheduleComplete}
+        />
+      </ScreenBackground>
       <BottomNav active="training" profileId="default" />
-    </View>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: 'transparent',
   },
 });

--- a/app/src/screens/TrainingScreen.tsx
+++ b/app/src/screens/TrainingScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { View, Text, Pressable, StyleSheet, SafeAreaView } from 'react-native';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
 import * as FileSystem from 'expo-file-system';
 // Camera preview replaced by MediaPipe WebView detector
 import Svg, { Circle } from 'react-native-svg';
@@ -25,6 +25,7 @@ import PerformanceAnalytics from '../components/PerformanceAnalytics';
 import PracticeSessionManager from '../components/PracticeSessionManager';
 import { positiveTelemetryService } from '../services/positiveTelemetryService';
 import type { ClipReadyPayload, FrameBatchPayload } from '../types/frames';
+import ScreenBackground from '../components/ScreenBackground';
 
 const CLIP_RECORDING_ERROR_TEXT = 'Videoclip konnte nicht gespeichert werden. Versuch es nochmal!';
 
@@ -325,7 +326,7 @@ export default function TrainingScreen({ navigation, route }: any) {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: highContrast ? COLORS.highContrastBackground : COLORS.backgroundStart,
+      backgroundColor: 'transparent',
     },
     content: {
       flex: 1,
@@ -484,285 +485,304 @@ export default function TrainingScreen({ navigation, route }: any) {
   // Camera permission handled by WebView context.
 
   return (
-    <SafeAreaView style={styles.container}>
-      <View style={styles.content}>
-        <Text style={styles.title}>
-          {isPractice
-            ? gestureId
-              ? `Practice ${gestureId}`
-              : 'Practice Mode'
-            : `Training ${gestureId ? `for ${gestureId}` : 'Mode'}`}
-        </Text>
-        {!gestureId ? (
+    <>
+      <ScreenBackground style={styles.container}>
+        <View style={styles.content}>
+          <Text style={styles.title}>
+            {isPractice
+              ? gestureId
+                ? `Practice ${gestureId}`
+                : 'Practice Mode'
+              : `Training ${gestureId ? `for ${gestureId}` : 'Mode'}`}
+          </Text>
+          {!gestureId ? (
             gestureModel.gestures.map((g: { id: string; label: string }) => (
-             <Pressable
-               key={g.id}
-               style={({ pressed }) => [
-            {
-              minWidth: 60,
-              minHeight: 60,
-              padding: SPACING.md,
-              alignItems: 'center',
-              justifyContent: 'center',
-            },
-                 styles.button,
-                 highContrast && styles.buttonHC,
-                 pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-               ]}
+              <Pressable
+                key={g.id}
+                style={({ pressed }) => [
+                  {
+                    minWidth: 60,
+                    minHeight: 60,
+                    padding: SPACING.md,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  },
+                  styles.button,
+                  highContrast && styles.buttonHC,
+                  pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+                ]}
                 onPress={() => {
                   void hapticFeedback.light();
                   setGestureId(g.id);
                 }}
-               accessibilityRole="button"
-               accessibilityLabel={`Trainiere Geste ${g.label}`}
-             >
-               <Text style={[
-                 styles.buttonText,
-                 largeText && styles.buttonTextLarge,
-                 highContrast && styles.buttonTextHC,
-               ]}>
-                 {g.label}
-               </Text>
-             </Pressable>
-           ))
-        ) : count < TARGET_SAMPLES ? (
-          <>
-          {/* Optional DGS demo video if available */}
-          {gestureId && (() => {
-            const entry = gestureModel.gestures.find(g => g.id === gestureId);
-            const videoSource = entry?.dgsVideoUri ? { uri: entry.dgsVideoUri } : undefined;
-            return videoSource ? (
-              <View style={{ width: PREVIEW_SIZE, height: PREVIEW_SIZE, marginBottom: SPACING.sm }}>
-                <DgsVideoPlayer videoSource={videoSource} shouldPlay={true} />
-              </View>
-            ) : null;
-          })()}
-          <View style={styles.cameraHeader}>
-            <Text style={styles.cameraLabel}>
-              {`Aktive Kamera: ${facingMode === 'user' ? 'Vorderseite' : 'Rückseite'}`}
-            </Text>
-            <Pressable
-              onPress={toggleFacingMode}
-              accessibilityRole="button"
-              accessibilityLabel="Kamera wechseln"
-              accessibilityHint="Zwischen Vorder- und Rückkamera umschalten"
-              style={({ pressed }) => [
-                childFriendlyStyles.minTouchTarget,
-                styles.cameraToggle,
-                pressed && styles.cameraTogglePressed,
-              ]}
-            >
-              <Text style={styles.cameraToggleText}>
-                {facingMode === 'user' ? 'Zur Rückkamera' : 'Zur Frontkamera'}
-              </Text>
-            </Pressable>
-          </View>
-              <View style={styles.cameraContainer}>
-              <MediaPipeGestureDetector
-                ref={detectorRef}
-                onWebViewEvent={(telemetry) => {
-                  logger.info('Training WebView telemetry:', telemetry);
-                }}
-                onFrameBatch={handleFrameBatch}
-                onLandmarks={(lm) => {
-                  setLandmarks(cloneLandmarks(lm));
-                  setLastDetection(Date.now());
-                }}
-                onGestureDetected={(gesture, confidence) => {
-                  if (isRecordingRef.current && gestureId) {
-                    positiveTelemetryService.recordSuccess(
-                      gestureId,
-                      confidence,
-                      undefined, // context
-                      undefined, // emotionalState
-                      Date.now() - (sessionStartTime || Date.now()), // duration
-                    );
-                  }
-
-                  // Enhanced feedback for practice mode
-                  if (practiceMode && gesture && confidence > 0.5) {
-                    // Provide real-time feedback during practice
-                    if (confidence > 0.8) {
-                      setMessage('🎉 Perfekt! Das sieht sehr gut aus!');
-                    } else if (confidence > 0.6) {
-                      setMessage('👍 Gut gemacht! Fast richtig.');
-                    }
-                  }
-                }}
-                onError={(m) => {
-                  logger.warn('TrainingScreen detector error:', m);
-                  // Amy First: Show encouraging message instead of technical error
-                  setMessage('Das hat nicht geklappt. Lass es uns nochmal versuchen!');
-                }}
-                facingMode={facingMode}
-              />
-              {landmarks.length > 0 && (
-                <Svg
-                  style={StyleSheet.absoluteFill}
-                  viewBox={`0 0 ${PREVIEW_SIZE} ${PREVIEW_SIZE}`}
-                  pointerEvents="none"
+                accessibilityRole="button"
+                accessibilityLabel={`Trainiere Geste ${g.label}`}
+              >
+                <Text
+                  style={[
+                    styles.buttonText,
+                    largeText && styles.buttonTextLarge,
+                    highContrast && styles.buttonTextHC,
+                  ]}
                 >
-                  {landmarks.map((hand, handIdx) =>
-                    hand.map((l, lmIdx) => {
-                      const [x, y] = l ?? [];
-                      if (typeof x !== 'number' || typeof y !== 'number') {
-                        return null;
-                      }
-                      return (
-                        <Circle
-                          key={`${handIdx}-${lmIdx}`}
-                          cx={x * PREVIEW_SIZE}
-                          cy={y * PREVIEW_SIZE}
-                          r={3}
-                          fill={COLORS.warning}
-                        />
-                      );
-                    })
-                  )}
-                </Svg>
-              )}
-              <View style={styles.detectionIndicator}>
-                <View style={[styles.dot, { backgroundColor: detectionActive ? COLORS.success : COLORS.warning }]} />
-                <Text style={styles.detectionText}>
-                  {isRecording
-                    ? detectionActive
-                      ? `Recording... ${framesCaptured}`
-                      : 'No hand detected'
-                    : detectionActive
-                    ? 'Hand detected'
-                    : 'No hand'}
+                  {g.label}
                 </Text>
+              </Pressable>
+            ))
+          ) : count < TARGET_SAMPLES ? (
+            <>
+              {/* Optional DGS demo video if available */}
+              {gestureId && (() => {
+                const entry = gestureModel.gestures.find((g) => g.id === gestureId);
+                const videoSource = entry?.dgsVideoUri ? { uri: entry.dgsVideoUri } : undefined;
+                return videoSource ? (
+                  <View style={{ width: PREVIEW_SIZE, height: PREVIEW_SIZE, marginBottom: SPACING.sm }}>
+                    <DgsVideoPlayer videoSource={videoSource} shouldPlay={true} />
+                  </View>
+                ) : null;
+              })()}
+              <View style={styles.cameraHeader}>
+                <Text style={styles.cameraLabel}>
+                  {`Aktive Kamera: ${facingMode === 'user' ? 'Vorderseite' : 'Rückseite'}`}
+                </Text>
+                <Pressable
+                  onPress={toggleFacingMode}
+                  accessibilityRole="button"
+                  accessibilityLabel="Kamera wechseln"
+                  accessibilityHint="Zwischen Vorder- und Rückkamera umschalten"
+                  style={({ pressed }) => [
+                    childFriendlyStyles.minTouchTarget,
+                    styles.cameraToggle,
+                    pressed && styles.cameraTogglePressed,
+                  ]}
+                >
+                  <Text style={styles.cameraToggleText}>
+                    {facingMode === 'user' ? 'Zur Rückkamera' : 'Zur Frontkamera'}
+                  </Text>
+                </Pressable>
               </View>
-            </View>
-            <View
-              style={styles.progressBar}
-              accessibilityRole="progressbar"
-              accessibilityValue={{ now: count, min: 0, max: TARGET_SAMPLES }}
-            >
+              <View style={styles.cameraContainer}>
+                <MediaPipeGestureDetector
+                  ref={detectorRef}
+                  onWebViewEvent={(telemetry) => {
+                    logger.info('Training WebView telemetry:', telemetry);
+                  }}
+                  onFrameBatch={handleFrameBatch}
+                  onLandmarks={(lm) => {
+                    setLandmarks(cloneLandmarks(lm));
+                    setLastDetection(Date.now());
+                  }}
+                  onGestureDetected={(gesture, confidence) => {
+                    if (isRecordingRef.current && gestureId) {
+                      positiveTelemetryService.recordSuccess(
+                        gestureId,
+                        confidence,
+                        undefined, // context
+                        undefined, // emotionalState
+                        Date.now() - (sessionStartTime || Date.now()), // duration
+                      );
+                    }
+
+                    // Enhanced feedback for practice mode
+                    if (practiceMode && gesture && confidence > 0.5) {
+                      // Provide real-time feedback during practice
+                      if (confidence > 0.8) {
+                        setMessage('🎉 Perfekt! Das sieht sehr gut aus!');
+                      } else if (confidence > 0.6) {
+                        setMessage('👍 Gut gemacht! Fast richtig.');
+                      }
+                    }
+                  }}
+                  onError={(m) => {
+                    logger.warn('TrainingScreen detector error:', m);
+                    // Amy First: Show encouraging message instead of technical error
+                    setMessage('Das hat nicht geklappt. Lass es uns nochmal versuchen!');
+                  }}
+                  facingMode={facingMode}
+                />
+                {landmarks.length > 0 && (
+                  <Svg
+                    style={StyleSheet.absoluteFill}
+                    viewBox={`0 0 ${PREVIEW_SIZE} ${PREVIEW_SIZE}`}
+                    pointerEvents="none"
+                  >
+                    {landmarks.map((hand, handIdx) =>
+                      hand.map((l, lmIdx) => {
+                        const [x, y] = l ?? [];
+                        if (typeof x !== 'number' || typeof y !== 'number') {
+                          return null;
+                        }
+                        return (
+                          <Circle
+                            key={`${handIdx}-${lmIdx}`}
+                            cx={x * PREVIEW_SIZE}
+                            cy={y * PREVIEW_SIZE}
+                            r={3}
+                            fill={COLORS.warning}
+                          />
+                        );
+                      })
+                    )}
+                  </Svg>
+                )}
+                <View style={styles.detectionIndicator}>
+                  <View style={[styles.dot, { backgroundColor: detectionActive ? COLORS.success : COLORS.warning }]} />
+                  <Text style={styles.detectionText}>
+                    {isRecording
+                      ? detectionActive
+                        ? `Recording... ${framesCaptured}`
+                        : 'No hand detected'
+                      : detectionActive
+                      ? 'Hand detected'
+                      : 'No hand'}
+                  </Text>
+                </View>
+              </View>
               <View
-                style={[
-                  styles.progressFill,
-                  { width: `${(count / TARGET_SAMPLES) * 100}%` },
+                style={styles.progressBar}
+                accessibilityRole="progressbar"
+                accessibilityValue={{ now: count, min: 0, max: TARGET_SAMPLES }}
+              >
+                <View
+                  style={[
+                    styles.progressFill,
+                    { width: `${(count / TARGET_SAMPLES) * 100}%` },
+                  ]}
+                />
+              </View>
+              <Pressable
+                style={({ pressed }) => [
+                  childFriendlyStyles.minTouchTarget,
+                  styles.button,
+                  highContrast && styles.buttonHC,
+                  !gestureId && styles.buttonDisabled,
+                  pressed &&
+                    gestureId &&
+                    (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
                 ]}
-              />
-            </View>
+                onPress={() => {
+                  void hapticFeedback.light();
+                  if (isRecording) {
+                    void stopRecording();
+                  } else {
+                    void startRecording();
+                  }
+                }}
+                accessibilityRole="button"
+                accessibilityLabel="Gestenaufnahme starten"
+                disabled={!gestureId}
+              >
+                <Text
+                  style={[
+                    styles.buttonText,
+                    largeText && styles.buttonTextLarge,
+                    highContrast && styles.buttonTextHC,
+                  ]}
+                >
+                  {isRecording
+                    ? 'Stop Recording'
+                    : `Record Sample ${count + 1} / ${TARGET_SAMPLES}`}
+                </Text>
+              </Pressable>
+              {!isRecording && framesCaptured > 0 && (
+                <Text style={styles.detectionText}>
+                  Last recording length: {framesCaptured} frames
+                </Text>
+              )}
+
+              {/* Practice mode toggle */}
+              <View style={styles.practiceModeContainer}>
+                <Text style={styles.practiceModeLabel}>
+                  Übungsmodus: {practiceMode ? 'Aktiviert' : 'Deaktiviert'}
+                </Text>
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.practiceModeToggle,
+                    practiceMode && styles.practiceModeToggleActive,
+                    pressed && styles.practiceModeTogglePressed,
+                  ]}
+                  onPress={() => setPracticeMode(!practiceMode)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Übungsmodus umschalten"
+                >
+                  <Text style={styles.practiceModeToggleText}>
+                    {practiceMode ? '🎯' : '📝'}
+                  </Text>
+                </Pressable>
+              </View>
+            </>
+          ) : (
             <Pressable
               style={({ pressed }) => [
                 childFriendlyStyles.minTouchTarget,
                 styles.button,
                 highContrast && styles.buttonHC,
-                !gestureId && styles.buttonDisabled,
-                pressed && gestureId && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
+                pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
               ]}
-             onPress={() => {
-               void hapticFeedback.light();
-               if (isRecording) {
-                  void stopRecording();
-                } else {
-                  void startRecording();
+              onPress={async () => {
+                void hapticFeedback.light();
+                if (isPractice && gestureId) {
+                  try {
+                    await audioService.playCelebrationFeedback();
+                  } catch {}
+                  try {
+                    await logHIPEvent('HIP_4', 'practice_completed', {
+                      gestureId,
+                      samples: TARGET_SAMPLES,
+                    });
+                  } catch {}
                 }
+                handleFinish();
               }}
               accessibilityRole="button"
-              accessibilityLabel="Gestenaufnahme starten"
-              disabled={!gestureId}
+              accessibilityLabel={
+                isPractice ? 'Übung beenden' : 'Trainingsdaten speichern'
+              }
             >
-              <Text style={[
-                styles.buttonText,
-                largeText && styles.buttonTextLarge,
-                highContrast && styles.buttonTextHC,
-              ]}>
-                {isRecording ? 'Stop Recording' : `Record Sample ${count + 1} / ${TARGET_SAMPLES}`}
+              <Text
+                style={[
+                  styles.buttonText,
+                  largeText && styles.buttonTextLarge,
+                  highContrast && styles.buttonTextHC,
+                ]}
+              >
+                {isPractice ? 'Übung beenden' : 'Trainingsdaten speichern'}
               </Text>
             </Pressable>
-             {!isRecording && framesCaptured > 0 && (
-               <Text style={styles.detectionText}>
-                 Last recording length: {framesCaptured} frames
-               </Text>
-             )}
+          )}
+        </View>
 
-             {/* Practice mode toggle */}
-             <View style={styles.practiceModeContainer}>
-               <Text style={styles.practiceModeLabel}>
-                 Übungsmodus: {practiceMode ? 'Aktiviert' : 'Deaktiviert'}
-               </Text>
-               <Pressable
-                 style={({ pressed }) => [
-                   styles.practiceModeToggle,
-                   practiceMode && styles.practiceModeToggleActive,
-                   pressed && styles.practiceModeTogglePressed,
-                 ]}
-                 onPress={() => setPracticeMode(!practiceMode)}
-                 accessibilityRole="button"
-                 accessibilityLabel="Übungsmodus umschalten"
-               >
-                 <Text style={styles.practiceModeToggleText}>
-                   {practiceMode ? '🎯' : '📝'}
-                 </Text>
-               </Pressable>
-             </View>
-
-           </>
-         ) : (
-          <Pressable
-            style={({ pressed }) => [
-              childFriendlyStyles.minTouchTarget,
-              styles.button,
-              highContrast && styles.buttonHC,
-              pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-            ]}
-             onPress={async () => {
-               void hapticFeedback.light();
-               if (isPractice && gestureId) {
-                 try { await audioService.playCelebrationFeedback(); } catch {}
-                 try { await logHIPEvent('HIP_4', 'practice_completed', { gestureId, samples: TARGET_SAMPLES }); } catch {}
-               }
-               handleFinish();
-             }}
-            accessibilityRole="button"
-            accessibilityLabel={isPractice ? 'Übung beenden' : 'Trainingsdaten speichern'}
-          >
-            <Text style={[
-              styles.buttonText,
-              largeText && styles.buttonTextLarge,
-              highContrast && styles.buttonTextHC,
-            ]}>
-              {isPractice ? 'Übung beenden' : 'Trainingsdaten speichern'}
-            </Text>
-          </Pressable>
+        {/* Performance Analytics Overlay */}
+        {showPerformanceAnalytics && performanceMetrics && gestureId && (
+          <View style={styles.overlay}>
+            <PerformanceAnalytics
+              gestureId={gestureId}
+              metrics={performanceMetrics}
+              onClose={() => setShowPerformanceAnalytics(false)}
+              onRetry={() => {
+                setShowPerformanceAnalytics(false);
+                setCount(0);
+                setIsRecording(false);
+                setRecordedFrames([]);
+                setFramesCaptured(0);
+              }}
+            />
+          </View>
         )}
-       </View>
 
-       {/* Performance Analytics Overlay */}
-       {showPerformanceAnalytics && performanceMetrics && gestureId && (
-         <View style={styles.overlay}>
-           <PerformanceAnalytics
-             gestureId={gestureId}
-             metrics={performanceMetrics}
-             onClose={() => setShowPerformanceAnalytics(false)}
-             onRetry={() => {
-               setShowPerformanceAnalytics(false);
-               setCount(0);
-               setIsRecording(false);
-               setRecordedFrames([]);
-               setFramesCaptured(0);
-             }}
-           />
-         </View>
-       )}
-
-       {/* Practice Session Manager */}
-       {practiceMode && gestureId && (
-         <PracticeSessionManager
-           gestureId={gestureId}
-           currentProgress={count}
-           targetSamples={TARGET_SAMPLES}
-           onSessionComplete={() => {
-             setMessage('🎉 Übungssession abgeschlossen! Gut gemacht!');
-           }}
-         />
-       )}
-
-       {profile && <BottomNav active="training" profileId={profile.id} />}
-     </SafeAreaView>
-   );
- }
+        {/* Practice Session Manager */}
+        {practiceMode && gestureId && (
+          <PracticeSessionManager
+            gestureId={gestureId}
+            currentProgress={count}
+            targetSamples={TARGET_SAMPLES}
+            onSessionComplete={() => {
+              setMessage('🎉 Übungssession abgeschlossen! Gut gemacht!');
+            }}
+          />
+        )}
+      </ScreenBackground>
+      {profile && <BottomNav active="training" profileId={profile.id} />}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap the remaining scheduler, progress, and settings screens in `ScreenBackground` to extend the shared gradient treatment
- update container styling to keep safe-area padding while leaving BottomNav outside the gradient wrapper
- refactor `TrainingScreen` to replace the `SafeAreaView` with `ScreenBackground` for consistent layout handling

## Testing
- npm run type-check --prefix app

------
https://chatgpt.com/codex/tasks/task_e_68d9989c06208322944a882535b0e9c6