### PR TITLE
Add offline MLP fallback for model client

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -33,7 +33,8 @@
         }
       ],
       "expo-audio",
-      "expo-secure-store"
+      "expo-secure-store",
+      "expo-asset"
     ]
   }
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,17 +15,18 @@
         "@react-navigation/stack": "6.4.1",
         "buffer": "^6.0.3",
         "crypto-js": "4.2.0",
-        "expo": "~54.0.10",
+        "expo": "54.0.12",
+        "expo-asset": "~12.0.9",
         "expo-audio": "^1.0.13",
         "expo-camera": "^17.0.8",
-        "expo-file-system": "~19.0.15",
+        "expo-file-system": "~19.0.16",
         "expo-haptics": "^15.0.7",
         "expo-linear-gradient": "^15.0.7",
         "expo-secure-store": "^15.0.7",
         "expo-speech": "^14.0.7",
         "expo-video": "^3.0.11",
         "react": "19.1.0",
-        "react-native": "^0.81.4",
+        "react-native": "0.81.4",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -2232,28 +2233,27 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "54.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.8.tgz",
-      "integrity": "sha512-bRJXvtjgxpyElmJuKLotWyIW5j9a2K3rGUjd2A8LRcFimrZp0wwuKPQjlUK0sFNbU7zHWfxubNq/B+UkUNkCxw==",
+      "version": "54.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.10.tgz",
+      "integrity": "sha512-iw9gAnN6+PKWWLIyYmiskY/wzZjuFMctunqGXuC8BGATWgtr/HpzjVqWbcL3KIX/GvEBCCh74Tkckrh+Ylxh5Q==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
         "@expo/code-signing-certificates": "^0.0.5",
-        "@expo/config": "~12.0.9",
-        "@expo/config-plugins": "~54.0.1",
+        "@expo/config": "~12.0.10",
+        "@expo/config-plugins": "~54.0.2",
         "@expo/devcert": "^1.1.2",
         "@expo/env": "~2.0.7",
         "@expo/image-utils": "^0.8.7",
         "@expo/json-file": "^10.0.7",
         "@expo/mcp-tunnel": "~0.0.7",
         "@expo/metro": "~54.0.0",
-        "@expo/metro-config": "~54.0.5",
+        "@expo/metro-config": "~54.0.6",
         "@expo/osascript": "^2.3.7",
         "@expo/package-manager": "^1.9.8",
         "@expo/plist": "^0.4.7",
-        "@expo/prebuild-config": "^54.0.3",
+        "@expo/prebuild-config": "^54.0.4",
         "@expo/schema-utils": "^0.1.7",
-        "@expo/server": "^0.7.5",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
         "@expo/xcpretty": "^4.3.0",
@@ -2271,6 +2271,7 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
+        "expo-server": "^1.0.0",
         "freeport-async": "^2.0.0",
         "getenv": "^2.0.0",
         "glob": "^10.4.2",
@@ -2394,13 +2395,13 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "12.0.9",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.9.tgz",
-      "integrity": "sha512-HiDVVaXYKY57+L1MxSF3TaYjX6zZlGBnuWnOKZG+7mtsLD+aNTtW4bZM0pZqZfoRumyOU0SfTCwT10BWtUUiJQ==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.10.tgz",
+      "integrity": "sha512-lJMof5Nqakq1DxGYlghYB/ogSBjmv4Fxn1ovyDmcjlRsQdFCXgu06gEUogkhPtc9wBt9WlTTfqENln5HHyLW6w==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.1",
+        "@expo/config-plugins": "~54.0.2",
         "@expo/config-types": "^54.0.8",
         "@expo/json-file": "^10.0.7",
         "deepmerge": "^4.3.1",
@@ -2415,9 +2416,9 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "54.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.1.tgz",
-      "integrity": "sha512-NyBChhiWFL6VqSgU+LzK4R1vC397tEG2XFewVt4oMr4Pnalq/mJxBANQrR+dyV1RHhSyhy06RNiJIkQyngVWeg==",
+      "version": "54.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.2.tgz",
+      "integrity": "sha512-jD4qxFcURQUVsUFGMcbo63a/AnviK8WUGard+yrdQE3ZrB/aurn68SlApjirQQLEizhjI5Ar2ufqflOBlNpyPg==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^54.0.8",
@@ -2652,15 +2653,15 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "54.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.5.tgz",
-      "integrity": "sha512-Y+oYtLg8b3L4dHFImfu8+yqO+KOcBpLLjxN7wGbs7miP/BjntBQ6tKbPxyKxHz5UUa1s+buBzZlZhsFo9uqKMg==",
+      "version": "54.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.6.tgz",
+      "integrity": "sha512-z3wufTr1skM03PI6Dr1ZsrvjAiGKf/w0VQvdZL+mEnKNqRA7Q4bhJDGk1+nzs+WWRWz4vS488uad9ERmSclBmg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
-        "@expo/config": "~12.0.9",
+        "@expo/config": "~12.0.10",
         "@expo/env": "~2.0.7",
         "@expo/json-file": "~10.0.7",
         "@expo/metro": "~54.0.0",
@@ -2727,13 +2728,13 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "54.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.3.tgz",
-      "integrity": "sha512-okf6Umaz1VniKmm+pA37QHBzB9XlRHvO1Qh3VbUezy07LTkz87kXUW7uLMmrA319WLavWSVORTXeR0jBRihObA==",
+      "version": "54.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.4.tgz",
+      "integrity": "sha512-X+oTbmclWf2kfWIEkjagOzPZNg2SkiWW+JoRX6CWxKpDTQKfsi/bf22Ymv5Zxe1Q/aGjOuFL5useStm3iNi+PA==",
       "license": "MIT",
       "dependencies": {
         "@expo/config": "~12.0.9",
-        "@expo/config-plugins": "~54.0.1",
+        "@expo/config-plugins": "~54.0.2",
         "@expo/config-types": "^54.0.8",
         "@expo/image-utils": "^0.8.7",
         "@expo/json-file": "^10.0.7",
@@ -2770,19 +2771,6 @@
       "resolved": "https://registry.npmjs.org/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz",
       "integrity": "sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==",
       "license": "MIT"
-    },
-    "node_modules/@expo/server": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@expo/server/-/server-0.7.5.tgz",
-      "integrity": "sha512-aNVcerBSJEcUspvXRWChEgFhix1gTNIcgFDevaU/A1+TkfbejNIjGX4rfLEpfyRzzdLIRuOkBNjD+uTYMzohyg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
     },
     "node_modules/@expo/spawn-async": {
       "version": "1.7.2",
@@ -7711,29 +7699,29 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.10.tgz",
-      "integrity": "sha512-49+IginEoKC+g125ZlRvUYNl9jKjjHcDiDnQvejNWlMQ0LtcFIWiFad/PLjmi7YqF/0rj9u3FNxqM6jNP16O0w==",
+      "version": "54.0.12",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.12.tgz",
+      "integrity": "sha512-BVvG1A9BlKAOBwczMi7XThOLzI3TUShkV/yRnAMGvQP5SQFDq7UojkZLLG285gg3OvkoqjMUE0tZvVXbvuI4tA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.8",
-        "@expo/config": "~12.0.9",
-        "@expo/config-plugins": "~54.0.1",
+        "@expo/cli": "54.0.10",
+        "@expo/config": "~12.0.10",
+        "@expo/config-plugins": "~54.0.2",
         "@expo/devtools": "0.1.7",
         "@expo/fingerprint": "0.15.1",
         "@expo/metro": "~54.0.0",
-        "@expo/metro-config": "54.0.5",
+        "@expo/metro-config": "54.0.6",
         "@expo/vector-icons": "^15.0.2",
         "@ungap/structured-clone": "^1.3.0",
         "babel-preset-expo": "~54.0.3",
         "expo-asset": "~12.0.9",
         "expo-constants": "~18.0.9",
-        "expo-file-system": "~19.0.15",
+        "expo-file-system": "~19.0.16",
         "expo-font": "~14.0.8",
         "expo-keep-awake": "~15.0.7",
-        "expo-modules-autolinking": "3.0.13",
-        "expo-modules-core": "3.0.18",
+        "expo-modules-autolinking": "3.0.14",
+        "expo-modules-core": "3.0.20",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -7823,9 +7811,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "19.0.15",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.15.tgz",
-      "integrity": "sha512-sRLW+3PVJDiuoCE2LuteHhC7OxPjh1cfqLylf1YG1TDEbbQXnzwjfsKeRm6dslEPZLkMWfSLYIrVbnuq5mF7kQ==",
+      "version": "19.0.16",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.16.tgz",
+      "integrity": "sha512-9Ee6HpcUEfO7dOet/on9yAg7ysegBua35Q0oGrJzoRc+xW6IlTxoSFbmK8QhjA3MZpkukP3DhaiYENYOzkw9SQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -7877,9 +7865,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.13.tgz",
-      "integrity": "sha512-58WnM15ESTyT2v93Rba7jplXtGvh5cFbxqUCi2uTSpBf3nndDRItLzBQaoWBzAvNUhpC2j1bye7Dn/E+GJFXmw==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.14.tgz",
+      "integrity": "sha512-/qh1ru2kGPOycGvE9dXEKJZbPmYA5U5UcAlWWFbcq9+VhhWdZWZ0zs7V2JCdl+OvpBDo1y9WbqPP5VHQSYqT+Q==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -7894,9 +7882,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.18.tgz",
-      "integrity": "sha512-9JPnjlXEFaq/uACZ7I4wb/RkgPYCEsfG75UKMvfl7P7rkymtpRGYj8/gTL2KId8Xt1fpmIPOF57U8tKamjtjXg==",
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.20.tgz",
+      "integrity": "sha512-AnC7VG8k8ZAAKoNFP5zyCiTlwppp6U3A/z63KtuSjMWlxn5w45FOf2LuyF1SNUqkiARdckuPVNvLGO/I/5vkrg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
@@ -7913,6 +7901,15 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-server": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.0.tgz",
+      "integrity": "sha512-fAAI0ZXxayc2Rt5KfQjULv+TFreuLRZ+hdpc5TxZJ7CDpW1ZIqaVzELHh1rYTRVEBDFDiCBXtioS9WWTEAX+fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.16.0"
       }
     },
     "node_modules/expo-speech": {
@@ -10943,9 +10940,9 @@
       "license": "MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
-      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -10958,22 +10955,43 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.30.1",
-        "lightningcss-darwin-x64": "1.30.1",
-        "lightningcss-freebsd-x64": "1.30.1",
-        "lightningcss-linux-arm-gnueabihf": "1.30.1",
-        "lightningcss-linux-arm64-gnu": "1.30.1",
-        "lightningcss-linux-arm64-musl": "1.30.1",
-        "lightningcss-linux-x64-gnu": "1.30.1",
-        "lightningcss-linux-x64-musl": "1.30.1",
-        "lightningcss-win32-arm64-msvc": "1.30.1",
-        "lightningcss-win32-x64-msvc": "1.30.1"
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
-      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
       "cpu": [
         "arm64"
       ],
@@ -10991,9 +11009,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
-      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
       "cpu": [
         "x64"
       ],
@@ -11011,9 +11029,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
-      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
       "cpu": [
         "x64"
       ],
@@ -11031,9 +11049,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
-      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
       "cpu": [
         "arm"
       ],
@@ -11051,9 +11069,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
-      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
       "cpu": [
         "arm64"
       ],
@@ -11071,9 +11089,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
-      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
       "cpu": [
         "arm64"
       ],
@@ -11091,9 +11109,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
-      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
       "cpu": [
         "x64"
       ],
@@ -11111,9 +11129,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
-      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
       "cpu": [
         "x64"
       ],
@@ -11131,9 +11149,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
-      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
       "cpu": [
         "arm64"
       ],
@@ -11151,9 +11169,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
-      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
       "cpu": [
         "x64"
       ],
@@ -15846,9 +15864,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
+      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "buffer": "^6.0.3",
     "crypto-js": "4.2.0",
     "expo": "54.0.12",
+    "expo-asset": "~12.0.9",
     "expo-audio": "^1.0.13",
     "expo-camera": "^17.0.8",
     "expo-file-system": "~19.0.16",

--- a/app/src/declarations.d.ts
+++ b/app/src/declarations.d.ts
@@ -1,5 +1,6 @@
 declare module 'crypto-js';
 declare module 'react-native-webview';
+declare module '*.npz';
 declare module 'expo-file-system' {
   export enum FileSystemUploadType {
     BINARY_CONTENT = 0,

--- a/app/src/declarations.d.ts
+++ b/app/src/declarations.d.ts
@@ -8,6 +8,24 @@ declare module 'expo-file-system' {
   }
 }
 
+declare module 'expo-file-system/build/legacy/FileSystem.types' {
+  interface InfoOptions {
+    size?: boolean;
+  }
+}
+
+declare module 'expo-file-system/legacy' {
+  import type {
+    FileInfo,
+    InfoOptions,
+  } from 'expo-file-system/build/legacy/FileSystem.types';
+
+  export function getInfoAsync(
+    fileUri: string,
+    options?: InfoOptions & { size?: boolean },
+  ): Promise<FileInfo>;
+}
+
 import type { unzip, unzipSync } from 'fflate';
 
 export {};

--- a/app/src/declarations.d.ts
+++ b/app/src/declarations.d.ts
@@ -1,29 +1,14 @@
 declare module 'crypto-js';
 declare module 'react-native-webview';
-declare module '*.npz';
+declare module '*.npz' {
+  const value: number;
+  export default value;
+}
 declare module 'expo-file-system' {
   export enum FileSystemUploadType {
     BINARY_CONTENT = 0,
     MULTIPART = 1,
   }
-}
-
-declare module 'expo-file-system/build/legacy/FileSystem.types' {
-  interface InfoOptions {
-    size?: boolean;
-  }
-}
-
-declare module 'expo-file-system/legacy' {
-  import type {
-    FileInfo,
-    InfoOptions,
-  } from 'expo-file-system/build/legacy/FileSystem.types';
-
-  export function getInfoAsync(
-    fileUri: string,
-    options?: InfoOptions & { size?: boolean },
-  ): Promise<FileInfo>;
 }
 
 import type { unzip, unzipSync } from 'fflate';

--- a/app/src/services/dgsModelClient.ts
+++ b/app/src/services/dgsModelClient.ts
@@ -278,10 +278,7 @@ async function loadDocumentDirectoryModel(): Promise<string | null> {
     return null;
   }
 
-  const normalizedDirectory = documentDirectory.endsWith('/')
-    ? documentDirectory
-    : `${documentDirectory}/`;
-  const modelUri = `${normalizedDirectory}${LOCAL_MODEL_FILE}`;
+  const modelUri = `${documentDirectory}/${LOCAL_MODEL_FILE}`;
   try {
     const info = await FileSystem.getInfoAsync(modelUri);
     if (!info.exists || info.isDirectory) {

--- a/app/src/services/dgsModelClient.ts
+++ b/app/src/services/dgsModelClient.ts
@@ -250,6 +250,7 @@ export async function loadLocalMlpModel(): Promise<string | null> {
   try {
     const documentModel = await loadDocumentDirectoryModel();
     if (documentModel) {
+      logger.info('Loaded local MLP model from document directory');
       return documentModel;
     }
 
@@ -277,20 +278,22 @@ async function loadDocumentDirectoryModel(): Promise<string | null> {
     return null;
   }
 
-  const modelUri = `${documentDirectory}${LOCAL_MODEL_FILE}`;
+  const normalizedDirectory = documentDirectory.endsWith('/')
+    ? documentDirectory
+    : `${documentDirectory}/`;
+  const modelUri = `${normalizedDirectory}${LOCAL_MODEL_FILE}`;
   try {
-    const info = await FileSystem.getInfoAsync(modelUri, { size: true });
+    const info = await FileSystem.getInfoAsync(modelUri);
     if (!info.exists || info.isDirectory) {
       return null;
     }
-    if (info.size === 0) {
+    if (typeof info.size === 'number' && info.size === 0) {
       return null;
     }
     const data = await FileSystem.readAsStringAsync(modelUri, {
       encoding: FileSystem.EncodingType.Base64,
     });
     if (data && data.length > 0) {
-      logger.info('Loaded local MLP model from document directory');
       return data;
     }
   } catch (error) {

--- a/app/src/services/dgsModelClient.ts
+++ b/app/src/services/dgsModelClient.ts
@@ -279,7 +279,7 @@ async function loadDocumentDirectoryModel(): Promise<string | null> {
 
   const modelUri = `${documentDirectory}${LOCAL_MODEL_FILE}`;
   try {
-    const info = await FileSystem.getInfoAsync(modelUri);
+    const info = await FileSystem.getInfoAsync(modelUri, { size: true });
     if (!info.exists || info.isDirectory) {
       return null;
     }

--- a/app/src/services/dgsModelClient.ts
+++ b/app/src/services/dgsModelClient.ts
@@ -280,10 +280,10 @@ async function loadDocumentDirectoryModel(): Promise<string | null> {
   const modelUri = `${documentDirectory}${LOCAL_MODEL_FILE}`;
   try {
     const info = await FileSystem.getInfoAsync(modelUri);
-    if (!info.exists) {
+    if (!info.exists || info.isDirectory) {
       return null;
     }
-    if ('size' in info && typeof info.size === 'number' && info.size === 0) {
+    if (info.size === 0) {
       return null;
     }
     const data = await FileSystem.readAsStringAsync(modelUri, {

--- a/app/src/services/dgsModelClient.ts
+++ b/app/src/services/dgsModelClient.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { Asset } from 'expo-asset';
 import * as FileSystem from 'expo-file-system/legacy';
 import { logger } from '../utils/logger';
 
@@ -245,142 +246,80 @@ export async function clearMlpModelBackup(profileId?: string): Promise<void> {
  */
 export async function loadLocalMlpModel(): Promise<string | null> {
   try {
-    // Try to load from the app data directory (for development/testing)
-    try {
-      console.log('Trying react-native-fs for model loading...');
-      const fs = require('react-native-fs');
-
-      // Try different possible paths for the model file
-      const possiblePaths = [
-        fs.MainBundlePath + '/data/amy_model.npz',
-        fs.DocumentDirectoryPath + '/amy_model.npz',
-        '/data/amy_model.npz', // Absolute path for development
-      ];
-
-      console.log('Available paths:', possiblePaths);
-
-      for (const modelPath of possiblePaths) {
-        try {
-          console.log(`Checking path: ${modelPath}`);
-          const exists = await fs.exists(modelPath);
-          console.log(`Path ${modelPath} exists:`, exists);
-
-          if (exists) {
-            const modelData = await fs.readFile(modelPath, 'base64');
-            if (modelData && modelData.length > 0) {
-              console.log(`Loaded MLP model from ${modelPath}, size: ${modelData.length} bytes`);
-              return modelData;
-            } else {
-              console.warn(`Model data from ${modelPath} is empty`);
-            }
-          }
-        } catch (pathError) {
-          console.warn(`Failed to load from ${modelPath}:`, (pathError as Error).message);
-          // Continue to next path
-          continue;
-        }
-      }
-    } catch (fsError) {
-      console.warn('react-native-fs not available, trying Expo FileSystem', fsError);
+    const documentModel = await loadDocumentDirectoryModel();
+    if (documentModel) {
+      return documentModel;
     }
 
-    // Try Expo FileSystem as fallback
-    try {
-      console.log('Trying Expo FileSystem for model loading...');
-
-      // Log available directories for debugging
-      console.log('Document directory:', FileSystem.documentDirectory);
-      console.log('Bundle directory:', FileSystem.bundleDirectory);
-
-      // First, try to copy the model from assets to document directory if it doesn't exist
-      const docModelUri = FileSystem.documentDirectory + 'amy_model.npz';
-      let modelInfo = await FileSystem.getInfoAsync(docModelUri);
-      console.log('Document directory model exists:', modelInfo.exists, 'size:', modelInfo.exists ? (modelInfo as any).size : 0);
-
-      if (!modelInfo.exists) {
-        try {
-          // Try to copy from the bundle assets (for production)
-          const bundleUri = FileSystem.bundleDirectory + 'data/amy_model.npz';
-          console.log('Attempting to copy from bundle assets:', bundleUri);
-
-          await FileSystem.copyAsync({
-            from: bundleUri,
-            to: docModelUri
-          });
-
-          console.log('Successfully copied model from bundle to document directory');
-          modelInfo = await FileSystem.getInfoAsync(docModelUri);
-          console.log('After copy - model exists:', modelInfo.exists, 'size:', modelInfo.exists ? (modelInfo as any).size : 0);
-        } catch (bundleError) {
-          console.warn('Failed to copy model from bundle:', bundleError);
-          try {
-            // Try to copy from the project data directory (for development)
-            const sourceUri = '/home/lars/PhpstormProjects/AmysEcho/data/amy_model.npz';
-            console.log('Attempting to copy from project data directory:', sourceUri);
-
-            await FileSystem.copyAsync({
-              from: sourceUri,
-              to: docModelUri
-            });
-
-            console.log('Successfully copied model to document directory');
-            modelInfo = await FileSystem.getInfoAsync(docModelUri);
-            console.log('After copy - model exists:', modelInfo.exists, 'size:', modelInfo.exists ? (modelInfo as any).size : 0);
-          } catch (copyError) {
-            console.warn('Failed to copy model from project directory:', copyError);
-          }
-        }
-      }
-
-      if (modelInfo.exists && modelInfo.size > 0) {
-        console.log(`Loading MLP model from document directory: ${docModelUri}, size: ${modelInfo.size} bytes`);
-        const modelData = await FileSystem.readAsStringAsync(docModelUri, {
-          encoding: FileSystem.EncodingType.Base64,
-        });
-
-        if (modelData && modelData.length > 0) {
-          console.log('Successfully loaded MLP model from document directory, data length:', modelData.length);
-          return modelData;
-        } else {
-          console.warn('Model data from document directory is empty or invalid');
-        }
-      } else {
-        console.warn('Model file not found in document directory or has invalid size');
-      }
-    } catch (expoError) {
-      console.warn('Expo FileSystem fallback failed:', expoError);
+    const bundledModel = await loadBundledFallbackModel();
+    if (bundledModel) {
+      logger.info('Loaded bundled fallback MLP model');
+      return bundledModel;
     }
 
-    // Fallback: Try to load bundled base64 model
-    try {
-      console.log('Trying to load bundled base64 model...');
-      // For now, return a placeholder - we'll implement proper bundling
-      console.log('Bundled model loading not yet implemented');
-    } catch (bundleError) {
-      console.warn('Bundled model loading failed:', bundleError);
-    }
-
-    // For development: Try to load from the app data directory
-    try {
-      const fs = require('react-native-fs');
-      const appModelPath = '/data/amy_model.npz';
-      if (await fs.exists(appModelPath)) {
-        const modelData = await fs.readFile(appModelPath, 'base64');
-        if (modelData && modelData.length > 0) {
-          console.log('Loaded MLP model from app data directory');
-          return modelData;
-        }
-      }
-    } catch (projectError) {
-      console.warn('Could not load from app data directory', projectError);
-    }
-
-    // Last resort: Return null - gesture detection will rely on MediaPipe only
-    console.warn('No local MLP model available, gesture detection will rely on MediaPipe only');
+    logger.warn('No bundled MLP model fallback available');
     return null;
-
   } catch (error) {
-    console.error('Failed to load local MLP model', error);
+    logger.error('Failed to load local MLP model', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+const LOCAL_MODEL_FILE = 'amy_model.npz';
+
+async function loadDocumentDirectoryModel(): Promise<string | null> {
+  const { documentDirectory } = FileSystem;
+  if (!documentDirectory) {
+    return null;
+  }
+
+  const modelUri = `${documentDirectory}${LOCAL_MODEL_FILE}`;
+  try {
+    const info = await FileSystem.getInfoAsync(modelUri);
+    if (!info.exists) {
+      return null;
+    }
+    if ('size' in info && typeof info.size === 'number' && info.size === 0) {
+      return null;
+    }
+    const data = await FileSystem.readAsStringAsync(modelUri, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+    if (data && data.length > 0) {
+      logger.info('Loaded local MLP model from document directory');
+      return data;
+    }
+  } catch (error) {
+    logger.warn('Unable to read MLP model from document directory', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return null;
+}
+
+async function loadBundledFallbackModel(): Promise<string | null> {
+  try {
+    const asset = Asset.fromModule(require('../../assets/dgs_model.npz'));
+    if (!asset.localUri) {
+      await asset.downloadAsync();
+    }
+
+    const uri = asset.localUri;
+    if (!uri) {
+      return null;
+    }
+
+    const data = await FileSystem.readAsStringAsync(uri, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+
+    return data && data.length > 0 ? data : null;
+  } catch (error) {
+    logger.error('Failed to load bundled fallback MLP model', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }

--- a/app/src/services/dgsModelClient.ts
+++ b/app/src/services/dgsModelClient.ts
@@ -70,7 +70,9 @@ export async function fetchCentroids(profileId?: string): Promise<{ centroids: C
     await storage.setItem(`${KEY}:${profileId || 'global'}`, JSON.stringify(data));
     return data;
   } catch (error) {
-    console.error('Failed to fetch MLP model:', error);
+    logger.error('Failed to fetch MLP model', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }
@@ -267,7 +269,7 @@ export async function loadLocalMlpModel(): Promise<string | null> {
   }
 }
 
-const LOCAL_MODEL_FILE = 'amy_model.npz';
+const LOCAL_MODEL_FILE = 'dgs_model.npz';
 
 async function loadDocumentDirectoryModel(): Promise<string | null> {
   const { documentDirectory } = FileSystem;

--- a/app/test/appServicesProvider.test.tsx
+++ b/app/test/appServicesProvider.test.tsx
@@ -454,7 +454,7 @@ describe('AppServicesProvider', () => {
 
   it('skips model refresh when connectivity disallows downloads', async () => {
     audioServiceMock.initialize.mockResolvedValueOnce();
-    shouldAllowModelRefreshMock.mockResolvedValueOnce(false);
+    shouldAllowModelRefreshMock.mockResolvedValue(false);
 
     const component = await renderProvider();
     await expectChildRendered(component);

--- a/app/test/services/dgsModelClient.test.ts
+++ b/app/test/services/dgsModelClient.test.ts
@@ -3,7 +3,7 @@ import { fetchMlpModel, loadLocalMlpModel } from '../../src/services/dgsModelCli
 const mockGetInfoAsync = jest.fn();
 const mockReadAsStringAsync = jest.fn();
 const mockFromModule = jest.fn();
-let mockDocumentDirectoryValue: string | null = 'file:///documents/';
+let mockDocumentDirectoryValue: string | null = 'file:///documents';
 
 jest.mock('expo-file-system/legacy', () => ({
   __esModule: true,
@@ -35,7 +35,7 @@ jest.mock('../../src/utils/logger', () => ({
 const originalFetch = global.fetch;
 
 beforeEach(() => {
-  mockDocumentDirectoryValue = 'file:///documents/';
+  mockDocumentDirectoryValue = 'file:///documents';
   mockGetInfoAsync.mockReset();
   mockReadAsStringAsync.mockReset();
   mockFromModule.mockReset();
@@ -57,7 +57,7 @@ describe('dgsModelClient local fallback', () => {
     mockFromModule.mockReturnValue(asset);
 
     mockGetInfoAsync.mockImplementation(async (uri: string) => {
-      if (uri.startsWith('file:///documents/')) {
+      if (uri.startsWith('file:///documents')) {
         return { exists: false } as const;
       }
       return { exists: true } as const;
@@ -76,7 +76,7 @@ describe('dgsModelClient local fallback', () => {
     const result = await fetchMlpModel();
 
     expect(fetchMock).toHaveBeenCalled();
-    expect(mockGetInfoAsync).toHaveBeenCalledWith('file:///documents/dgs_model.npz', { size: true });
+    expect(mockGetInfoAsync).toHaveBeenCalledWith('file:///documents/dgs_model.npz');
     expect(mockFromModule).toHaveBeenCalled();
     expect(mockReadAsStringAsync).toHaveBeenCalledWith(asset.localUri, {
       encoding: 'base64',

--- a/app/test/services/dgsModelClient.test.ts
+++ b/app/test/services/dgsModelClient.test.ts
@@ -21,7 +21,6 @@ jest.mock('expo-asset', () => ({
   },
 }));
 
-jest.mock('../../src/assets/dgs_model.npz', () => 'mock-mlp-asset', { virtual: true });
 jest.mock('../../assets/dgs_model.npz', () => 'mock-mlp-asset', { virtual: true });
 
 jest.mock('../../src/utils/logger', () => ({

--- a/app/test/services/dgsModelClient.test.ts
+++ b/app/test/services/dgsModelClient.test.ts
@@ -10,7 +10,7 @@ jest.mock('expo-file-system/legacy', () => ({
   get documentDirectory() {
     return mockDocumentDirectoryValue;
   },
-  getInfoAsync: (...args: unknown[]) => mockGetInfoAsync(...(args as [string])),
+  getInfoAsync: (...args: unknown[]) => mockGetInfoAsync(...args),
   readAsStringAsync: (...args: unknown[]) => mockReadAsStringAsync(...args),
   EncodingType: { Base64: 'base64' },
 }));
@@ -76,6 +76,7 @@ describe('dgsModelClient local fallback', () => {
     const result = await fetchMlpModel();
 
     expect(fetchMock).toHaveBeenCalled();
+    expect(mockGetInfoAsync).toHaveBeenCalledWith('file:///documents/dgs_model.npz', { size: true });
     expect(mockFromModule).toHaveBeenCalled();
     expect(mockReadAsStringAsync).toHaveBeenCalledWith(asset.localUri, {
       encoding: 'base64',
@@ -94,5 +95,6 @@ describe('dgsModelClient local fallback', () => {
     const result = await loadLocalMlpModel();
 
     expect(result).toBeNull();
+    expect(mockGetInfoAsync).not.toHaveBeenCalled();
   });
 });

--- a/app/test/services/dgsModelClient.test.ts
+++ b/app/test/services/dgsModelClient.test.ts
@@ -1,0 +1,99 @@
+import { fetchMlpModel, loadLocalMlpModel } from '../../src/services/dgsModelClient';
+
+const mockGetInfoAsync = jest.fn();
+const mockReadAsStringAsync = jest.fn();
+const mockFromModule = jest.fn();
+let mockDocumentDirectoryValue: string | null = 'file:///documents/';
+
+jest.mock('expo-file-system/legacy', () => ({
+  __esModule: true,
+  get documentDirectory() {
+    return mockDocumentDirectoryValue;
+  },
+  getInfoAsync: (...args: unknown[]) => mockGetInfoAsync(...(args as [string])),
+  readAsStringAsync: (...args: unknown[]) => mockReadAsStringAsync(...args),
+  EncodingType: { Base64: 'base64' },
+}));
+
+jest.mock('expo-asset', () => ({
+  Asset: {
+    fromModule: (...args: unknown[]) => mockFromModule(...args),
+  },
+}));
+
+jest.mock('../../src/assets/dgs_model.npz', () => 'mock-mlp-asset', { virtual: true });
+jest.mock('../../assets/dgs_model.npz', () => 'mock-mlp-asset', { virtual: true });
+
+jest.mock('../../src/utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  mockDocumentDirectoryValue = 'file:///documents/';
+  mockGetInfoAsync.mockReset();
+  mockReadAsStringAsync.mockReset();
+  mockFromModule.mockReset();
+  global.fetch = originalFetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('dgsModelClient local fallback', () => {
+  it('loads the bundled fallback model when the API is unreachable', async () => {
+    const bundledModel = 'YmFzZTY0LW1vZGVs';
+    const asset = {
+      localUri: 'file:///bundled/dgs_model.npz',
+      downloadAsync: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockFromModule.mockReturnValue(asset);
+
+    mockGetInfoAsync.mockImplementation(async (uri: string) => {
+      if (uri.startsWith('file:///documents/')) {
+        return { exists: false } as const;
+      }
+      return { exists: true } as const;
+    });
+
+    mockReadAsStringAsync.mockImplementation(async (uri: string) => {
+      if (uri === asset.localUri) {
+        return bundledModel;
+      }
+      throw new Error(`Unexpected read for ${uri}`);
+    });
+
+    const fetchMock = jest.fn().mockRejectedValue(new Error('network down'));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await fetchMlpModel();
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(mockFromModule).toHaveBeenCalled();
+    expect(mockReadAsStringAsync).toHaveBeenCalledWith(asset.localUri, {
+      encoding: 'base64',
+    });
+    expect(result).toBe(bundledModel);
+  });
+
+  it('returns null when no local fallback is available', async () => {
+    mockDocumentDirectoryValue = null;
+    mockGetInfoAsync.mockResolvedValue({ exists: false } as const);
+    mockReadAsStringAsync.mockRejectedValue(new Error('not found'));
+    mockFromModule.mockImplementation(() => {
+      throw new Error('asset missing');
+    });
+
+    const result = await loadLocalMlpModel();
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- simplify local MLP model loading by preferring cached document files before a bundled fallback
- load bundled dgs_model.npz via expo asset when network fetch fails and log failures with project logger
- adjust service provider test to keep connectivity guard active and add unit tests that cover the new fallback logic

## Testing
- npx jest --runTestsByPath test/services/dgsModelClient.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e021def5a08322ac2f1a933d8fbde3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graceful handling when local models fail to load; avoids crashes and returns null when unavailable.
  * Prefer document-directory model first, then bundled fallback for more reliable offline behavior.
  * Improved structured logging (info/warn/error) for clearer troubleshooting.

* **Refactor**
  * Modularized local model loading into isolated load paths with unified error handling and a centralized local-model filename.

* **Tests**
  * Added tests for bundled-fallback and no-fallback scenarios.
  * Updated mocks to persist connectivity restrictions across calls.

* **Chores**
  * Added expo-asset dependency and app config entry; added NPZ module declaration for type support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->