### PR TITLE
Recompute analytics server-side

### DIFF
--- a/app/src/screens/DashboardScreen.tsx
+++ b/app/src/screens/DashboardScreen.tsx
@@ -31,7 +31,7 @@ export default function DashboardScreen({ navigation }: any) {
   useEffect(() => {
     loadAnalytics().then((d) => {
       setData(d);
-      uploadAnalytics(d);
+      uploadAnalytics();
     });
     loadProfile().then(setProfile);
     // Fetch server analytics summary and insights for caregivers

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -82,17 +82,14 @@ export async function getGestureStats(): Promise<GestureStats[]> {
   }));
 }
 
-export async function uploadAnalytics(
-  analytics: LearningAnalytics,
-): Promise<void> {
+// Trigger a server-side analytics refresh using stored interaction logs.
+export async function uploadAnalytics(): Promise<void> {
   try {
     await fetch(ANALYTICS_ENDPOINT, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
         Authorization: `Bearer ${API_TOKEN}`,
       },
-      body: JSON.stringify(analytics),
     });
   } catch {
     // best-effort; ignore errors

--- a/docs/API.md
+++ b/docs/API.md
@@ -140,6 +140,26 @@ Return aggregated metrics such as correction rate, uncertainty ratio, median lat
 }
 ```
 
+#### POST /analytics
+Trigger a server-side refresh of learning analytics. The server recalculates success rates and trends directly from stored interaction logs, ignoring any client-provided metrics.
+
+**Body**
+
+No body required.
+
+**Response**
+```json
+{
+  "id": "default",
+  "gestureDefinitionId": "overall",
+  "successRate24h": 1,
+  "successRate7d": 0.92,
+  "avgConfidenceScore": 0.88,
+  "improvementTrend": 0.12,
+  "lastCalculated": 1700000000000
+}
+```
+
 #### POST /api/telemetry
 Submit telemetry events recording gesture processing metrics and fallback usage. Accepts a single event object or an array of events. Returns `202 Accepted`.
 

--- a/docs/BUILD_AND_TEST.md
+++ b/docs/BUILD_AND_TEST.md
@@ -29,6 +29,16 @@ npm test
 
 If all tests pass, you should see a success message in the console. This indicates that the core functionality of the application is working as expected.
 
+## Testing the Server
+
+The backend relies on both Jest (TypeScript) and Pytest (Python). Make sure Node.js 18 or newer is installed so the compiled server bundle is available to the Python suite. Before running the Python tests, compile the TypeScript sources so `dist/services/analyticsService.js` exists:
+
+```bash
+npm run build --prefix server
+```
+
+Running `npm test --prefix server` automatically builds the server before invoking Pytest, so the manual build step is only necessary when executing `npm run test:py --prefix server` directly.
+
 ## Running the Server and App
 
 To exercise the full training and recognition flow, start both the Node server and the Expo client from the repository root:

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "test": "npm run test:ts && npm run test:py",
     "test:ts": "jest",
+    "pretest:py": "npm run build",
     "test:py": "PYTHONPATH=./src:./ pytest -q",
     "train:mlp": "python3 src/amyserver_tools/train_mlp.py",
     "type-check": "tsc --noEmit --project tsconfig.json",

--- a/server/src/portal/index.ts
+++ b/server/src/portal/index.ts
@@ -14,6 +14,7 @@ import {
   getGestureTrainingDataById,
   updateGestureTrainingData,
 } from '../db.js';
+import type { Database } from '../db.js';
 import { promises as fs } from 'fs';
 import path from 'path';
 
@@ -33,6 +34,7 @@ type TrainingManifestEntry = {
 declare module 'express-serve-static-core' {
   interface Request {
     trainingBundleEntry?: TrainingManifestEntry;
+    db?: Database;
   }
 }
 
@@ -155,8 +157,12 @@ router.get('/', (_req, res) => {
   `);
 });
 
-router.get('/analytics', limiter, async (_req, res) => {
-  const db = await loadDatabase(DB_FILE_PATH);
+router.get('/analytics', limiter, async (req, res) => {
+  const db = req.db ?? (req.app?.locals?.dbInstance as Database | undefined);
+  if (!db) {
+    res.status(500).send('Datenbank nicht initialisiert');
+    return;
+  }
   const analytics = db.learningAnalytics.find((entry) => entry.id === 'default');
   if (!analytics) {
     res.status(404).send('No analytics available');

--- a/server/src/portal/index.ts
+++ b/server/src/portal/index.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import rateLimit from 'express-rate-limit';
-import { loadAnalyticsFromFile } from '../services/analyticsService.js';
 import {
   TRAINED_MODEL_PATH,
   TRAINING_MANIFEST_PATH,
@@ -157,7 +156,8 @@ router.get('/', (_req, res) => {
 });
 
 router.get('/analytics', limiter, async (_req, res) => {
-  const analytics = await loadAnalyticsFromFile();
+  const db = await loadDatabase(DB_FILE_PATH);
+  const analytics = db.learningAnalytics.find((entry) => entry.id === 'default');
   if (!analytics) {
     res.status(404).send('No analytics available');
     return;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -58,6 +58,7 @@ import {
   saveTelemetry,
   TelemetryEvent,
   computeAnalyticsInsights,
+  computeLearningAnalytics,
 } from './services/analyticsService.js';
 import { getLLMSuggestions, LLMRequest } from './services/dialogEngine.js';
 import portalRouter from './portal/index.js';
@@ -1329,23 +1330,19 @@ app.get('/model-metadata', legacyAuth, async (req: Request, res: Response) => {
   }
 });
 
-app.post('/analytics', legacyAuth, async (req: Request, res: Response) => {
-  const { successRate7d, improvementTrend } = req.body || {};
-  if (typeof successRate7d !== 'number' || typeof improvementTrend !== 'number') {
-    res.status(400).json({ error: 'Invalid analytics' });
-    return;
-  }
+app.post('/analytics', legacyAuth, async (_req: Request, res: Response) => {
   try {
-    await saveAnalyticsToFile({
-      id: 'default',
-      gestureDefinitionId: 'default', // Placeholder
-      successRate24h: 0, // Placeholder
-      successRate7d,
-      avgConfidenceScore: 0, // Placeholder
-      improvementTrend,
-      lastCalculated: Date.now(), // Placeholder
-    });
-    res.json({ status: 'ok' });
+    const analytics = computeLearningAnalytics(dbInstance);
+    const existingIndex = dbInstance.learningAnalytics.findIndex(
+      (entry) => entry.id === analytics.id,
+    );
+    if (existingIndex >= 0) {
+      dbInstance.learningAnalytics[existingIndex] = analytics;
+    } else {
+      dbInstance.learningAnalytics.push(analytics);
+    }
+    await saveAnalyticsToFile(analytics);
+    res.json(analytics);
   } catch (err) {
     console.error('Save analytics failed:', err);
     res.status(500).json({ error: 'Failed to save analytics' });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -51,8 +51,6 @@ import {
   CentroidModel,
 } from './types.js';
 import {
-  saveAnalyticsToFile,
-  loadAnalyticsFromFile,
   computeSummaryMetrics,
   loadTelemetry,
   saveTelemetry,
@@ -135,6 +133,13 @@ const dialogLimiter = rateLimit({
 const apiLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: config.apiLimit,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const analyticsPostLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
   standardHeaders: true,
   legacyHeaders: false,
 });
@@ -1330,32 +1335,39 @@ app.get('/model-metadata', legacyAuth, async (req: Request, res: Response) => {
   }
 });
 
-app.post('/analytics', legacyAuth, async (_req: Request, res: Response) => {
-  try {
-    const analytics = computeLearningAnalytics(dbInstance);
-    const existingIndex = dbInstance.learningAnalytics.findIndex(
-      (entry) => entry.id === analytics.id,
-    );
-    if (existingIndex >= 0) {
-      dbInstance.learningAnalytics[existingIndex] = analytics;
-    } else {
-      dbInstance.learningAnalytics.push(analytics);
+app.post(
+  '/analytics',
+  legacyAuth,
+  analyticsPostLimiter,
+  async (_req: Request, res: Response) => {
+    try {
+      const analytics = computeLearningAnalytics(dbInstance);
+      const existingIndex = dbInstance.learningAnalytics.findIndex(
+        (entry) => entry.id === analytics.id,
+      );
+      if (existingIndex >= 0) {
+        dbInstance.learningAnalytics[existingIndex] = analytics;
+      } else {
+        dbInstance.learningAnalytics.push(analytics);
+      }
+      await withFileLock(DB_FILE_PATH, async () => {
+        await saveDatabase(dbInstance, DB_FILE_PATH);
+      });
+      res.json(analytics);
+    } catch (err) {
+      console.error('Save analytics failed:', err);
+      res.status(500).json({ error: 'Failed to save analytics' });
     }
-    await saveAnalyticsToFile(analytics);
-    res.json(analytics);
-  } catch (err) {
-    console.error('Save analytics failed:', err);
-    res.status(500).json({ error: 'Failed to save analytics' });
-  }
-});
+  },
+);
 
 app.get('/analytics', legacyAuth, async (_req: Request, res: Response) => {
-  const data = await loadAnalyticsFromFile();
-  if (!data) {
+  const analytics = dbInstance.learningAnalytics.find((entry) => entry.id === 'default');
+  if (!analytics) {
     res.status(404).json({ error: 'Analytics not found' });
     return;
   }
-  res.json(data);
+  res.json(analytics);
 });
 
 // Add error handling middleware

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -144,6 +144,13 @@ const analyticsPostLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+const modelMetadataLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 // Serve static files from the portal directory
 if (portalAvailable) {
   app.use('/portal', express.static(portalPath));
@@ -360,6 +367,7 @@ const genId = () =>
 let dbInstance: Database;
 try {
   dbInstance = await setupDatabase(DB_FILE_PATH);
+  app.locals.dbInstance = dbInstance;
 } catch (err) {
   console.error('Database setup failed:', err);
   process.exit(1); // Exit if database setup fails
@@ -367,7 +375,7 @@ try {
 
 // Middleware to attach dbInstance to req
 app.use((req: Request, res: Response, next: Function) => {
-  (req as any).db = dbInstance;
+  req.db = dbInstance;
   next();
 });
 
@@ -1317,7 +1325,11 @@ app.get('/latest-mlp-model', legacyAuth, async (req: Request, res: Response) => 
 });
 
 // Model metadata: version, size, sha256
-app.get('/model-metadata', legacyAuth, async (req: Request, res: Response) => {
+app.get(
+  '/model-metadata',
+  legacyAuth,
+  modelMetadataLimiter,
+  async (req: Request, res: Response) => {
   const profileId =
     typeof req.query.profileId === 'string' ? req.query.profileId : undefined;
   const resolvedFile = await resolveModelFile(profileId, res, getTrainedModelPath);
@@ -1333,7 +1345,8 @@ app.get('/model-metadata', legacyAuth, async (req: Request, res: Response) => {
     console.error('Failed to read model metadata:', err);
     res.status(404).json({ error: 'Model not found' });
   }
-});
+  },
+);
 
 app.post(
   '/analytics',

--- a/server/test/test_analytics_endpoint.py
+++ b/server/test/test_analytics_endpoint.py
@@ -9,13 +9,11 @@ import pytest
 
 SERVER_DIR = Path(__file__).resolve().parents[1]
 DB_PATH = SERVER_DIR / "db.json"
-ANALYTICS_PATH = SERVER_DIR / "analytics.json"
 
 
 @pytest.fixture
 def analytics_seed():
     original_db = DB_PATH.read_text() if DB_PATH.exists() else None
-    original_analytics = ANALYTICS_PATH.read_text() if ANALYTICS_PATH.exists() else None
 
     now = int(time.time() * 1000)
     week = 7 * 24 * 60 * 60 * 1000
@@ -69,12 +67,8 @@ def analytics_seed():
     }
 
     DB_PATH.write_text(json.dumps(seeded, indent=2))
-    if ANALYTICS_PATH.exists():
-        ANALYTICS_PATH.unlink()
-
     yield {
         "db_path": DB_PATH,
-        "analytics_path": ANALYTICS_PATH,
     }
 
     if original_db is not None:
@@ -82,10 +76,6 @@ def analytics_seed():
     else:
         DB_PATH.unlink(missing_ok=True)
 
-    if original_analytics is not None:
-        ANALYTICS_PATH.write_text(original_analytics)
-    else:
-        ANALYTICS_PATH.unlink(missing_ok=True)
 
 
 @pytest.fixture
@@ -121,19 +111,22 @@ def test_server_computes_analytics(analytics_seed, seeded_server, base_url):
         method="POST",
         headers={
             "Authorization": "Bearer testtoken",
-            "Content-Type": "application/json",
         },
-        data=json.dumps({}).encode(),
+        data=b"",
     )
 
     with urllib.request.urlopen(req, timeout=5) as resp:
         assert resp.getcode() == 200
         body = json.loads(resp.read())
 
-    assert ANALYTICS_PATH.exists()
-    saved = json.loads(ANALYTICS_PATH.read_text())
+    saved_db = json.loads(DB_PATH.read_text())
+    saved = next(
+        (entry for entry in saved_db.get("learningAnalytics", []) if entry.get("id") == "default"),
+        None,
+    )
 
-    expected = compute_expected(analytics_seed["db_path"], saved["lastCalculated"])
+    assert saved is not None
 
-    assert body == saved
-    assert saved == expected
+    expected = compute_expected(analytics_seed["db_path"], body["lastCalculated"])
+
+    assert body == saved == expected

--- a/server/test/test_analytics_endpoint.py
+++ b/server/test/test_analytics_endpoint.py
@@ -1,0 +1,139 @@
+import json
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+import urllib.request
+
+import pytest
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+DB_PATH = SERVER_DIR / "db.json"
+ANALYTICS_PATH = SERVER_DIR / "analytics.json"
+
+
+@pytest.fixture
+def analytics_seed():
+    original_db = DB_PATH.read_text() if DB_PATH.exists() else None
+    original_analytics = ANALYTICS_PATH.read_text() if ANALYTICS_PATH.exists() else None
+
+    now = int(time.time() * 1000)
+    week = 7 * 24 * 60 * 60 * 1000
+    day = 24 * 60 * 60 * 1000
+
+    seeded = {
+        "symbols": [],
+        "gestureDefinitions": [],
+        "gestureTrainingData": [],
+        "interactionLogs": [
+            {
+                "id": "1",
+                "gestureDefinitionId": "hello",
+                "wasSuccessful": True,
+                "confidenceScore": 0.9,
+                "timestamp": now - 2 * 60 * 60 * 1000,
+                "processedBy": "local",
+            },
+            {
+                "id": "2",
+                "gestureDefinitionId": "hello",
+                "wasSuccessful": False,
+                "confidenceScore": 0.2,
+                "timestamp": now - 3 * day,
+                "processedBy": "local",
+            },
+            {
+                "id": "3",
+                "gestureDefinitionId": "drink",
+                "wasSuccessful": True,
+                "confidenceScore": 0.7,
+                "timestamp": now - 6 * day,
+                "processedBy": "local",
+            },
+            {
+                "id": "4",
+                "gestureDefinitionId": "drink",
+                "wasSuccessful": False,
+                "confidenceScore": 0.5,
+                "timestamp": now - (week + day),
+                "processedBy": "local",
+            },
+        ],
+        "profiles": [],
+        "vocabularySets": [],
+        "vocabularySetSymbols": [],
+        "usageStats": [],
+        "learningAnalytics": [],
+        "corrections": [],
+        "negativeSamples": [],
+    }
+
+    DB_PATH.write_text(json.dumps(seeded, indent=2))
+    if ANALYTICS_PATH.exists():
+        ANALYTICS_PATH.unlink()
+
+    yield {
+        "db_path": DB_PATH,
+        "analytics_path": ANALYTICS_PATH,
+    }
+
+    if original_db is not None:
+        DB_PATH.write_text(original_db)
+    else:
+        DB_PATH.unlink(missing_ok=True)
+
+    if original_analytics is not None:
+        ANALYTICS_PATH.write_text(original_analytics)
+    else:
+        ANALYTICS_PATH.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def seeded_server(analytics_seed, running_server):
+    yield
+
+
+def compute_expected(db_path: Path, last_calculated: int) -> dict:
+    script = textwrap.dedent(
+        f"""
+        import fs from 'fs';
+        import {{ computeLearningAnalytics }} from './dist/services/analyticsService.js';
+
+        const db = JSON.parse(fs.readFileSync({json.dumps(str(db_path))}, 'utf8'));
+        const originalNow = Date.now;
+        Date.now = () => {last_calculated};
+        const result = computeLearningAnalytics(db);
+        Date.now = originalNow;
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    output = subprocess.check_output(
+        ["node", "--input-type=module", "-e", script],
+        cwd=SERVER_DIR,
+    )
+    return json.loads(output.decode())
+
+
+def test_server_computes_analytics(analytics_seed, seeded_server, base_url):
+    req = urllib.request.Request(
+        f"{base_url}/analytics",
+        method="POST",
+        headers={
+            "Authorization": "Bearer testtoken",
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({}).encode(),
+    )
+
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        assert resp.getcode() == 200
+        body = json.loads(resp.read())
+
+    assert ANALYTICS_PATH.exists()
+    saved = json.loads(ANALYTICS_PATH.read_text())
+
+    expected = compute_expected(analytics_seed["db_path"], saved["lastCalculated"])
+
+    assert body == saved
+    assert saved == expected


### PR DESCRIPTION
## Summary
- compute caregiver analytics on the server from the database before saving and returning the result
- update the mobile client and API docs to reflect the server-driven analytics refresh
- add an integration test that seeds the database, calls /analytics, and verifies the saved analytics match computeLearningAnalytics

## Testing
- npm run test:ts --prefix server
- npm run test:py --prefix server

------
https://chatgpt.com/codex/tasks/task_e_68e45fafe7948322980f3705896107de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - App can trigger a server-side analytics recomputation; dashboard shows updated metrics returned by the server.
- Documentation
  - Added API docs for POST /analytics describing a no-body request that triggers recomputation and the returned analytics fields.
- Tests
  - Added end-to-end tests verifying POST /analytics computes, persists, and returns expected analytics consistently.
- Chores
  - Test tooling updated to ensure the server is built before Python tests run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->