### PR TITLE
Add configurable gesture size tolerance to MediaPipe detector

### DIFF
--- a/app/src/components/MediaPipeGestureDetector.tsx
+++ b/app/src/components/MediaPipeGestureDetector.tsx
@@ -95,6 +95,7 @@ interface Props {
   onModelUpdateStatus?: (status: 'idle' | 'updating' | 'complete' | 'error') => void;
   facingMode?: 'user' | 'environment';
   onFrameBatch?: (payload: FrameBatchPayload) => void;
+  gestureSizeTolerance?: number;
 }
 
 const WEBVIEW_UNAVAILABLE_TEXT = 'Ich brauche einen Moment. Lass uns gleich weitermachen!';
@@ -122,6 +123,7 @@ export const MediaPipeGestureDetector = forwardRef<MediaPipeGestureDetectorHandl
     onModelUpdateStatus,
     onFrameBatch,
     facingMode = 'user',
+    gestureSizeTolerance = 0.3,
   },
   ref,
 ) => {
@@ -344,6 +346,18 @@ export const MediaPipeGestureDetector = forwardRef<MediaPipeGestureDetectorHandl
     [],
   );
 
+  const sanitizedGestureSizeTolerance = useMemo(() => {
+    if (typeof gestureSizeTolerance !== 'number' || !Number.isFinite(gestureSizeTolerance)) {
+      return 0.3;
+    }
+
+    if (gestureSizeTolerance < 0) {
+      return 0;
+    }
+
+    return gestureSizeTolerance;
+  }, [gestureSizeTolerance]);
+
   const htmlContent = useMemo(() => {
     const tapToStart = escapeJs(TAP_TO_START_TEXT);
     const recognizerFailed = escapeJs(RECOGNIZER_INIT_FAILED_TEXT);
@@ -363,7 +377,7 @@ export const MediaPipeGestureDetector = forwardRef<MediaPipeGestureDetectorHandl
     window.__fallbackThreshold = ${FALLBACK_CONFIDENCE_THRESHOLD};
     window.__facingMode = '${escapeJs(facingMode)}';
     window.__mirrorOverlay = ${facingMode === 'user'};
-    window.__gestureSizeTolerance = 0.3;
+    window.__gestureSizeTolerance = ${sanitizedGestureSizeTolerance};
     window.__autostartCamera = false;
   </script>
   <script>
@@ -406,7 +420,35 @@ export const MediaPipeGestureDetector = forwardRef<MediaPipeGestureDetectorHandl
 </head>
 <body></body>
 </html>`;
-  }, [facingMode, inlineGestureDetectorSource]);
+  }, [facingMode, inlineGestureDetectorSource, sanitizedGestureSizeTolerance]);
+
+  useEffect(() => {
+    const tolerance = sanitizedGestureSizeTolerance;
+
+    if (!webviewRef.current || typeof webviewRef.current.injectJavaScript !== 'function') {
+      return;
+    }
+
+    try {
+      webviewRef.current.injectJavaScript(
+        `(() => {
+          var value = ${tolerance};
+          window.__gestureSizeTolerance = value;
+          try {
+            if (window.__gestureOrchestrator && typeof window.__gestureOrchestrator.updateGestureSizeTolerance === 'function') {
+              window.__gestureOrchestrator.updateGestureSizeTolerance(value);
+            } else if (window.__gestureOrchestrator && typeof window.__gestureOrchestrator.setGestureTolerance === 'function') {
+              window.__gestureOrchestrator.setGestureTolerance(value);
+            }
+          } catch (error) {
+            console.warn('Failed to apply gesture size tolerance', error);
+          }
+        })(); true;`,
+      );
+    } catch (err) {
+      logger.warn('Failed to inject gesture size tolerance update', err);
+    }
+  }, [sanitizedGestureSizeTolerance]);
 
   const handlePermissionRequest = useCallback((event: WebViewPermissionRequestEvent) => {
     try {

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -829,6 +829,7 @@ export default function RecognitionScreen({
                 }}
                 onModelUpdateStatus={handleModelUpdateStatus}
                 facingMode={facingMode}
+                gestureSizeTolerance={gestureSizeTolerance}
               />
 
               <View style={StyleSheet.absoluteFillObject} pointerEvents="none">

--- a/app/test/MediaPipeGestureDetector.test.tsx
+++ b/app/test/MediaPipeGestureDetector.test.tsx
@@ -161,6 +161,50 @@ describe('MediaPipeGestureDetector', () => {
     debugSpy.mockRestore();
   });
 
+  it('applies gesture size tolerance to the WebView and updates when the prop changes', () => {
+    const onGestureDetected = jest.fn();
+    const onError = jest.fn();
+
+    act(() => {
+      component = renderer.create(
+        <MediaPipeGestureDetector
+          onGestureDetected={onGestureDetected}
+          onError={onError}
+          gestureSizeTolerance={0.45}
+        />,
+      );
+    });
+
+    const initialWebview = component!.root.findByType('mock-webview');
+    const initialInject = initialWebview.props.injectJavaScript as jest.Mock;
+
+    expect(initialWebview.props.htmlContent).toContain('window.__gestureSizeTolerance = 0.45;');
+    expect(initialInject).toHaveBeenCalledWith(expect.stringContaining('0.45'));
+
+    act(() => {
+      component!.update(
+        <MediaPipeGestureDetector
+          onGestureDetected={onGestureDetected}
+          onError={onError}
+          gestureSizeTolerance={0.6}
+        />,
+      );
+    });
+
+    const updatedWebview = component!.root.findByType('mock-webview');
+    const updatedInject = updatedWebview.props.injectJavaScript as jest.Mock;
+
+    expect(updatedWebview.props.htmlContent).toContain('window.__gestureSizeTolerance = 0.6;');
+    expect(updatedInject).toHaveBeenCalledWith(expect.stringContaining('0.6'));
+
+    if (updatedInject === initialInject) {
+      expect(updatedInject).toHaveBeenCalledTimes(2);
+    } else {
+      expect(initialInject).toHaveBeenCalledTimes(1);
+      expect(updatedInject).toHaveBeenCalledTimes(1);
+    }
+  });
+
   it('calls onError when the message data is invalid JSON', () => {
     const onGestureDetected = jest.fn();
     const onError = jest.fn();


### PR DESCRIPTION
## Summary
- add an optional gestureSizeTolerance prop to MediaPipeGestureDetector and inject updates into the WebView
- wire RecognitionScreen state into the detector so caregiver settings reach the webview bundle
- extend MediaPipeGestureDetector tests to cover gestureSizeTolerance HTML and update behavior

## Testing
- npm test --prefix app -- MediaPipeGestureDetector

------
https://chatgpt.com/codex/tasks/task_e_68e54c65b5748322b7ef3157af1d2501