### PR TITLE
Remove bullying protection configuration and simplify recognition state

### DIFF
--- a/app/jest.setup.ts
+++ b/app/jest.setup.ts
@@ -9,7 +9,10 @@ console.error = (...args: any[]) => {
   const msg = args[0];
   if (typeof msg === 'string') {
     if (msg.includes('react-test-renderer is deprecated')) return;
-    if (msg.startsWith('[ERROR]')) return; // logger error in tests
+    const normalized = msg.trimStart();
+    if (normalized.startsWith('[ERROR]') || normalized.includes(' [ERROR]')) {
+      return; // suppress logger error output (timestamps prefix lines in tests)
+    }
   }
   originalConsoleError(...args);
 };
@@ -18,7 +21,11 @@ const originalConsoleWarn = console.warn;
 console.warn = (...args: any[]) => {
   const msg = args[0];
   if (typeof msg === 'string') {
-    if (msg.startsWith('[🍉]') || msg.startsWith('[WARN]')) return; // Suppress WatermelonDB and logger warnings
+    const normalized = msg.trimStart();
+    if (normalized.startsWith('[🍉]')) return; // Suppress WatermelonDB noise
+    if (normalized.startsWith('[WARN]') || normalized.includes(' [WARN]')) {
+      return; // Suppress logger warnings that include timestamps
+    }
   }
   originalConsoleWarn(...args);
 };

--- a/app/src/hooks/useRecognitionState.ts
+++ b/app/src/hooks/useRecognitionState.ts
@@ -97,8 +97,6 @@ export interface RecognitionSessionState {
   setShowCelebration: Dispatch<SetStateAction<boolean>>;
   celebrationKey: number;
   setCelebrationKey: Dispatch<SetStateAction<number>>;
-  bullyingProtectionActive: boolean;
-  setBullyingProtectionActive: Dispatch<SetStateAction<boolean>>;
 }
 
 export interface RecognitionState
@@ -131,7 +129,6 @@ export const useRecognitionState = (): RecognitionState => {
   const [celebrationKey, setCelebrationKey] = useState(0);
   const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
   const [modelUpdateStatus, setModelUpdateStatus] = useState<'idle' | 'updating' | 'complete' | 'error'>('idle');
-  const [bullyingProtectionActive, setBullyingProtectionActive] = useState(false);
   const [gestureSizeTolerance, setGestureSizeTolerance] = useState(0.3);
   const [showVisualRipple, setShowVisualRipple] = useState(false);
   const [successSound, setSuccessSound] = useState('success');
@@ -187,8 +184,6 @@ export const useRecognitionState = (): RecognitionState => {
     setScreenReaderEnabled,
     modelUpdateStatus,
     setModelUpdateStatus,
-    bullyingProtectionActive,
-    setBullyingProtectionActive,
     gestureSizeTolerance,
     setGestureSizeTolerance,
     showVisualRipple,

--- a/app/src/screens/ProfileManagerScreen.tsx
+++ b/app/src/screens/ProfileManagerScreen.tsx
@@ -21,7 +21,6 @@ import ScreenBackground from '../components/ScreenBackground';
 export default function ProfileManagerScreen({ navigation, route }: any) {
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [isTrustedDevice, setIsTrustedDevice] = useState(false);
-  const [bullyingProtectionEnabled, setBullyingProtectionEnabled] = useState(false);
   const [gestureSizeTolerance, setGestureSizeTolerance] = useState(0.3);
   const [selectedSuccessSound, setSelectedSuccessSound] = useState('success');
   const { largeText, highContrast, update } = useAccessibility();
@@ -120,10 +119,6 @@ export default function ProfileManagerScreen({ navigation, route }: any) {
       const deviceId = await AsyncStorage.getItem('trustedDeviceId');
       setIsTrustedDevice(!!deviceId);
 
-      // Check bullying protection status
-      const protectionEnabled = await AsyncStorage.getItem('bullyingProtectionEnabled');
-      setBullyingProtectionEnabled(protectionEnabled === 'true');
-
       // Check gesture size tolerance
       const toleranceStr = await AsyncStorage.getItem('gestureSizeTolerance');
       if (toleranceStr) {
@@ -174,29 +169,6 @@ export default function ProfileManagerScreen({ navigation, route }: any) {
         },
       ],
     );
-  };
-
-  const toggleBullyingProtection = async (enabled: boolean) => {
-    try {
-      await AsyncStorage.setItem('bullyingProtectionEnabled', enabled.toString());
-      setBullyingProtectionEnabled(enabled);
-
-      if (enabled) {
-        Alert.alert(
-          'Mobbing-Schutz aktiviert',
-          "Das Gerät ist jetzt vor unbefugter Nutzung geschützt. Nur vertrauenswürdige Benutzer können Amy's App verwenden.",
-          [{ text: 'OK' }],
-        );
-      } else {
-        Alert.alert(
-          'Mobbing-Schutz deaktiviert',
-          'Der Schutz wurde deaktiviert. Stelle sicher, dass das Gerät sicher verwendet wird.',
-          [{ text: 'OK' }],
-        );
-      }
-    } catch (error) {
-      logger.error('Failed to toggle bullying protection:', error);
-    }
   };
 
   const saveGestureSizeTolerance = async (tolerance: number) => {
@@ -469,47 +441,6 @@ export default function ProfileManagerScreen({ navigation, route }: any) {
               </Pressable>
             </View>
           )}
-        </View>
-
-        {/* Bullying Protection Section */}
-        <View style={styles.trustedDeviceSection}>
-          <Text style={styles.sectionTitle}>Mobbing-Schutz</Text>
-          <View style={styles.protectionInfo}>
-            <Text style={styles.trustedDeviceText}>
-              {bullyingProtectionEnabled
-                ? '🛡️ Mobbing-Schutz ist aktiviert'
-                : '⚠️ Mobbing-Schutz ist deaktiviert'}
-            </Text>
-            <Text style={styles.protectionDescription}>
-              Schützt Amy vor unbefugter Nutzung auf geteilten Geräten
-            </Text>
-            <View style={styles.buttonRow}>
-              <Pressable
-                style={({ pressed }) => [
-                  childFriendlyStyles.minTouchTarget,
-                  styles.button,
-                  highContrast && styles.buttonHC,
-                  pressed && (highContrast ? styles.buttonPressedHC : styles.buttonPressed),
-                ]}
-                onPress={() => {
-                  void childHaptic();
-                  toggleBullyingProtection(!bullyingProtectionEnabled);
-                }}
-                accessibilityRole="button"
-                accessibilityLabel={`Mobbing-Schutz ${bullyingProtectionEnabled ? 'deaktivieren' : 'aktivieren'}`}
-              >
-                <Text
-                  style={[
-                    styles.buttonText,
-                    largeText && styles.buttonTextLarge,
-                    highContrast && styles.buttonTextHC,
-                  ]}
-                >
-                  {bullyingProtectionEnabled ? 'Deaktivieren' : 'Aktivieren'}
-                </Text>
-              </Pressable>
-            </View>
-          </View>
         </View>
 
         {/* Gesture Size Tolerance Section */}

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -142,8 +142,6 @@ export default function RecognitionScreen({
     screenReaderEnabled,
     setScreenReaderEnabled,
     modelUpdateStatus,
-    bullyingProtectionActive,
-    setBullyingProtectionActive,
     gestureSizeTolerance,
     setGestureSizeTolerance,
     showVisualRipple,
@@ -454,30 +452,18 @@ export default function RecognitionScreen({
   }, []);
 
   useEffect(() => {
-    // Check bullying protection status
-    const checkBullyingProtection = async () => {
+    const loadGestureSizeTolerance = async () => {
       try {
-        const protectionEnabled = await AsyncStorage.getItem('bullyingProtectionEnabled');
-        const isTrustedDevice = await AsyncStorage.getItem('trustedDeviceId');
-
-        if (protectionEnabled === 'true' && !isTrustedDevice) {
-          setBullyingProtectionActive(true);
-          setStatus('🔒 Gerät ist nicht vertrauenswürdig. Bitte wende dich an einen Betreuer.');
-        } else {
-          setBullyingProtectionActive(false);
-        }
-
-        // Load gesture size tolerance
         const toleranceStr = await AsyncStorage.getItem('gestureSizeTolerance');
         if (toleranceStr) {
           setGestureSizeTolerance(parseFloat(toleranceStr));
         }
       } catch (error) {
-        logger.warn('Failed to check bullying protection:', error);
+        logger.warn('Failed to load gesture size tolerance:', error);
       }
     };
 
-    checkBullyingProtection();
+    loadGestureSizeTolerance();
   }, []);
 
   useEffect(() => {

--- a/app/test/screens/ProfileManagerScreen.a11y.test.tsx
+++ b/app/test/screens/ProfileManagerScreen.a11y.test.tsx
@@ -58,17 +58,13 @@ describe('ProfileManagerScreen accessibility', () => {
     });
     const texts = comp.root.findAll((n) => n.type === 'Text').map((n) => n.props.children);
     expect(texts).toContain('Vertrauenswürdiges Gerät');
-    expect(texts).toContain('Mobbing-Schutz');
     expect(texts).toContain('Gestengrößen-Toleranz');
 
     const pressables = comp.root.findAll((n) => n.type === 'Pressable');
     expect(pressables.length).toBeGreaterThan(0);
     const labels = pressables.map((p) => p.props.accessibilityLabel).filter(Boolean);
     expect(labels).toEqual(
-      expect.arrayContaining([
-        'Gerät als vertrauenswürdig einrichten',
-        expect.stringContaining('Mobbing-Schutz'),
-      ]),
+      expect.arrayContaining(['Gerät als vertrauenswürdig einrichten']),
     );
     pressables.forEach((p) => expect(p.props.accessibilityRole).toBe('button'));
   });

--- a/app/test/screens/RecognitionScreen.test.tsx
+++ b/app/test/screens/RecognitionScreen.test.tsx
@@ -161,8 +161,6 @@ jest.mock('../../src/hooks/useRecognitionState', () => {
       setScreenReaderEnabled: jest.fn(),
       modelUpdateStatus: 'idle',
       setModelUpdateStatus: jest.fn(),
-      bullyingProtectionActive: false,
-      setBullyingProtectionActive: jest.fn(),
       gestureSizeTolerance: 0.3,
       setGestureSizeTolerance: jest.fn(),
       showVisualRipple: false,


### PR DESCRIPTION
## Summary
- remove bullying protection state from the recognition hook and screen so we only load stored gesture tolerance
- drop the bullying protection toggle and storage reads from the profile manager settings view
- update screen accessibility and recognition tests to reflect the simplified settings

## Testing
- npm test --prefix app -- ProfileManagerScreen.a11y.test.tsx
- npm test --prefix app -- RecognitionScreen.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e5d3c7d6ac8322b4ac2d62979a21ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed the Bullying Protection setting and related UI across the app, simplifying Profile Manager and Recognition flows.
  - Streamlined Recognition initialization to focus on gesture size tolerance.

- Tests
  - Updated accessibility and screen tests and mocks to reflect removal of the Bullying Protection option and labels.
  - Adjusted test setup to improve suppression of specific console warnings/errors.

- Chores
  - Cleaned up stored preferences and related state for the removed feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->