### PR TITLE
Remove screen reader handling for alpha scope

### DIFF
--- a/app/src/hooks/useRecognitionCallbacks.ts
+++ b/app/src/hooks/useRecognitionCallbacks.ts
@@ -123,7 +123,6 @@ export const useRecognitionCallbacks = ({
   const {
     successSound,
     contextInsights,
-    screenReaderEnabled,
     gestureConfidence,
     dialogContext,
     lastRecognizedGesture,
@@ -615,7 +614,7 @@ export const useRecognitionCallbacks = ({
         logger.debug('Optional success feedback failed', error),
       );
     },
-    [screenReaderEnabled, setPendingGesture, setStatus],
+    [setPendingGesture, setStatus],
   );
 
   const handleStabilityFeedback = useCallback(

--- a/app/src/hooks/useRecognitionState.ts
+++ b/app/src/hooks/useRecognitionState.ts
@@ -29,8 +29,6 @@ export interface RecognitionProfileState {
   setError: Dispatch<SetStateAction<string | null>>;
   facingMode: 'user' | 'environment';
   setFacingMode: Dispatch<SetStateAction<'user' | 'environment'>>;
-  screenReaderEnabled: boolean;
-  setScreenReaderEnabled: Dispatch<SetStateAction<boolean>>;
   modelUpdateStatus: 'idle' | 'updating' | 'complete' | 'error';
   setModelUpdateStatus: Dispatch<SetStateAction<'idle' | 'updating' | 'complete' | 'error'>>;
 }
@@ -127,7 +125,6 @@ export const useRecognitionState = (): RecognitionState => {
   const [showDgsVideo, setShowDgsVideo] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
   const [celebrationKey, setCelebrationKey] = useState(0);
-  const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
   const [modelUpdateStatus, setModelUpdateStatus] = useState<'idle' | 'updating' | 'complete' | 'error'>('idle');
   const [gestureSizeTolerance, setGestureSizeTolerance] = useState(0.3);
   const [showVisualRipple, setShowVisualRipple] = useState(false);
@@ -180,8 +177,6 @@ export const useRecognitionState = (): RecognitionState => {
     setShowCelebration,
     celebrationKey,
     setCelebrationKey,
-    screenReaderEnabled,
-    setScreenReaderEnabled,
     modelUpdateStatus,
     setModelUpdateStatus,
     gestureSizeTolerance,

--- a/app/src/screens/RecognitionScreen.tsx
+++ b/app/src/screens/RecognitionScreen.tsx
@@ -7,7 +7,6 @@ import {
   Animated,
   Easing,
   Button,
-  AccessibilityInfo,
   ScrollView,
 } from 'react-native';
 import type { NavigationProp } from '@react-navigation/native';
@@ -139,8 +138,6 @@ export default function RecognitionScreen({
     setShowCelebration,
     celebrationKey,
     setCelebrationKey,
-    screenReaderEnabled,
-    setScreenReaderEnabled,
     modelUpdateStatus,
     gestureSizeTolerance,
     setGestureSizeTolerance,
@@ -433,23 +430,6 @@ export default function RecognitionScreen({
     },
     [setShowOpenaiFeedback],
   );
-
-  useEffect(() => {
-    // Track screen reader to avoid overlapping TTS and accessibility announcements
-    const checkScreenReader = AccessibilityInfo?.isScreenReaderEnabled;
-    if (typeof checkScreenReader === 'function') {
-      checkScreenReader()
-        .then(setScreenReaderEnabled)
-        .catch((error) =>
-          logger.warn('Failed to check if screen reader is enabled:', error),
-        );
-    }
-    const sub = AccessibilityInfo?.addEventListener?.(
-      'screenReaderChanged',
-      setScreenReaderEnabled,
-    );
-    return () => sub?.remove?.();
-  }, []);
 
   useEffect(() => {
     const loadGestureSizeTolerance = async () => {

--- a/app/test/integration/ServiceIntegration.test.ts
+++ b/app/test/integration/ServiceIntegration.test.ts
@@ -324,7 +324,6 @@ describe('Service Integration Tests', () => {
           hapticFeedback: true,
           audioFeedback: true,
           visualFeedback: true,
-          screenReader: true,
           emergencyAccess: true
         },
 

--- a/app/test/screens/RecognitionScreen.test.tsx
+++ b/app/test/screens/RecognitionScreen.test.tsx
@@ -157,8 +157,6 @@ jest.mock('../../src/hooks/useRecognitionState', () => {
       setShowCelebration: jest.fn(),
       celebrationKey: 0,
       setCelebrationKey: jest.fn(),
-      screenReaderEnabled: false,
-      setScreenReaderEnabled: jest.fn(),
       modelUpdateStatus: 'idle',
       setModelUpdateStatus: jest.fn(),
       gestureSizeTolerance: 0.3,

--- a/docs/DGS_Testing_Guide.md
+++ b/docs/DGS_Testing_Guide.md
@@ -108,19 +108,19 @@ assert((mode & 0o022) === 0, 'Insecure file permissions');
 **Purpose**: Ensures the DGS integration meets accessibility standards for users with disabilities.
 
 **Test Cases**:
-- **Screen Reader Support**: Validates gesture announcements
 - **Keyboard Navigation**: Tests keyboard-only gesture triggering
 - **High Contrast Support**: Ensures visibility in high contrast modes
 - **Focus Management**: Validates proper focus indicators
+- **Screen Reader Support**: *Alpha-Scope Hinweis – derzeit ausgesetzt*
 
 **Accessibility Requirements**:
 ```typescript
 const ACCESSIBILITY_CHECKS = {
-  screenReader: true,
   keyboardNavigation: true,
   highContrast: true,
   focusManagement: true,
-  ariaLabels: true
+  ariaLabels: true,
+  screenReader: false // Alpha release excludes screen reader verification
 };
 ```
 
@@ -288,8 +288,8 @@ npm test --prefix integration -- --coverage --grep "dgs"
   },
   "accessibility": {
     "wcagLevel": "AA",
-    "screenReader": "supported",
-    "keyboardNav": "enabled"
+    "keyboardNav": "enabled",
+    "screenReader": "out_of_scope"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- remove screen reader tracking from the recognition state and screen to align with the alpha scope
- update related tests and documentation to reflect that screen reader verification is out of scope

## Testing
- npm test --prefix app -- RecognitionScreen.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e5f1cda0d483229b3d6a340a682826