### PR TITLE
Pin MediaPipe Tasks Vision (0.10.35) and bump server MediaPipe

### DIFF
--- a/docs/deployment/multimodal-dependency-support.md
+++ b/docs/deployment/multimodal-dependency-support.md
@@ -1,9 +1,9 @@
 # Multimodal dependency support
 
-This repository already ships the pieces required to capture and transport multimodal DGS data (hands, pose, face landmarks plus handedness/features) without additional npm packages.
+This repository already ships the pieces required to capture and transport multimodal DGS data (hands, pose, face landmarks plus handedness/features) with the pinned `@mediapipe/tasks-vision` web dependency available for version discovery and CDN URL alignment.
 
 ## Client capture
-- The web client dynamically loads the MediaPipe Tasks Vision bundle (which includes hands, pose, and face models) from pinned CDN URLs so the browser receives all landmark modalities at runtime; no local dependency is required besides network access.
+- The web client dynamically loads the MediaPipe Tasks Vision bundle (which includes hands, pose, and face models) from CDN URLs aligned to the pinned `@mediapipe/tasks-vision` package version (`0.10.35`) so the browser receives all landmark modalities at runtime.
 - MediaPipe results are normalized into hands + handedness + pose + face arrays and then filtered with a One Euro smoother before being routed into the rest of the capture and recording pipeline.
 - Captured frames persist the full multimodal payload (hand landmarks, pose landmarks, face landmarks, handedness, and derived feature metrics) inside `landmarks.json` within each training bundle.
 
@@ -11,5 +11,5 @@ This repository already ships the pieces required to capture and transport multi
 - The server’s bundle ingestor accepts the richer bundle format and normalizes every modality with bounds (max hands/points for hands, pose, and face) plus numeric feature sanitation before writing dataset samples.
 
 ## What this means
-- As long as the CDN-hosted `@mediapipe/tasks-vision` assets remain reachable, the current setup supports multimodal capture, visualization, bundling, and ingestion without extra dependencies.
-- No additional Node packages are needed for multimodal handling; MediaPipe is fetched at runtime in the browser, and the server treats the data as structured JSON.
+- As long as the CDN-hosted `@mediapipe/tasks-vision` assets for the pinned package version remain reachable, the current setup supports multimodal capture, visualization, bundling, and ingestion.
+- The Node package pin documents the expected MediaPipe Tasks Vision release, while MediaPipe is still fetched at runtime in the browser and the server treats the data as structured JSON.

--- a/scripts/check-pins.js
+++ b/scripts/check-pins.js
@@ -26,6 +26,7 @@ const criticalWebappDeps = [
   'react',
   'react-dom',
   'vite',
+  '@mediapipe/tasks-vision',
 ];
 const criticalServerDeps = ['express', 'express-rate-limit'];
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 pytest
-mediapipe==0.10.33
+mediapipe==0.10.35
 opencv-python
 pillow
 beautifulsoup4

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "webapp",
       "version": "0.0.0",
       "dependencies": {
+        "@mediapipe/tasks-vision": "0.10.35",
         "fflate": "^0.8.2",
         "js-sha256": "^0.11.0",
         "react": "19.2.5",
@@ -1248,6 +1249,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.35",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.35.tgz",
+      "integrity": "sha512-HOvadwVRE6JC+45nyYhmnywnr5h/J8KZvOeUNVOG9q/0875pZgItznFB9bRTvLc264YSJqiZ1NsIpCStJw/egg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -19,6 +19,7 @@
     "diagnose:fixtures": "vite-node scripts/gesture-fixture-diagnose.ts"
   },
   "dependencies": {
+    "@mediapipe/tasks-vision": "0.10.35",
     "fflate": "^0.8.2",
     "js-sha256": "^0.11.0",
     "react": "19.2.5",

--- a/webapp/src/gesture/config/MediaPipeDependencies.ts
+++ b/webapp/src/gesture/config/MediaPipeDependencies.ts
@@ -3,8 +3,12 @@ export const MEDIAPIPE_TASKS_VISION_CDN_BASE = 'https://cdn.jsdelivr.net/npm';
 
 export function buildMediaPipeTasksVisionUrl(assetPath: string): string {
   const normalizedAssetPath = assetPath.startsWith('/') ? assetPath.slice(1) : assetPath;
+  const version =
+    typeof window !== 'undefined' && typeof (window as any).__mediapipeVersion === 'string' && (window as any).__mediapipeVersion.length
+      ? (window as any).__mediapipeVersion
+      : MEDIAPIPE_TASKS_VISION_VERSION;
   return (
     `${MEDIAPIPE_TASKS_VISION_CDN_BASE}/@mediapipe/tasks-vision@` +
-    `${MEDIAPIPE_TASKS_VISION_VERSION}/${normalizedAssetPath}`
+    `${version}/${normalizedAssetPath}`
   );
 }

--- a/webapp/src/gesture/config/MediaPipeDependencies.ts
+++ b/webapp/src/gesture/config/MediaPipeDependencies.ts
@@ -1,0 +1,10 @@
+export const MEDIAPIPE_TASKS_VISION_VERSION = '0.10.35';
+export const MEDIAPIPE_TASKS_VISION_CDN_BASE = 'https://cdn.jsdelivr.net/npm';
+
+export function buildMediaPipeTasksVisionUrl(assetPath: string): string {
+  const normalizedAssetPath = assetPath.startsWith('/') ? assetPath.slice(1) : assetPath;
+  return (
+    `${MEDIAPIPE_TASKS_VISION_CDN_BASE}/@mediapipe/tasks-vision@` +
+    `${MEDIAPIPE_TASKS_VISION_VERSION}/${normalizedAssetPath}`
+  );
+}

--- a/webapp/src/gesture/core/MediaPipeLoader.ts
+++ b/webapp/src/gesture/core/MediaPipeLoader.ts
@@ -4,6 +4,10 @@
  */
 
 import { logger } from '../../services/logger';
+import {
+  MEDIAPIPE_TASKS_VISION_CDN_BASE,
+  MEDIAPIPE_TASKS_VISION_VERSION,
+} from '../config/MediaPipeDependencies';
 
 // Types for MediaPipe components
 export interface MediaPipeComponents {
@@ -52,39 +56,10 @@ export async function loadTasksVision(): Promise<MediaPipeComponents> {
     if (typeof pinnedVersion === 'string' && pinnedVersion.length) {
       return { base: 'https://cdn.jsdelivr.net/npm', version: pinnedVersion };
     }
-    const cdns = ['https://cdn.jsdelivr.net/npm', 'https://unpkg.com'];
-    const controllers = cdns.map(() => new AbortController());
-    const fetches = cdns.map((base, i) =>
-      (async () => {
-        try {
-          const ac = controllers[i];
-          if (!ac) throw new Error('AbortController not found');
-          const t = setTimeout(() => ac.abort(), 8000); // LOAD_TIMEOUT_MS
-          const pkg = await fetch(base + '/@mediapipe/tasks-vision/package.json', {
-            method: 'GET',
-            signal: ac.signal,
-            cache: 'no-store',
-          }).finally(() => clearTimeout(t));
-          if (pkg.ok) {
-            const json = await pkg.json().catch(() => null);
-            const v = json?.version;
-            if (typeof v === 'string' && v.length) {
-              controllers.forEach((c, j) => {
-                if (j !== i) c.abort();
-              });
-              return { base, version: v };
-            }
-          }
-        } catch (err) {
-          if ((err as any)?.name !== 'AbortError') {
-            console.warn('Fetch failed:', base, err);
-          }
-        }
-        return null;
-      })(),
-    );
-    const results = await Promise.all(fetches);
-    return results.find(Boolean) || null;
+    return {
+      base: MEDIAPIPE_TASKS_VISION_CDN_BASE,
+      version: MEDIAPIPE_TASKS_VISION_VERSION,
+    };
   }
 
   function tryLoadScript(src: string, integrity?: string, timeoutMs = 8000) {

--- a/webapp/src/gesture/workers/DetectionWorker.ts
+++ b/webapp/src/gesture/workers/DetectionWorker.ts
@@ -43,9 +43,9 @@ export interface WorkerDetectRequest {
 
 export interface WorkerInitRequest {
   type: 'init';
-  /** Tasks Vision bundle URL, e.g. https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.22/vision_bundle.mjs */
+  /** Tasks Vision bundle URL, e.g. https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.35/vision_bundle.mjs */
   visionBundleUrl: string;
-  /** Tasks Vision WASM CDN base URL, e.g. https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.22/wasm */
+  /** Tasks Vision WASM CDN base URL, e.g. https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.35/wasm */
   wasmBase: string;
   /** GestureRecognizer model URL. */
   gestureModelUrl: string;

--- a/webapp/src/gesture/workers/WorkerDetectionBridge.ts
+++ b/webapp/src/gesture/workers/WorkerDetectionBridge.ts
@@ -15,6 +15,8 @@
  *   bridge.dispose(); // cleanup on stop
  */
 
+import { buildMediaPipeTasksVisionUrl } from '../config/MediaPipeDependencies';
+
 import type {
   WorkerDetectResponse,
   WorkerDetectionResult,
@@ -59,7 +61,7 @@ export class WorkerDetectionBridge {
 
   constructor(options: WorkerBridgeOptions) {
     this.options = {
-      visionBundleUrl: 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.22/vision_bundle.mjs',
+      visionBundleUrl: buildMediaPipeTasksVisionUrl('vision_bundle.mjs'),
       minDetectionConfidence: 0.7,
       minTrackingConfidence: 0.5,
       numHands: 2,


### PR DESCRIPTION
### Motivation
- Enable discovery and use of new MediaPipe/MLP features by aligning the web client to a pinned Tasks Vision release and updating the server-side MediaPipe package. 
- Reduce runtime CDN-version drift by centralizing the pinned Tasks Vision CDN version used by the loader and worker bridge.

### Description
- Bump server Python dependency `mediapipe` from `0.10.33` to `0.10.35` in `server/requirements.txt` and install it during verification. 
- Add and pin the web package `@mediapipe/tasks-vision` `0.10.35` in `webapp/package.json` with a corresponding `webapp/package-lock.json` entry. 
- Add `webapp/src/gesture/config/MediaPipeDependencies.ts` and update `webapp/src/gesture/core/MediaPipeLoader.ts` and `webapp/src/gesture/workers/WorkerDetectionBridge.ts` to use the centralized CDN/version helper instead of probing for the latest at runtime. 
- Update worker docs/comments and `webapp/src/gesture/workers/DetectionWorker.ts` examples, add `@mediapipe/tasks-vision` to `scripts/check-pins.js` critical deps, and update `docs/deployment/multimodal-dependency-support.md` to describe the pinned web dependency. 

### Testing
- Ran `npm run type-check --prefix webapp` which completed successfully. 
- Ran `npm test --prefix webapp -- WorkerDetectionBridge.test.ts` and all tests passed. 
- Built the webapp with `npm run build --prefix webapp` which completed successfully. 
- Ran `npm run lint --prefix webapp` and `node scripts/check-pins.js`, both succeeded. 
- Installed Python dependencies with `python -m pip install -r server/requirements.txt` which installed `mediapipe==0.10.35` successfully, but a runtime import check of `mediapipe.tasks.python.vision` failed in this container due to a missing system library (`libGL.so.1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a240ee8646c832282330ee56d4cd66a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependency Updates**
  * Updated MediaPipe Tasks Vision to version 0.10.35 across webapp and server for version-aligned CDN asset loading and enhanced multimodal support.
  * Added dependency pin verification for critical packages.

* **Documentation**
  * Updated multimodal dependency support guidance to reflect version alignment and CDN asset availability requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->